### PR TITLE
Decreased the number of items of the _sensors array

### DIFF
--- a/NodeManager.cpp
+++ b/NodeManager.cpp
@@ -2193,7 +2193,7 @@ void NodeManager::before() {
     if (! _battery_internal_vcc && _battery_pin > -1) analogReference(INTERNAL);
   #endif
   // setup individual sensors
-  for (int i = 0; i < 255; i++) {
+  for (int i = 0; i < MAX_SENSORS; i++) {
     if (_sensors[i] == 0) continue;
     // call each sensor's setup()
     _sensors[i]->before();
@@ -2217,7 +2217,7 @@ void NodeManager::presentation() {
     _process("BATTERY");
   #endif
   // present each sensor
-  for (int i = 0; i < 255; i++) {
+  for (int i = 0; i < MAX_SENSORS; i++) {
     if (_sensors[i] == 0) continue;
     // call each sensor's presentation()
     if (_sleep_between_send > 0) sleep(_sleep_between_send);
@@ -2242,7 +2242,7 @@ void NodeManager::setup() {
     _send(_msg.set("STARTED"));
   #endif
   // run setup for all the registered sensors
-  for (int i = 0; i < 255; i++) {
+  for (int i = 0; i < MAX_SENSORS; i++) {
     if (_sensors[i] == 0) continue;
     // call each sensor's setup()
     _sensors[i]->setup();
@@ -2261,7 +2261,7 @@ void NodeManager::loop() {
       if (_auto_power_pins) powerOn();
     #endif
     // run loop for all the registered sensors
-    for (int i = 0; i < 255; i++) {
+    for (int i = 0; i < MAX_SENSORS; i++) {
       // skip not configured sensors
       if (_sensors[i] == 0) continue;
       // if waking up from an interrupt skip all the sensor without that interrupt configured
@@ -2609,7 +2609,7 @@ void NodeManager::_present(int child_id, int type) {
 
 // return the next available child_id
 int NodeManager::_getAvailableChildId() {
-  for (int i = 1; i < 255; i++) {
+  for (int i = 1; i < MAX_SENSORS; i++) {
     if (i == CONFIGURATION_CHILD_ID) continue;
     if (i == BATTERY_CHILD_ID) continue;
     // empty place, return it

--- a/NodeManager.h
+++ b/NodeManager.h
@@ -51,6 +51,10 @@
 /***********************************
    Default configuration settings
 */
+// if enabled, enable debug messages on serial port
+#ifndef DEBUG
+  #define DEBUG 1
+#endif
 
 // if enabled, enable the capability to power on sensors with the arduino's pins to save battery while sleeping
 #ifndef POWER_MANAGER
@@ -69,27 +73,13 @@
   #define PERSIST 0
 #endif
 
-// if enabled, enable debug messages on serial port
-#ifndef DEBUG
-  #define DEBUG 1
-#endif
-
 // if enabled, send a SLEEPING and AWAKE service messages just before entering and just after leaving a sleep cycle
 #ifndef SERVICE_MESSAGES
-  #define SERVICE_MESSAGES 1
+  #define SERVICE_MESSAGES 0
 #endif
 // if enabled, a battery sensor will be created at BATTERY_CHILD_ID and will report vcc voltage together with the battery level percentage
 #ifndef BATTERY_SENSOR
   #define BATTERY_SENSOR 1
-#endif
-
-// the child id used to allow remote configuration
-#ifndef CONFIGURATION_CHILD_ID
-  #define CONFIGURATION_CHILD_ID 200
-#endif
-// the child id used to report the battery voltage to the controller
-#ifndef BATTERY_CHILD_ID
-  #define BATTERY_CHILD_ID 201
 #endif
 
 // Enable this module to use one of the following sensors: SENSOR_ANALOG_INPUT, SENSOR_LDR, SENSOR_THERMISTOR, SENSOR_MQ, SENSOR_ACS712
@@ -147,6 +137,19 @@
 // Enable this module to use one of the following sensors: SENSOR_MCP9808
 #ifndef MODULE_MCP9808
   #define MODULE_MCP9808 0
+#endif
+
+// the child id used to allow remote configuration
+#ifndef CONFIGURATION_CHILD_ID
+  #define CONFIGURATION_CHILD_ID 200
+#endif
+// the child id used to report the battery voltage to the controller
+#ifndef BATTERY_CHILD_ID
+  #define BATTERY_CHILD_ID 201
+#endif
+// define the maximum number of sensors that can be managed
+#ifndef MAX_SENSORS
+  #define MAX_SENSORS 10
 #endif
 
 /***********************************
@@ -1063,7 +1066,7 @@ class NodeManager {
     int _interrupt_2_pull = -1;
     int _last_interrupt_pin = -1;
     long _timestamp = -1;
-    Sensor* _sensors[255] = {0};
+    Sensor* _sensors[MAX_SENSORS] = {0};
     bool _ack = false;
     void _process(const char * message);
     void _sleep();


### PR DESCRIPTION
By decreasing from 255 to 10 the pointers pre-allocated to *Sensor, can save up to 20% of dynamic memory and mitigate #28.
* Added MAX_SENSORS define in NodeManager.h set to 10
* MAX_SENSORS is NOT in the default config.h but can be set there