### PR TITLE
Interrupt Management Enhancement

### DIFF
--- a/NodeManager.cpp
+++ b/NodeManager.cpp
@@ -855,11 +855,15 @@ void SensorRainGauge::setReportInterval(int value) {
 void SensorRainGauge::setSingleTip(float value) {
   _single_tip = value;
 }
+void SensorRainGauge::setInitialValue(int value) {
+  _initial_value = value;
+}
 
 // what to do during before
 void SensorRainGauge::onBefore() {
   // set the pin as input and enabled pull up
-  pinMode(_pin, INPUT_PULLUP);
+  pinMode(_pin, INPUT);
+  digitalWrite(_pin,_initial_value);
   // attach to the pin's interrupt and execute the routine on falling
   attachInterrupt(digitalPinToInterrupt(_pin), _onTipped, FALLING);
   // start the timer

--- a/NodeManager.cpp
+++ b/NodeManager.cpp
@@ -390,8 +390,8 @@ void Sensor::loop(const MyMessage & message) {
     if (_isReceive(message) || _isWorthSending(avg != _last_value_int))  {
       _last_value_int = avg;
       _send(_msg.set(avg));
+      _value_int = -1;
     }
-    _value_int = -1;
   }
   // process a float value
   else if (_value_type == TYPE_FLOAT && total > -1) {
@@ -401,8 +401,8 @@ void Sensor::loop(const MyMessage & message) {
     if (_isReceive(message) || _isWorthSending(avg != _last_value_float))  {
       _last_value_float = avg;
       _send(_msg.set(avg, _float_precision));
+      _value_float = -1;
     }
-    _value_float = -1;
   }
   // process a string value
   else if (_value_type == TYPE_STRING) {
@@ -410,8 +410,8 @@ void Sensor::loop(const MyMessage & message) {
     if (_isReceive(message) || _isWorthSending(strcmp(_value_string, _last_value_string) != 0))  {
       _last_value_string = _value_string;
       _send(_msg.set(_value_string));
+      _value_string = "";
     }
-    _value_string = "";
   }
   // turn the sensor off
   #if POWER_MANAGER == 1

--- a/NodeManager.cpp
+++ b/NodeManager.cpp
@@ -323,6 +323,12 @@ void Sensor::setReportIntervalMinutes(int value) {
   _report_timer->start(value,MINUTES);
 }
 
+// listen for interrupts on the given pin so interrupt() will be called when occurring
+void Sensor::setInterrupt(int pin, int mode, int initial) {
+  _interrupt_pin = pin;
+  _node_manager->setInterrupt(pin,mode,initial);
+}
+
 // present the sensor to the gateway and controller
 void Sensor::presentation() {
   #if DEBUG == 1
@@ -1083,9 +1089,6 @@ void SensorDigitalOutput::setInputIsElapsed(bool value) {
 
 // main task
 void SensorDigitalOutput::onLoop() {
-    // set the value to -1 so to avoid reporting to the gateway during loop
-    _value_int = -1;
-    _last_value_int = -1;
   // if a safeguard is set, check if it is time for it
   if (_safeguard_timer->isRunning()) {
     // update the timer
@@ -1391,8 +1394,7 @@ void SensorSwitch::onBefore() {
   if (_mode == RISING) _value_int = LOW;
   else if (_mode == FALLING) _value_int = HIGH;
   // set the interrupt pin so it will be called only when waking up from that interrupt
-  _interrupt_pin = _pin;
-  _node_manager->setInterrupt(_pin,_mode,_initial);
+  setInterrupt(_pin,_mode,_initial);
 }
 
 // what to do during setup
@@ -2059,8 +2061,6 @@ void SensorSonoff::onSetup() {
 
 // what to do during loop
 void SensorSonoff::onLoop() {
-  // set the value to -1 so to avoid reporting to the gateway during loop
-  _value_int = -1;
   _debouncer.update();
   // Get the update value from the button
   int value = _debouncer.read();

--- a/NodeManager.cpp
+++ b/NodeManager.cpp
@@ -1393,6 +1393,29 @@ void SensorSwitch::onSetup() {
 
 // what to do during loop
 void SensorSwitch::onLoop() {
+}
+// what to do as the main task when receiving a message
+void SensorSwitch::onReceive(const MyMessage & message) {
+  if (message.getCommand() == C_REQ) {
+    _value_int = digitalRead(_pin);
+  }
+}
+
+// what to do when receiving a remote message
+void SensorSwitch::onProcess(Request & request) {
+  int function = request.getFunction();
+  switch(function) {
+    case 101: setMode(request.getValueInt()); break;
+    case 102: setDebounce(request.getValueInt()); break;
+    case 103: setTriggerTime(request.getValueInt()); break;
+    case 104: setInitial(request.getValueInt()); break;
+    default: return;
+  }
+  _send(_msg_service.set(function));
+}
+
+// what to do when receiving an interrupt
+void SensorSwitch::onInterrupt() {
   // wait to ensure the the input is not floating
   if (_debounce > 0) wait(_debounce);
   // read the value of the pin
@@ -1414,27 +1437,6 @@ void SensorSwitch::onLoop() {
     // invalid
     _value_int = -1;
   }
-}
-// what to do as the main task when receiving a message
-void SensorSwitch::onReceive(const MyMessage & message) {
-  if (message.getCommand() == C_REQ) onLoop();
-}
-
-// what to do when receiving a remote message
-void SensorSwitch::onProcess(Request & request) {
-  int function = request.getFunction();
-  switch(function) {
-    case 101: setMode(request.getValueInt()); break;
-    case 102: setDebounce(request.getValueInt()); break;
-    case 103: setTriggerTime(request.getValueInt()); break;
-    case 104: setInitial(request.getValueInt()); break;
-    default: return;
-  }
-  _send(_msg_service.set(function));
-}
-
-// what to do when receiving an interrupt
-void SensorSwitch::onInterrupt() {
 }
 
 /*

--- a/NodeManager.cpp
+++ b/NodeManager.cpp
@@ -2800,7 +2800,7 @@ void NodeManager::loop() {
     // turn on the pin powering all the sensors
     if (_auto_power_pins) powerOn();
   #endif
-  // run interrupt/loop for all the registered sensors
+  // run loop for all the registered sensors
   for (int i = 1; i <= MAX_SENSORS; i++) {
     // skip unconfigured sensors
     if (_sensors[i] == 0) continue;

--- a/NodeManager.cpp
+++ b/NodeManager.cpp
@@ -587,6 +587,10 @@ void SensorAnalogInput::onProcess(Request & request) {
   _send(_msg_service.set(function));
 }
 
+// what to do when receiving an interrupt
+void SensorAnalogInput::onInterrupt() {
+}
+
 // read the analog input
 int SensorAnalogInput::_getAnalogRead() {
   #ifndef MY_GATEWAY_ESP8266
@@ -712,6 +716,10 @@ void SensorThermistor::onProcess(Request & request) {
   _send(_msg_service.set(function));
 }
 
+// what to do when receiving an interrupt
+void SensorThermistor::onInterrupt() {
+}
+
 /*
    SensorML8511
 */
@@ -762,6 +770,10 @@ void SensorML8511::onReceive(const MyMessage & message) {
 
 // what to do when receiving a remote message
 void SensorML8511::onProcess(Request & request) {
+}
+
+// what to do when receiving an interrupt
+void SensorML8511::onInterrupt() {
 }
 
 // The Arduino Map function but for floats
@@ -830,6 +842,10 @@ void SensorACS712::onProcess(Request & request) {
   _send(_msg_service.set(function));
 }
 
+// what to do when receiving an interrupt
+void SensorACS712::onInterrupt() {
+}
+
 /*
    SensorRainGauge
 */
@@ -861,11 +877,9 @@ void SensorRainGauge::setInitialValue(int value) {
 
 // what to do during before
 void SensorRainGauge::onBefore() {
-  // set the pin as input and enabled pull up
-  pinMode(_pin, INPUT);
-  digitalWrite(_pin,_initial_value);
-  // attach to the pin's interrupt and execute the routine on falling
-  attachInterrupt(digitalPinToInterrupt(_pin), _onTipped, FALLING);
+  // set the interrupt pin so it will be called only when waking up from that interrupt
+  _interrupt_pin = _pin;
+  _node_manager->setInterrupt(_pin,FALLING,_initial_value);
   // start the timer
   _timer->start(_report_interval,MINUTES);
 }
@@ -925,6 +939,10 @@ void SensorRainGauge::onProcess(Request & request) {
     default: return;
   }
   _send(_msg_service.set(function));
+}
+
+// what to do when receiving an interrupt
+void SensorRainGauge::onInterrupt() {
 }
 
 /*
@@ -1001,6 +1019,10 @@ void SensorDigitalInput::onReceive(const MyMessage & message) {
 
 // what to do when receiving a remote message
 void SensorDigitalInput::onProcess(Request & request) {
+}
+
+// what to do when receiving an interrupt
+void SensorDigitalInput::onInterrupt() {
 }
 #endif
 
@@ -1091,6 +1113,10 @@ void SensorDigitalOutput::onProcess(Request & request) {
     default: return;
   }
   _send(_msg_service.set(function));
+}
+
+// what to do when receiving an interrupt
+void SensorDigitalOutput::onInterrupt() {
 }
 
 // write the value to the output
@@ -1235,6 +1261,10 @@ void SensorDHT::onReceive(const MyMessage & message) {
 // what to do when receiving a remote message
 void SensorDHT::onProcess(Request & request) {
 }
+
+// what to do when receiving an interrupt
+void SensorDHT::onInterrupt() {
+}
 #endif
 
 /*
@@ -1309,6 +1339,10 @@ void SensorSHT21::onReceive(const MyMessage & message) {
 
 // what to do when receiving a remote message
 void SensorSHT21::onProcess(Request & request) {
+}
+
+// what to do when receiving an interrupt
+void SensorSHT21::onInterrupt() {
 }
 #endif
 
@@ -1399,6 +1433,10 @@ void SensorSwitch::onProcess(Request & request) {
   _send(_msg_service.set(function));
 }
 
+// what to do when receiving an interrupt
+void SensorSwitch::onInterrupt() {
+}
+
 /*
  * SensorDoor
  */
@@ -1482,6 +1520,10 @@ void SensorDs18b20::onProcess(Request & request) {
   _send(_msg_service.set(function));
 }
 
+// what to do when receiving an interrupt
+void SensorDs18b20::onInterrupt() {
+}
+
 // function to print a device address
 DeviceAddress* SensorDs18b20::getDeviceAddress() {
   return &_device_address;
@@ -1544,6 +1586,11 @@ void SensorBH1750::onReceive(const MyMessage & message) {
 // what to do when receiving a remote message
 void SensorBH1750::onProcess(Request & request) {
 }
+
+
+// what to do when receiving an interrupt
+void SensorBH1750::onInterrupt() {
+}
 #endif
 
 /*
@@ -1591,6 +1638,10 @@ void SensorMLX90614::onReceive(const MyMessage & message) {
 
 // what to do when receiving a remote message
 void SensorMLX90614::onProcess(Request & request) {
+}
+
+// what to do when receiving an interrupt
+void SensorMLX90614::onInterrupt() {
 }
 #endif
 
@@ -1660,6 +1711,10 @@ void SensorBosch::onProcess(Request & request) {
     default: return;
   }
   _send(_msg_service.set(function));
+}
+
+// what to do when receiving an interrupt
+void SensorBosch::onInterrupt() {
 }
 
 // calculate and send the forecast back
@@ -1944,6 +1999,10 @@ void SensorHCSR04::onProcess(Request & request) {
   }
   _send(_msg_service.set(function));
 }
+
+// what to do when receiving an interrupt
+void SensorHCSR04::onInterrupt() {
+}
 #endif
 
 /*
@@ -2028,6 +2087,10 @@ void SensorSonoff::onProcess(Request & request) {
   _send(_msg_service.set(function));
 }
 
+// what to do when receiving an interrupt
+void SensorSonoff::onInterrupt() {
+}
+
 // toggle the state
 void SensorSonoff::_toggle() {
   // toggle the state
@@ -2100,6 +2163,10 @@ void SensorMCP9808::onReceive(const MyMessage & message) {
 
 // what to do when receiving a remote message
 void SensorMCP9808::onProcess(Request & request) {
+}
+
+// what to do when receiving an interrupt
+void SensorMCP9808::onInterrupt() {
 }
 #endif
 
@@ -2212,6 +2279,10 @@ void SensorMQ::onProcess(Request & request) {
     default: return;
   }
   _send(_msg_service.set(function));
+}
+
+// what to do when receiving an interrupt
+void SensorMQ::onInterrupt() {
 }
 
 // returns the calculated sensor resistance

--- a/NodeManager.cpp
+++ b/NodeManager.cpp
@@ -2273,6 +2273,9 @@ NodeManager::NodeManager() {
 }
 
 int NodeManager::_last_interrupt_pin = -1;
+long NodeManager::_last_interrupt_1 = millis();
+long NodeManager::_last_interrupt_2 = millis();
+long NodeManager::_interrupt_min_delta = 1000;
 
 // setter/getter
 void NodeManager::setRetries(int value) {
@@ -2639,8 +2642,6 @@ void NodeManager::before() {
     Serial.print(F(" B="));
     Serial.println(MY_CAP_RXBUF);
   #endif
-  // setup the interrupt pins
-  setupInterrupts();
   #if PERSIST == 1
     // restore the configuration saved in the eeprom
     _loadConfig();
@@ -2658,6 +2659,8 @@ void NodeManager::before() {
     // call each sensor's setup()
     _sensors[i]->before();
   }
+  // setup the interrupt pins
+  setupInterrupts();
 }
 
 // present NodeManager and its sensors
@@ -3008,18 +3011,26 @@ void NodeManager::setupInterrupts() {
 
 // handle an interrupt
 void NodeManager::_onInterrupt_1() {
-  _last_interrupt_pin = INTERRUPT_PIN_1;
-  #if DEBUG == 1
-    Serial.print(F("INT P="));
-    Serial.println(INTERRUPT_PIN_1);
-  #endif
+  long now = millis();
+  if ( (now - _last_interrupt_1 > _interrupt_min_delta) || (now < _last_interrupt_1) ) {
+    _last_interrupt_pin = INTERRUPT_PIN_1;
+    #if DEBUG == 1
+      Serial.print(F("INT P="));
+      Serial.println(INTERRUPT_PIN_1);
+    #endif
+    _last_interrupt_1 = now;
+  }
 }
 void NodeManager::_onInterrupt_2() {
-  _last_interrupt_pin = INTERRUPT_PIN_2;
-  #if DEBUG == 1
-    Serial.print(F("INT P="));
-    Serial.println(INTERRUPT_PIN_2);
-  #endif
+  long now = millis();
+  if ( (now - _last_interrupt_2 > _interrupt_min_delta) || (now < _last_interrupt_2) ) {
+    _last_interrupt_pin = INTERRUPT_PIN_2;
+    #if DEBUG == 1
+      Serial.print(F("INT P="));
+      Serial.println(INTERRUPT_PIN_2);
+    #endif
+    _last_interrupt_2 = now;
+  }
 }
 
 // send a message to the network

--- a/NodeManager.cpp
+++ b/NodeManager.cpp
@@ -2743,7 +2743,7 @@ void NodeManager::loop() {
     if (_auto_power_pins) powerOn();
   #endif
   // run loop for all the registered sensors
-  for (int i = 0; i < MAX_SENSORS; i++) {
+  for (int i = 1; i <= MAX_SENSORS; i++) {
     // skip unconfigured sensors
     if (_sensors[i] == 0) continue;
     // if the sensor is associated with an interrupt and the last interrupt is different than the sensor's interrupt, skip it

--- a/NodeManager.cpp
+++ b/NodeManager.cpp
@@ -2720,8 +2720,6 @@ void NodeManager::setup() {
 // run the main function for all the register sensors
 void NodeManager::loop() {
   MyMessage empty;
-  // reset the last interrupt pin
-  _last_interrupt_pin = -1;
   // if in idle mode, do nothing
   if (_sleep_mode == IDLE) return;
   // if sleep time is not set, do nothing
@@ -2751,6 +2749,8 @@ void NodeManager::loop() {
     // call the sensor's loop()
     _sensors[i]->loop(empty);
   }
+  // reset the last interrupt pin
+  _last_interrupt_pin = -1;
   #if POWER_MANAGER == 1
     // turn off the pin powering all the sensors
     if (_auto_power_pins) powerOff();

--- a/NodeManager.cpp
+++ b/NodeManager.cpp
@@ -2339,14 +2339,14 @@ void NodeManager::setSleep(int value1, int value2, int value3) {
 void NodeManager::setSleepInterruptPin(int value) {
   _sleep_interrupt_pin = value;
 }
-void NodeManager::setInterrupt(int pin, int mode, int pull) {
+void NodeManager::setInterrupt(int pin, int mode, int initial) {
   if (pin == INTERRUPT_PIN_1) {
     _interrupt_1_mode = mode;
-    _interrupt_1_pull = pull;
+    _interrupt_1_initial = initial;
   }
   if (pin == INTERRUPT_PIN_2) { 
     _interrupt_2_mode = mode;
-    _interrupt_2_pull = pull;
+    _interrupt_2_initial = initial;
   }
 }
 void NodeManager::setInterruptMinDelta(long value) {
@@ -2875,6 +2875,7 @@ void NodeManager::process(Request & request) {
     #endif
     case 26: unRegisterSensor(request.getValueInt()); break;
     case 27: saveToMemory(0,request.getValueInt()); break;
+    case 28: setInterruptMinDelta(request.getValueInt()); break;
     default: return; 
   }
   _send(_msg.set(function));
@@ -2992,13 +2993,13 @@ void NodeManager::setupInterrupts() {
   // setup the interrupt pins
   if (_interrupt_1_mode != MODE_NOT_DEFINED) {
     pinMode(INTERRUPT_PIN_1,INPUT);
-    if (_interrupt_1_pull > -1) digitalWrite(INTERRUPT_PIN_1,_interrupt_1_pull);
+    if (_interrupt_1_initial > -1) digitalWrite(INTERRUPT_PIN_1,_interrupt_1_initial);
     // for non sleeping nodes, we need to handle the interrupt by ourselves  
     if (_sleep_mode != SLEEP) attachInterrupt(digitalPinToInterrupt(INTERRUPT_PIN_1), _onInterrupt_1, _interrupt_1_mode);
   }
   if (_interrupt_2_mode != MODE_NOT_DEFINED) {
     pinMode(INTERRUPT_PIN_2, INPUT);
-    if (_interrupt_2_pull > -1) digitalWrite(INTERRUPT_PIN_2,_interrupt_2_pull);
+    if (_interrupt_2_initial > -1) digitalWrite(INTERRUPT_PIN_2,_interrupt_2_initial);
     // for non sleeping nodes, we need to handle the interrupt by ourselves  
     if (_sleep_mode != SLEEP) attachInterrupt(digitalPinToInterrupt(INTERRUPT_PIN_2), _onInterrupt_2, _interrupt_2_mode);
   }

--- a/NodeManager.cpp
+++ b/NodeManager.cpp
@@ -1063,6 +1063,9 @@ void SensorDigitalOutput::setInputIsElapsed(bool value) {
 
 // main task
 void SensorDigitalOutput::onLoop() {
+  // set the value to -1 so to avoid reporting to the gateway during loop
+  _value_int = -1;
+  _last_value_int = -1;
   // if a safeguard is set, check if it is time for it
   if (_safeguard_timer->isRunning()) {
     // update the timer
@@ -2802,7 +2805,7 @@ void NodeManager::loop() {
   #endif
   // run loop for all the registered sensors
   for (int i = 1; i <= MAX_SENSORS; i++) {
-    // skip unconfigured sensors
+    // skip not configured sensors
     if (_sensors[i] == 0) continue;
     // if there was an interrupt for this sensor, call the sensor's interrupt()
     if (_last_interrupt_pin != -1 && _sensors[i]->getInterruptPin() == _last_interrupt_pin) _sensors[i]->interrupt();

--- a/NodeManager.cpp
+++ b/NodeManager.cpp
@@ -2339,7 +2339,7 @@ void NodeManager::setInterrupt(int pin, int mode, int pull) {
     _interrupt_1_mode = mode;
     _interrupt_1_pull = pull;
   }
-  if (pin == INTERRUPT_PIN_2) {
+  if (pin == INTERRUPT_PIN_2) { 
     _interrupt_2_mode = mode;
     _interrupt_2_pull = pull;
   }

--- a/NodeManager.cpp
+++ b/NodeManager.cpp
@@ -2349,6 +2349,9 @@ void NodeManager::setInterrupt(int pin, int mode, int pull) {
     _interrupt_2_pull = pull;
   }
 }
+void NodeManager::setInterruptMinDelta(long value) {
+  _interrupt_min_delta = value;
+}
 #if POWER_MANAGER == 1
   void NodeManager::setPowerPins(int ground_pin, int vcc_pin, int wait_time) {
     _powerManager.setPowerPins(ground_pin, vcc_pin, wait_time);

--- a/NodeManager.cpp
+++ b/NodeManager.cpp
@@ -892,6 +892,8 @@ void SensorRainGauge::onSetup() {
 
 // what to do during loop
 void SensorRainGauge::onLoop() {
+  // do not execute loop if called by an interrupt
+  if (_node_manager->getLastInterruptPin() == _interrupt_pin) return;
   // time to report the rain so far
   _value_float = _count * _single_tip;
   #if DEBUG == 1
@@ -3071,6 +3073,11 @@ void NodeManager::setupInterrupts() {
     Serial.print(F(" M="));
     Serial.println(_interrupt_2_mode);
   #endif
+}
+
+// return the pin from which the last interrupt came
+int NodeManager::getLastInterruptPin() {
+  return _last_interrupt_pin;
 }
 
 // handle an interrupt

--- a/NodeManager.h
+++ b/NodeManager.h
@@ -471,6 +471,7 @@ class Sensor {
     virtual void onLoop() = 0;
     virtual void onReceive(const MyMessage & message) = 0;
     virtual void onProcess(Request & request) = 0;
+    virtual void onInterrupt() = 0;
   protected:
     MyMessage _msg;
     MyMessage _msg_service;
@@ -526,6 +527,7 @@ class SensorAnalogInput: public Sensor {
     void onLoop();
     void onReceive(const MyMessage & message);
     void onProcess(Request & request);
+    void onInterrupt();
   protected:
     int _reference = -1;
     bool _reverse = false;
@@ -566,6 +568,7 @@ class SensorThermistor: public Sensor {
     void onLoop();
     void onReceive(const MyMessage & message);
     void onProcess(Request & request);
+    void onInterrupt();
   protected:
     long _nominal_resistor = 10000;
     int _nominal_temperature = 25;
@@ -587,6 +590,7 @@ class SensorML8511: public Sensor {
     void onLoop();
     void onReceive(const MyMessage & message);
     void onProcess(Request & request);
+    void onInterrupt();
   protected:
     float _mapfloat(float x, float in_min, float in_max, float out_min, float out_max);
 };
@@ -608,6 +612,7 @@ class SensorACS712: public Sensor {
     void onLoop();
     void onReceive(const MyMessage & message);
     void onProcess(Request & request);
+    void onInterrupt();
   protected:
     int _ACS_offset = 2500;
     int _mv_per_amp = 185;
@@ -632,6 +637,7 @@ class SensorRainGauge: public Sensor {
     void onLoop();
     void onReceive(const MyMessage & message);
     void onProcess(Request & request);
+    void onInterrupt();
   public:
     static void _onTipped();
     static long _last_tip;
@@ -674,6 +680,7 @@ class SensorDigitalInput: public Sensor {
     void onLoop();
     void onReceive(const MyMessage & message);
     void onProcess(Request & request);
+    void onInterrupt();
 };
 #endif
 
@@ -706,6 +713,7 @@ class SensorDigitalOutput: public Sensor {
     void onLoop();
     void onReceive(const MyMessage & message);
     void onProcess(Request & request);
+    void onInterrupt();
   protected:
     int _initial_value = LOW;
     int _on_value = HIGH;
@@ -747,6 +755,7 @@ class SensorDHT: public Sensor {
     void onLoop();
     void onReceive(const MyMessage & message);
     void onProcess(Request & request);
+    void onInterrupt();
     // constants
     const static int TEMPERATURE = 0;
     const static int HUMIDITY = 1;
@@ -771,6 +780,7 @@ class SensorSHT21: public Sensor {
     void onLoop();
     void onReceive(const MyMessage & message);
     void onProcess(Request & request);
+    void onInterrupt();
     // constants
     const static int TEMPERATURE = 0;
     const static int HUMIDITY = 1;
@@ -810,6 +820,7 @@ class SensorSwitch: public Sensor {
     void onLoop();
     void onReceive(const MyMessage & message);
     void onProcess(Request & request);
+    void onInterrupt();
   protected:
     int _debounce = 0;
     int _trigger_time = 0;
@@ -854,6 +865,7 @@ class SensorDs18b20: public Sensor {
     void onLoop();
     void onReceive(const MyMessage & message);
     void onProcess(Request & request);
+    void onInterrupt();
   protected:
     float _offset = 0;
     int _index;
@@ -876,6 +888,7 @@ class SensorBH1750: public Sensor {
     void onLoop();
     void onReceive(const MyMessage & message);
     void onProcess(Request & request);
+    void onInterrupt();
   protected:
     BH1750* _lightSensor;
 };
@@ -894,6 +907,7 @@ class SensorMLX90614: public Sensor {
     void onLoop();
     void onReceive(const MyMessage & message);
     void onProcess(Request & request);
+    void onInterrupt();
     // constants
     const static int TEMPERATURE_AMBIENT = 0;
     const static int TEMPERATURE_OBJECT = 1;
@@ -920,6 +934,7 @@ class SensorBosch: public Sensor {
     void onLoop();
     void onReceive(const MyMessage & message);
     void onProcess(Request & request);
+    void onInterrupt();
     // constants
     const static int TEMPERATURE = 0;
     const static int HUMIDITY = 1;
@@ -986,6 +1001,7 @@ class SensorHCSR04: public Sensor {
     void onLoop();
     void onReceive(const MyMessage & message);
     void onProcess(Request & request);
+    void onInterrupt();
   protected:
     int _trigger_pin;
     int _echo_pin;
@@ -1013,6 +1029,7 @@ class SensorSonoff: public Sensor {
     void onLoop();
     void onReceive(const MyMessage & message);
     void onProcess(Request & request);
+    void onInterrupt();
   protected:
     Bounce _debouncer = Bounce();
     int _button_pin = 0;
@@ -1042,6 +1059,7 @@ class SensorMCP9808: public Sensor {
     void onLoop();
     void onReceive(const MyMessage & message);
     void onProcess(Request & request);
+    void onInterrupt();
   protected:
     Adafruit_MCP9808* _mcp;
 };
@@ -1082,6 +1100,7 @@ class SensorMQ: public Sensor {
     void onLoop();
     void onReceive(const MyMessage & message);
     void onProcess(Request & request);
+    void onInterrupt();
   protected:
     float _rl_value = 1.0;
     float _ro_clean_air_factor = 9.83;

--- a/NodeManager.h
+++ b/NodeManager.h
@@ -624,6 +624,8 @@ class SensorRainGauge: public Sensor {
     void setReportInterval(int value);
     // [102] set how many mm of rain to count for each tip (default: 0.11)
     void setSingleTip(float value);
+    // set initial value - internal pull up (default: HIGH)
+    void setInitialValue(int value);
     // define what to do at each stage of the sketch
     void onBefore();
     void onSetup();
@@ -637,6 +639,7 @@ class SensorRainGauge: public Sensor {
   protected:
     int _report_interval = 60;
     float _single_tip = 0.11;
+    int _initial_value = HIGH;
     Timer* _timer;
 };
 

--- a/NodeManager.h
+++ b/NodeManager.h
@@ -1146,8 +1146,8 @@ class NodeManager {
     // [19] if enabled, when waking up from the interrupt, the board stops sleeping. Disable it when attaching e.g. a motion sensor (default: true)
     void setSleepInterruptPin(int value);
     // configure the interrupt pin and mode. Mode can be CHANGE, RISING, FALLING (default: MODE_NOT_DEFINED)
-    void setInterrupt(int pin, int mode, int pull = -1);
-    // ignore two consecutive interrupts if happening within this timeframe in milliseconds (default: 100)
+    void setInterrupt(int pin, int mode, int initial = -1);
+    // [28] ignore two consecutive interrupts if happening within this timeframe in milliseconds (default: 100)
     void setInterruptMinDelta(long value);
     // [20] optionally sleep interval in milliseconds before sending each message to the radio network (default: 0)
     void setSleepBetweenSend(int value);
@@ -1242,8 +1242,8 @@ class NodeManager {
     int _retries = 1;
     int _interrupt_1_mode = MODE_NOT_DEFINED;
     int _interrupt_2_mode = MODE_NOT_DEFINED;
-    int _interrupt_1_pull = -1;
-    int _interrupt_2_pull = -1;
+    int _interrupt_1_initial = -1;
+    int _interrupt_2_initial = -1;
     static int _last_interrupt_pin;
     static long _interrupt_min_delta;
     static long _last_interrupt_1;

--- a/NodeManager.h
+++ b/NodeManager.h
@@ -1225,6 +1225,8 @@ class NodeManager {
     float getVcc();
     // setup the configured interrupt pins
     void setupInterrupts();
+    // return the pin from which the last interrupt came
+    int getLastInterruptPin();
     // hook into the main sketch functions
     void before();
     void presentation();

--- a/NodeManager.h
+++ b/NodeManager.h
@@ -1147,6 +1147,8 @@ class NodeManager {
     void setSleepInterruptPin(int value);
     // configure the interrupt pin and mode. Mode can be CHANGE, RISING, FALLING (default: MODE_NOT_DEFINED)
     void setInterrupt(int pin, int mode, int pull = -1);
+    // ignore two consecutive interrupts if happening within this timeframe in milliseconds (default: 100)
+    void setInterruptMinDelta(long value);
     // [20] optionally sleep interval in milliseconds before sending each message to the radio network (default: 0)
     void setSleepBetweenSend(int value);
     int getSleepBetweenSend();

--- a/NodeManager.h
+++ b/NodeManager.h
@@ -628,8 +628,6 @@ class SensorACS712: public Sensor {
 class SensorRainGauge: public Sensor {
   public:
     SensorRainGauge(NodeManager* node_manager, int child_id, int pin);
-    // [101] set how frequently to report back to the controller in minutes. After reporting the measure is resetted (default: 60)
-    void setReportInterval(int value);
     // [102] set how many mm of rain to count for each tip (default: 0.11)
     void setSingleTip(float value);
     // set initial value - internal pull up (default: HIGH)
@@ -641,15 +639,10 @@ class SensorRainGauge: public Sensor {
     void onReceive(const MyMessage & message);
     void onProcess(Request & request);
     void onInterrupt();
-  public:
-    static void _onTipped();
-    static long _last_tip;
-    static long _count;
   protected:
-    int _report_interval = 60;
+    long _count = 0;
     float _single_tip = 0.11;
     int _initial_value = HIGH;
-    Timer* _timer;
 };
 
 /*

--- a/NodeManager.h
+++ b/NodeManager.h
@@ -464,6 +464,7 @@ class Sensor {
     virtual void presentation();
     virtual void setup();
     virtual void loop(const MyMessage & message);
+    virtual void interrupt();
     virtual void receive(const MyMessage & message);
     // abstract functions, subclasses need to implement
     virtual void onBefore() = 0;
@@ -1271,7 +1272,7 @@ class NodeManager {
     static long _last_interrupt_1;
     static long _last_interrupt_2;
     long _timestamp = -1;
-    Sensor* _sensors[MAX_SENSORS] = {0};
+    Sensor* _sensors[MAX_SENSORS+1] = {0};
     bool _ack = false;
     void _sleep();
     void _present(int child_id, int type);

--- a/NodeManager.h
+++ b/NodeManager.h
@@ -1203,6 +1203,8 @@ class NodeManager {
     void saveToMemory(int index, int value);
     // return vcc in V
     float getVcc();
+    // setup the configured interrupt pins
+    void setupInterrupts();
     // hook into the main sketch functions
     void before();
     void presentation();
@@ -1210,6 +1212,9 @@ class NodeManager {
     void loop();
     void receive(const MyMessage & msg);
     void receiveTime(unsigned long ts);
+    // handle interrupts
+    static void _onInterrupt_1();
+    static void _onInterrupt_2();
   private:
     #if BATTERY_MANAGER == 1
       float _battery_min = 2.6;
@@ -1237,7 +1242,7 @@ class NodeManager {
     int _interrupt_2_mode = MODE_NOT_DEFINED;
     int _interrupt_1_pull = -1;
     int _interrupt_2_pull = -1;
-    int _last_interrupt_pin = -1;
+    static int _last_interrupt_pin;
     long _timestamp = -1;
     Sensor* _sensors[MAX_SENSORS] = {0};
     bool _ack = false;

--- a/NodeManager.h
+++ b/NodeManager.h
@@ -459,6 +459,8 @@ class Sensor {
     void process(Request & request);
     // return the pin the interrupt is attached to
     int getInterruptPin();
+    // listen for interrupts on the given pin so interrupt() will be called when occurring
+    void setInterrupt(int pin, int mode, int initial);
     // define what to do at each stage of the sketch
     virtual void before();
     virtual void presentation();

--- a/NodeManager.h
+++ b/NodeManager.h
@@ -1243,6 +1243,9 @@ class NodeManager {
     int _interrupt_1_pull = -1;
     int _interrupt_2_pull = -1;
     static int _last_interrupt_pin;
+    static long _interrupt_min_delta;
+    static long _last_interrupt_1;
+    static long _last_interrupt_2;
     long _timestamp = -1;
     Sensor* _sensors[MAX_SENSORS] = {0};
     bool _ack = false;

--- a/NodeManager.ino
+++ b/NodeManager.ino
@@ -33,7 +33,12 @@ void before() {
   /*
    * Register below your sensors
   */
-
+      pinMode(4, OUTPUT);
+    digitalWrite(4, LOW);
+    pinMode(5, OUTPUT);
+    digitalWrite(5, HIGH);
+    nodeManager.registerSensor(SENSOR_MOTION,3);
+    nodeManager.setMode(ALWAYS_ON);
 
   /*
    * Register above your sensors

--- a/NodeManager.ino
+++ b/NodeManager.ino
@@ -37,8 +37,10 @@ void before() {
     digitalWrite(4, LOW);
     pinMode(5, OUTPUT);
     digitalWrite(5, HIGH);
-    int a = nodeManager.registerSensor(SENSOR_RAIN_GAUGE,3);
-    SensorRainGauge* s = (SensorRainGauge*)nodeManager.get(a);
+    int a = nodeManager.registerSensor(SENSOR_MOTION,3);
+     SensorMotion* s = (SensorMotion*)nodeManager.get(a);
+    s->setMode(CHANGE);   
+    //SensorRainGauge* s = (SensorRainGauge*)nodeManager.get(a);
     //s->setMode(CHANGE);
     nodeManager.setMode(ALWAYS_ON);
 

--- a/NodeManager.ino
+++ b/NodeManager.ino
@@ -33,13 +33,13 @@ void before() {
   /*
    * Register below your sensors
   */
-      pinMode(4, OUTPUT);
+    pinMode(4, OUTPUT);
     digitalWrite(4, LOW);
     pinMode(5, OUTPUT);
     digitalWrite(5, HIGH);
     int a = nodeManager.registerSensor(SENSOR_MOTION,3);
     SensorMotion* s = (SensorMotion*)nodeManager.get(a);
-    s->setMode(CHANGE);
+    //s->setMode(CHANGE);
     nodeManager.setMode(ALWAYS_ON);
 
   /*

--- a/NodeManager.ino
+++ b/NodeManager.ino
@@ -37,10 +37,11 @@ void before() {
     digitalWrite(4, LOW);
     pinMode(5, OUTPUT);
     digitalWrite(5, HIGH);
-    int a = nodeManager.registerSensor(SENSOR_MOTION,3);
-     SensorMotion* s = (SensorMotion*)nodeManager.get(a);
-    s->setMode(CHANGE);   
-    //SensorRainGauge* s = (SensorRainGauge*)nodeManager.get(a);
+    int a = nodeManager.registerSensor(SENSOR_RAIN_GAUGE,3);
+    // SensorMotion* s = (SensorMotion*)nodeManager.get(a);
+    //s->setMode(CHANGE);   
+    SensorRainGauge* s = (SensorRainGauge*)nodeManager.get(a);
+    s->setReportIntervalMinutes(1);
     //s->setMode(CHANGE);
     nodeManager.setMode(ALWAYS_ON);
     //nodeManager.setSleep(SLEEP,10,MINUTES);

--- a/NodeManager.ino
+++ b/NodeManager.ino
@@ -41,10 +41,11 @@ void before() {
     // SensorMotion* s = (SensorMotion*)nodeManager.get(a);
     //s->setMode(CHANGE);   
     SensorRainGauge* s = (SensorRainGauge*)nodeManager.get(a);
-    s->setReportIntervalMinutes(2);
+    
     //s->setMode(CHANGE);
     //nodeManager.setMode(ALWAYS_ON);
     nodeManager.setSleep(SLEEP,1,MINUTES);
+    s->setReportIntervalMinutes(2);
 
   /*
    * Register above your sensors

--- a/NodeManager.ino
+++ b/NodeManager.ino
@@ -37,7 +37,9 @@ void before() {
     digitalWrite(4, LOW);
     pinMode(5, OUTPUT);
     digitalWrite(5, HIGH);
-    nodeManager.registerSensor(SENSOR_MOTION,3);
+    int a = nodeManager.registerSensor(SENSOR_MOTION,3);
+    SensorMotion* s = (SensorMotion*)nodeManager.get(a);
+    s->setMode(CHANGE);
     nodeManager.setMode(ALWAYS_ON);
 
   /*

--- a/NodeManager.ino
+++ b/NodeManager.ino
@@ -37,8 +37,8 @@ void before() {
     digitalWrite(4, LOW);
     pinMode(5, OUTPUT);
     digitalWrite(5, HIGH);
-    int a = nodeManager.registerSensor(SENSOR_MOTION,3);
-    SensorMotion* s = (SensorMotion*)nodeManager.get(a);
+    int a = nodeManager.registerSensor(SENSOR_RAIN_GAUGE,3);
+    SensorRainGauge* s = (SensorRainGauge*)nodeManager.get(a);
     //s->setMode(CHANGE);
     nodeManager.setMode(ALWAYS_ON);
 

--- a/NodeManager.ino
+++ b/NodeManager.ino
@@ -43,6 +43,7 @@ void before() {
     //SensorRainGauge* s = (SensorRainGauge*)nodeManager.get(a);
     //s->setMode(CHANGE);
     nodeManager.setMode(ALWAYS_ON);
+    //nodeManager.setSleep(SLEEP,10,MINUTES);
 
   /*
    * Register above your sensors

--- a/NodeManager.ino
+++ b/NodeManager.ino
@@ -41,10 +41,10 @@ void before() {
     // SensorMotion* s = (SensorMotion*)nodeManager.get(a);
     //s->setMode(CHANGE);   
     SensorRainGauge* s = (SensorRainGauge*)nodeManager.get(a);
-    s->setReportIntervalMinutes(1);
+    s->setReportIntervalMinutes(2);
     //s->setMode(CHANGE);
-    nodeManager.setMode(ALWAYS_ON);
-    //nodeManager.setSleep(SLEEP,10,MINUTES);
+    //nodeManager.setMode(ALWAYS_ON);
+    nodeManager.setSleep(SLEEP,1,MINUTES);
 
   /*
    * Register above your sensors

--- a/NodeManager.ino
+++ b/NodeManager.ino
@@ -33,19 +33,9 @@ void before() {
   /*
    * Register below your sensors
   */
-    pinMode(4, OUTPUT);
-    digitalWrite(4, LOW);
-    pinMode(5, OUTPUT);
-    digitalWrite(5, HIGH);
-    int a = nodeManager.registerSensor(SENSOR_RAIN_GAUGE,3);
-    // SensorMotion* s = (SensorMotion*)nodeManager.get(a);
-    //s->setMode(CHANGE);   
-    SensorRainGauge* s = (SensorRainGauge*)nodeManager.get(a);
-    
-    //s->setMode(CHANGE);
-    //nodeManager.setMode(ALWAYS_ON);
-    nodeManager.setSleep(SLEEP,1,MINUTES);
-    s->setReportIntervalMinutes(2);
+
+
+
 
   /*
    * Register above your sensors

--- a/README.md
+++ b/README.md
@@ -503,8 +503,6 @@ Each sensor class can expose additional methods.
 
 * SensorRainGauge
 ~~~c
-    // [101] set how frequently to report back to the controller in minutes. After reporting the measure is resetted (default: 60)
-    void setReportInterval(int value);
     // [102] set how many mm of rain to count for each tip (default: 0.11)
     void setSingleTip(float value);
     // set initial value - internal pull up (default: HIGH)

--- a/README.md
+++ b/README.md
@@ -362,6 +362,8 @@ If you want to create a custom sensor and register it with NodeManager so it can
     void onReceive(const MyMessage & message);
 	// define what to do when receiving a remote configuration message
 	void onProcess(Request & request);
+	// define what to do when receiving an interrupt
+	void onInterrupt();
 ~~~
 
 You can then instantiate your newly created class and register with NodeManager:
@@ -689,6 +691,16 @@ NodeManager::receive():
 
 Sensor::receive(): 
 * Invoke `Sensor::loop()` which will execute the sensor main taks and eventually call `Sensor::onReceive()`
+
+NodeManager::process():
+* Process an incoming remote configuration request
+
+Sensor::process():
+* Process a sensor-generic incoming remote configuration request
+* Calls onProcess() for sensor-specific incoming remote configuration request
+
+Sensor::interrupt():
+* Calls the sensor's implementation of onInterrupt() to handle the interrupt
 
 ## Examples
 All the examples below takes place within the before() function in the main sketch, just below the "Register below your sensors" comment.

--- a/README.md
+++ b/README.md
@@ -505,6 +505,8 @@ Each sensor class can expose additional methods.
     void setReportInterval(int value);
     // [102] set how many mm of rain to count for each tip (default: 0.11)
     void setSingleTip(float value);
+    // set initial value - internal pull up (default: HIGH)
+    void setInitialValue(int value);
 ~~~
 
 * SensorDigitalOutput / SensorRelay / SensorLatchingRelay

--- a/README.md
+++ b/README.md
@@ -292,6 +292,10 @@ Node Manager comes with a reasonable default configuration. If you want/need to 
     void saveToMemory(int index, int value);
     // return vcc in V
     float getVcc();
+    // setup the configured interrupt pins
+    void setupInterrupts();
+    // return the pin from which the last interrupt came
+    int getLastInterruptPin();
 ~~~
 
 For example

--- a/README.md
+++ b/README.md
@@ -431,6 +431,8 @@ The following methods are available for all the sensors:
     void process(Request & request);
     // return the pin the interrupt is attached to
     int getInterruptPin();
+    // listen for interrupts on the given pin so interrupt() will be called when occurring
+    void setInterrupt(int pin, int mode, int initial);
 ~~~
 
 #### Sensor's specific configuration

--- a/config.h
+++ b/config.h
@@ -103,7 +103,7 @@
 #define SERVICE_MESSAGES 0
 
 // Enable this module to use one of the following sensors: SENSOR_ANALOG_INPUT, SENSOR_LDR, SENSOR_THERMISTOR, SENSOR_ML8511, SENSOR_ACS712, SENSOR_RAIN_GAUGE, SENSOR_RAIN, SENSOR_SOIL_MOISTURE
-#define MODULE_ANALOG_INPUT 1
+#define MODULE_ANALOG_INPUT 0
 // Enable this module to use one of the following sensors: SENSOR_DIGITAL_INPUT
 #define MODULE_DIGITAL_INPUT 0
 // Enable this module to use one of the following sensors: SENSOR_DIGITAL_OUTPUT, SENSOR_RELAY, SENSOR_LATCHING_RELAY
@@ -113,7 +113,7 @@
 // Enable this module to use one of the following sensors: SENSOR_SHT21
 #define MODULE_SHT21 0
 // Enable this module to use one of the following sensors: SENSOR_SWITCH, SENSOR_DOOR, SENSOR_MOTION
-#define MODULE_SWITCH 0
+#define MODULE_SWITCH 1
 // Enable this module to use one of the following sensors: SENSOR_DS18B20
 #define MODULE_DS18B20 0
 // Enable this module to use one of the following sensors: SENSOR_BH1750

--- a/config.h
+++ b/config.h
@@ -103,7 +103,7 @@
 #define SERVICE_MESSAGES 0
 
 // Enable this module to use one of the following sensors: SENSOR_ANALOG_INPUT, SENSOR_LDR, SENSOR_THERMISTOR, SENSOR_ML8511, SENSOR_ACS712, SENSOR_RAIN_GAUGE, SENSOR_RAIN, SENSOR_SOIL_MOISTURE
-#define MODULE_ANALOG_INPUT 0
+#define MODULE_ANALOG_INPUT 1
 // Enable this module to use one of the following sensors: SENSOR_DIGITAL_INPUT
 #define MODULE_DIGITAL_INPUT 0
 // Enable this module to use one of the following sensors: SENSOR_DIGITAL_OUTPUT, SENSOR_RELAY, SENSOR_LATCHING_RELAY
@@ -113,7 +113,7 @@
 // Enable this module to use one of the following sensors: SENSOR_SHT21
 #define MODULE_SHT21 0
 // Enable this module to use one of the following sensors: SENSOR_SWITCH, SENSOR_DOOR, SENSOR_MOTION
-#define MODULE_SWITCH 1
+#define MODULE_SWITCH 0
 // Enable this module to use one of the following sensors: SENSOR_DS18B20
 #define MODULE_DS18B20 0
 // Enable this module to use one of the following sensors: SENSOR_BH1750

--- a/config.h
+++ b/config.h
@@ -15,11 +15,11 @@
 // General settings
 #define MY_BAUD_RATE 9600
 //#define MY_DEBUG
-//#define MY_NODE_ID 100
+#define MY_NODE_ID 100
 
 // NRF24 radio settings
 #define MY_RADIO_NRF24
-//#define MY_RF24_ENABLE_ENCRYPTION
+#define MY_RF24_ENABLE_ENCRYPTION
 //#define MY_RF24_CHANNEL 76
 //#define MY_RF24_PA_LEVEL RF24_PA_HIGH
 //#define MY_DEBUG_VERBOSE_RF24
@@ -103,17 +103,17 @@
 #define SERVICE_MESSAGES 0
 
 // Enable this module to use one of the following sensors: SENSOR_ANALOG_INPUT, SENSOR_LDR, SENSOR_THERMISTOR, SENSOR_ML8511, SENSOR_ACS712, SENSOR_RAIN_GAUGE, SENSOR_RAIN, SENSOR_SOIL_MOISTURE
-#define MODULE_ANALOG_INPUT 1
+#define MODULE_ANALOG_INPUT 0
 // Enable this module to use one of the following sensors: SENSOR_DIGITAL_INPUT
-#define MODULE_DIGITAL_INPUT 1
+#define MODULE_DIGITAL_INPUT 0
 // Enable this module to use one of the following sensors: SENSOR_DIGITAL_OUTPUT, SENSOR_RELAY, SENSOR_LATCHING_RELAY
-#define MODULE_DIGITAL_OUTPUT 1
+#define MODULE_DIGITAL_OUTPUT 0
 // Enable this module to use one of the following sensors: SENSOR_DHT11, SENSOR_DHT22
 #define MODULE_DHT 0
 // Enable this module to use one of the following sensors: SENSOR_SHT21
 #define MODULE_SHT21 0
 // Enable this module to use one of the following sensors: SENSOR_SWITCH, SENSOR_DOOR, SENSOR_MOTION
-#define MODULE_SWITCH 0
+#define MODULE_SWITCH 1
 // Enable this module to use one of the following sensors: SENSOR_DS18B20
 #define MODULE_DS18B20 0
 // Enable this module to use one of the following sensors: SENSOR_BH1750

--- a/config.h
+++ b/config.h
@@ -90,11 +90,11 @@
 #define DEBUG 1
 
 // if enabled, enable the capability to power on sensors with the arduino's pins to save battery while sleeping
-#define POWER_MANAGER 1
+#define POWER_MANAGER 0
 // if enabled, will load the battery manager library to allow the battery level to be reported automatically or on demand
-#define BATTERY_MANAGER 1
+#define BATTERY_MANAGER 0
 // if enabled, allow modifying the configuration remotely by interacting with the configuration child id
-#define REMOTE_CONFIGURATION 1
+#define REMOTE_CONFIGURATION 0
 // if enabled, persist the remote configuration settings on EEPROM
 #define PERSIST 0
 // if enabled, a battery sensor will be created at BATTERY_CHILD_ID and will report vcc voltage together with the battery level percentage

--- a/config.h
+++ b/config.h
@@ -15,11 +15,11 @@
 // General settings
 #define MY_BAUD_RATE 9600
 //#define MY_DEBUG
-#define MY_NODE_ID 100
+//#define MY_NODE_ID 100
 
 // NRF24 radio settings
 #define MY_RADIO_NRF24
-#define MY_RF24_ENABLE_ENCRYPTION
+//#define MY_RF24_ENABLE_ENCRYPTION
 //#define MY_RF24_CHANNEL 76
 //#define MY_RF24_PA_LEVEL RF24_PA_HIGH
 //#define MY_DEBUG_VERBOSE_RF24
@@ -90,11 +90,11 @@
 #define DEBUG 1
 
 // if enabled, enable the capability to power on sensors with the arduino's pins to save battery while sleeping
-#define POWER_MANAGER 0
+#define POWER_MANAGER 1
 // if enabled, will load the battery manager library to allow the battery level to be reported automatically or on demand
-#define BATTERY_MANAGER 0
+#define BATTERY_MANAGER 1
 // if enabled, allow modifying the configuration remotely by interacting with the configuration child id
-#define REMOTE_CONFIGURATION 0
+#define REMOTE_CONFIGURATION 1
 // if enabled, persist the remote configuration settings on EEPROM
 #define PERSIST 0
 // if enabled, a battery sensor will be created at BATTERY_CHILD_ID and will report vcc voltage together with the battery level percentage
@@ -105,9 +105,9 @@
 // Enable this module to use one of the following sensors: SENSOR_ANALOG_INPUT, SENSOR_LDR, SENSOR_THERMISTOR, SENSOR_ML8511, SENSOR_ACS712, SENSOR_RAIN_GAUGE, SENSOR_RAIN, SENSOR_SOIL_MOISTURE
 #define MODULE_ANALOG_INPUT 1
 // Enable this module to use one of the following sensors: SENSOR_DIGITAL_INPUT
-#define MODULE_DIGITAL_INPUT 0
+#define MODULE_DIGITAL_INPUT 1
 // Enable this module to use one of the following sensors: SENSOR_DIGITAL_OUTPUT, SENSOR_RELAY, SENSOR_LATCHING_RELAY
-#define MODULE_DIGITAL_OUTPUT 0
+#define MODULE_DIGITAL_OUTPUT 1
 // Enable this module to use one of the following sensors: SENSOR_DHT11, SENSOR_DHT22
 #define MODULE_DHT 0
 // Enable this module to use one of the following sensors: SENSOR_SHT21


### PR DESCRIPTION
Will fix #142, #149, #166, #154

To allow NodeManager handling interrupts while sleeping or NOT sleeping. Either way, _last_interrupt_pin is set when an interrupt triggers, from MySensors' sleep() or from a custom interrupt:
* NodeManager::setInterrupt() will stay and can be called by any sensor. It just stores the pin and the mode as before. Sensor::setInterrupt() sets the interrupt pin and calls NodeManager::setInterrupt()
* Moved interrupt setup into NodeManager::setupInterrupts() which is called in NodeManager::before() 
* setupInterrupts() calls attachInterrupt() if mode != SLEEP which triggers a static function and register _last_interrupt_pin in the same way the board wakes up from an interrupt while sleeping
* added Sensor::interrupt() which calls onInterrupt() which must be implemented by any sensor to differentiate between what is done upon an interrupt and what is done during a standard loop cycle
* NodeManager::loop() calls Sensor::interrupt() if there was an interrupt and just after the sensor's loop()
* SensorSwitch has now an empty onLoop() and the logic is moved into onInterrupt() which sets _value_int which is eventually reported by Sensor::loop()
* SensorRainGauge increases the counter in onInterrupt() and during onLoop() report the measure provided it is not called from an interrupt. Requires setReportIntervalMinutes() to work in an ALWAYS_ON mode