### PR TITLE
Fix compilation and other issues

### DIFF
--- a/NodeManager.cpp
+++ b/NodeManager.cpp
@@ -2180,6 +2180,9 @@ SensorMQ::SensorMQ(NodeManager* node_manager, int child_id, int pin): Sensor(nod
 }
 
 //setter/getter
+void SensorMQ::setTargetGas(int value) {
+  _target_gas = value;
+}
 void SensorMQ::setRlValue(float value) {
   _rl_value = value;
 }
@@ -2468,7 +2471,7 @@ int NodeManager::registerSensor(int sensor_type, int pin, int child_id) {
   // get a child_id if not provided by the user
   if (child_id < 0) child_id = _getAvailableChildId();
   // based on the given sensor type instantiate the appropriate class
-  if (sensor_type == 0) return -1;
+  if (sensor_type < 0) return -1;
   #if MODULE_ANALOG_INPUT == 1
     else if (sensor_type == SENSOR_ANALOG_INPUT) return registerSensor(new SensorAnalogInput(this,child_id, pin));
     else if (sensor_type == SENSOR_LDR) return registerSensor(new SensorLDR(this,child_id, pin));

--- a/NodeManager.h
+++ b/NodeManager.h
@@ -1113,9 +1113,9 @@ class SensorMQ: public Sensor {
     float _MQRead();
     int _MQGetGasPercentage(float rs_ro_ratio, int gas_id);
     int  _MQGetPercentage(float rs_ro_ratio, float *pcurve);
-    int _gas_lpg = 0;
-    int _gas_co = 1;
-    int _gas_smoke = 2;
+    const static int _gas_lpg = 0;
+    const static int _gas_co = 1;
+    const static int _gas_smoke = 2;
     int _target_gas = _gas_co;
 };
 #endif


### PR DESCRIPTION
-) Enums (in particular the sensor types) start with 0, so we have to allow a sensor type of 0
-) Add missing SensorMQ::setTargetGas method
-) Make gas type identifiers for MQ sensors const static to preserve 6 bytes of memory per MQ instance