### PR TITLE
Implement support for the MH-Z19 CO2 sensor (via UART)

### DIFF
--- a/NodeManager.h
+++ b/NodeManager.h
@@ -171,6 +171,10 @@
 #ifndef MODULE_MQ
   #define MODULE_MQ 0
 #endif
+// Enable this module to use one of the following sensors: SENSOR_MHZ19
+#ifndef MODULE_MHZ19
+  #define MODULE_MHZ19 0
+#endif
 
 /***********************************
    Supported Sensors
@@ -260,6 +264,10 @@ enum supported_sensors {
     // MQ2 air quality sensor
     SENSOR_MQ,
   #endif
+  #if MODULE_MHZ19 == 1
+    // MH-Z19 CO2 sensor
+    SENSOR_MHZ19,
+  #endif
 };
 /***********************************
   Libraries
@@ -316,6 +324,9 @@ enum supported_sensors {
 #if MODULE_MCP9808 == 1
   #include <Wire.h>
   #include "Adafruit_MCP9808.h"
+#endif
+#if MODULE_MHZ19 == 1
+  #include <SoftwareSerial.h>
 #endif
 
 /*******************************************************************
@@ -1119,6 +1130,30 @@ class SensorMQ: public Sensor {
     int _target_gas = _gas_co;
 };
 #endif
+
+/*
+   SensorMHZ19
+*/
+#if MODULE_MHZ19 == 1
+class SensorMHZ19: public Sensor {
+  public:
+    SensorMHZ19(NodeManager* node_manager, int child_id, int pin);
+    // set the pins for RX and TX of the SoftwareSerial (default: Rx=6, Tx=7)
+    void setRxTx(int rxpin, int txpin);
+    // define what to do at each stage of the sketch
+    void onBefore();
+    void onSetup();
+    void onLoop();
+    void onReceive(const MyMessage & message);
+    void onProcess(Request & request);
+    int readCO2();
+  protected:
+    SoftwareSerial* _ser;
+    int _tx_pin = 6;
+    int _rx_pin = 7;
+};
+#endif
+
 
 /***************************************
    NodeManager: manages all the aspects of the node

--- a/README.md
+++ b/README.md
@@ -173,6 +173,8 @@ Those NodeManager's directives in the `config.h` file control which module/libra
 #define MODULE_MCP9808 0
 // Enable this module to use one of the following sensors: SENSOR_MQ
 #define MODULE_MQ 0
+// Enable this module to use one of the following sensors: SENSOR_MHZ19
+#define MODULE_MHZ19 0
 ~~~
 
 ### Installing the dependencies
@@ -333,6 +335,7 @@ SENSOR_MCP9808 | MCP9808 sensor, measure the temperature through the attached mo
 SENSOR_RAIN_GAUGE | Rain gauge sensor
 SENSOR_RAIN | Rain sensor, return the percentage of rain from an attached analog sensor
 SENSOR_SOIL_MOISTURE | Soil moisture sensor, return the percentage of moisture from an attached analog sensor
+SENSOR_MHZ19 | MH-Z19 CO2 sensor via UART (SoftwareSerial, default on pins 6(Rx) and 7(Tx)
 
 To register a sensor simply call the NodeManager instance with the sensory type and the pin the sensor is conncted to. For example:
 ~~~c
@@ -583,6 +586,12 @@ Each sensor class can expose additional methods.
     void setRelayPin(int value);
     // [103] set the led's pin (default: 13)
     void setLedPin(int value);
+~~~
+
+* SensorMHZ19
+~~~c
+    // set the RX and TX pins for the software serial port to talk to the sensor
+    void setRxTx(int rxpin, int txpin);
 ~~~
 
 ### Upload your sketch

--- a/config.h
+++ b/config.h
@@ -132,5 +132,7 @@
 #define MODULE_MCP9808 0
 // Enable this module to use one of the following sensors: SENSOR_MQ
 #define MODULE_MQ 0
+// Enable this module to use one of the following sensors: SENSOR_MHZ19
+#define MODULE_MHZ19 0
 #endif
 


### PR DESCRIPTION
The MH-Z19 is a nice CO2 sensor, with MySensors code already being available at 
https://github.com/mysensors/MySensorsArduinoExamples/blob/master/examples/MH-Z19%20CO2%20sensor

This pull request simply adds this sample code as a new sensor type to NodeManager.

The sensor provides three ways to access the CO2-level: 
  * PWM
  * Serial (UART)
  * Analog

This PR only uses the serial data, using a SoftwareSerial object to pins 6+7 by default (customizable).
