### PR TITLE
Fixed compiler warnings

### DIFF
--- a/NodeManager.cpp
+++ b/NodeManager.cpp
@@ -3203,7 +3203,7 @@ int NodeManager::registerSensor(Sensor* sensor) {
 void NodeManager::unRegisterSensor(int sensor_index) {
   if (sensor_index > MAX_SENSORS) return;
   // unlink the pointer to this sensor
-  _sensors[sensor_index] == 0;
+  if (_sensors[sensor_index] != 0) _sensors[sensor_index] == 0;
 }
 
 // return a sensor given its index

--- a/NodeManager.h
+++ b/NodeManager.h
@@ -548,7 +548,7 @@ class Sensor {
     int _child_id;
     int _presentation = S_CUSTOM;
     int _type = V_CUSTOM;
-    char* _description = "";
+    char* _description = (char *)"";
     int _samples = 1;
     int _samples_interval = 0;
     bool _track_last_value = false;
@@ -556,10 +556,10 @@ class Sensor {
     int _float_precision = 2;
     int _value_int = -1;
     float _value_float = -1;
-    char * _value_string = "";
+    char * _value_string = (char *)"";
     int _last_value_int = -1;
     float _last_value_float = -1;
-    char * _last_value_string = "";
+    char * _last_value_string = (char *)"";
     int _interrupt_pin = -1;
     #if POWER_MANAGER  == 1
       PowerManager _powerManager;


### PR DESCRIPTION
Fixes #155 
* deprecated conversion from string constant to 'char*' -> Added explicit cast (char *)""
* statement has no effect -> Added if statement
* control reaches end of non-void function -> final return statement already there