### PR TITLE
Reporting intervals and sleeping cycles review

### DIFF
--- a/NodeManager.cpp
+++ b/NodeManager.cpp
@@ -3316,10 +3316,15 @@ void NodeManager::loop() {
   for (int i = 1; i <= MAX_SENSORS; i++) {
     // skip not configured sensors
     if (_sensors[i] == 0) continue;
-    // if there was an interrupt for this sensor, call the sensor's interrupt()
-    if (_last_interrupt_pin != -1 && _sensors[i]->getInterruptPin() == _last_interrupt_pin) _sensors[i]->interrupt();
-    // call the sensor's loop()
-    _sensors[i]->loop(empty);
+    // if there was an interrupt for this sensor, call the sensor's interrupt() and loop()
+    if (_last_interrupt_pin != -1 && _sensors[i]->getInterruptPin() == _last_interrupt_pin) {
+      _sensors[i]->interrupt();
+      _sensors[i]->loop(empty);
+    }
+    // if this is just the time to report an updated measure call the sensor's loop() 
+    else if (_last_interrupt_pin == -1) {
+      _sensors[i]->loop(empty);
+    }
   }
   // reset the last interrupt pin
   _last_interrupt_pin = -1;
@@ -3694,7 +3699,7 @@ void NodeManager::_sleep() {
     }
     _last_interrupt_pin = pin_number;
     #if DEBUG == 1
-      Serial.print(F("WAKE P="));
+      Serial.print(F("INT P="));
       Serial.print(pin_number);
       Serial.print(F(", M="));
       Serial.println(interrupt_mode);

--- a/NodeManager.cpp
+++ b/NodeManager.cpp
@@ -86,7 +86,9 @@ void Timer::set(int target, int unit) {
   _last_millis = 0;
   // save the settings
   _target = target;
-  _unit = unit;
+  if (unit == MINUTES) _target = _target * 60;
+  else if (unit == HOURS) _target = _target * 60 *60;
+  else if (unit == DAYS) _target = _target * 60 * 60 *24;
   _is_running = false;
   _is_configured = true;
 }
@@ -3223,7 +3225,7 @@ void NodeManager::before() {
   #if BATTERY_MANAGER == 1 && !defined(MY_GATEWAY_ESP8266)
     // set analogReference to internal if measuring the battery through a pin
     if (! _battery_internal_vcc && _battery_pin > -1) analogReference(INTERNAL);
-    // if not configured report battery every 60 minutes
+    // if not already configured, report battery level every 60 minutes
     if (! _battery_report_timer.isConfigured()) _battery_report_timer.set(60,MINUTES);
     _battery_report_timer.start();
   #endif

--- a/NodeManager.cpp
+++ b/NodeManager.cpp
@@ -250,12 +250,6 @@ void Sensor::setSamplesInterval(int value) {
 void Sensor::setTrackLastValue(bool value) {
   _track_last_value = value;
 }
-void Sensor::setForceUpdate(int value) {
-  setForceUpdateCycles(value);
-}
-void Sensor::setForceUpdateCycles(int value) {
-  _force_update_timer->start(value,CYCLES);
-}
 void Sensor::setForceUpdateMinutes(int value) {
   _force_update_timer->start(value,MINUTES);
 }
@@ -293,11 +287,6 @@ float Sensor::getValueFloat() {
 }
 char* Sensor::getValueString() {
   return _last_value_string;
-}
-
-// After how many cycles the sensor will report back its measure (default: 1 cycle)
-void Sensor::setReportIntervalCycles(int value) {
-  _report_timer->start(value,CYCLES);
 }
 
 // After how many minutes the sensor will report back its measure (default: 1 cycle)
@@ -2827,9 +2816,6 @@ int NodeManager::getRetries() {
   }
   void NodeManager::setBatteryMax(float value) {
     _battery_max = value;
-  }
-  void NodeManager::setBatteryReportCycles(int value) {
-    _battery_report_timer.set(value,CYCLES);
   }
   void NodeManager::setBatteryReportMinutes(int value) {
     _battery_report_timer.set(value,MINUTES);

--- a/NodeManager.cpp
+++ b/NodeManager.cpp
@@ -3600,6 +3600,11 @@ void NodeManager::setReportIntervalMinutes(int value) {
   _report_interval_seconds = value*60;
 }
 
+// set the default interval in seconds all the sensors will report their measures
+void NodeManager::setReportIntervalSeconds(int value) {
+  _report_interval_seconds = value;
+}
+
 // handle an interrupt
 void NodeManager::_onInterrupt_1() {
   long now = millis();

--- a/NodeManager.cpp
+++ b/NodeManager.cpp
@@ -101,7 +101,7 @@ void Timer::update() {
     else if (sleep_unit == HOURS) sleep_time = sleep_time*3600;
     else if (sleep_unit == DAYS) sleep_time = sleep_time*86400;
     // update elapsed
-    _elapsed += sleep_time
+    _elapsed += sleep_time;
   } else {
     // use millis() to calculate the elapsed time in seconds
     _elapsed = (long)((millis() - _last_millis)/1000);
@@ -435,7 +435,6 @@ void Sensor::process(Request & request) {
     case 5: setSamples(request.getValueInt()); break;
     case 6: setSamplesInterval(request.getValueInt()); break;
     case 7: setTrackLastValue(request.getValueInt()); break;
-    case 8: setForceUpdateCycles(request.getValueInt()); break;
     case 9: setForceUpdateMinutes(request.getValueInt()); break;
     case 10: setValueType(request.getValueInt()); break;
     case 11: setFloatPrecision(request.getValueInt()); break;
@@ -444,7 +443,6 @@ void Sensor::process(Request & request) {
       case 13: powerOn(); break;
       case 14: powerOff(); break;
     #endif
-    case 15: setReportIntervalCycles(request.getValueInt()); break;
     case 16: setReportIntervalMinutes(request.getValueInt()); break;
     default: return;
   }
@@ -3297,8 +3295,6 @@ void NodeManager::setup() {
 // run the main function for all the register sensors
 void NodeManager::loop() {
   MyMessage empty;
-  // if in idle mode, do nothing
-  if (_sleep_mode == IDLE) return;
   // if sleep time is not set, do nothing
   if (isSleepingNode() &&  _sleep_time == 0) return;
   #if BATTERY_MANAGER == 1
@@ -3409,7 +3405,6 @@ void NodeManager::process(Request & request) {
       case 2: batteryReport(); return;
       case 11: setBatteryMin(request.getValueFloat()); break;
       case 12: setBatteryMax(request.getValueFloat()); break;
-      case 13: setBatteryReportCycles(request.getValueInt()); break;
       case 14: setBatteryReportMinutes(request.getValueInt()); break;
       case 15: setBatteryInternalVcc(request.getValueInt()); break;
       case 16: setBatteryPin(request.getValueInt()); break;
@@ -3522,7 +3517,7 @@ void NodeManager::wakeup() {
   #if DEBUG == 1
     Serial.println(F("WAKEUP"));
   #endif
-  _sleep_mode = IDLE;
+  _sleep_mode = AWAKE;
 }
 
 // return the value stored at the requested index from the EEPROM
@@ -3703,7 +3698,7 @@ void NodeManager::_sleep() {
         Serial.println(interrupt_mode);
       #endif
       // when waking up from an interrupt on the wakup pin, stop sleeping
-      if (_sleep_interrupt_pin == pin_number) _sleep_mode = IDLE;
+      if (_sleep_interrupt_pin == pin_number) _sleep_mode = AWAKE;
     }
   }
   // coming out of sleep

--- a/NodeManager.cpp
+++ b/NodeManager.cpp
@@ -1484,8 +1484,6 @@ SensorDoor::SensorDoor(NodeManager* node_manager, int child_id, int pin): Sensor
  */
 SensorMotion::SensorMotion(NodeManager* node_manager, int child_id, int pin): SensorSwitch(node_manager, child_id,pin) {
   setPresentation(S_MOTION);
-  // capture only when it triggers
-  setMode(RISING);
   // set initial value to LOW
   setInitial(LOW);
 }

--- a/NodeManager.cpp
+++ b/NodeManager.cpp
@@ -142,11 +142,6 @@ float Timer::getElapsed() {
   return _elapsed;
 }
 
-// return the configured unit
-int Timer::getUnit() {
-  return _unit;
-}
-
 
 /******************************************
     Request
@@ -3227,7 +3222,7 @@ void NodeManager::before() {
   #if BATTERY_MANAGER == 1 && !defined(MY_GATEWAY_ESP8266)
     // set analogReference to internal if measuring the battery through a pin
     if (! _battery_internal_vcc && _battery_pin > -1) analogReference(INTERNAL);
-    // if not configured report battery every 10 cycles
+    // if not configured report battery every 60 minutes
     if (! _battery_report_timer.isConfigured()) _battery_report_timer.set(60,MINUTES);
     _battery_report_timer.start();
   #endif
@@ -3299,8 +3294,7 @@ void NodeManager::loop() {
   if (isSleepingNode() &&  _sleep_time == 0) return;
   #if BATTERY_MANAGER == 1
     // update the timer for battery report
-    if (_battery_report_timer.getUnit() == MINUTES) _battery_report_timer.update();
-    if (_battery_report_timer.getUnit() == CYCLES && (_last_interrupt_pin == -1 || _battery_report_with_interrupt)) _battery_report_timer.update();
+    if (_battery_report_timer.isRunning()) _battery_report_timer.update();
     // if it is time to report the battery level
     if (_battery_report_timer.isOver()) {
       // time to report the battery level again
@@ -3590,6 +3584,11 @@ void NodeManager::setupInterrupts() {
 // return the pin from which the last interrupt came
 int NodeManager::getLastInterruptPin() {
   return _last_interrupt_pin;
+}
+
+// set the default interval in minutes all the sensors will report their measures
+void NodeManager::setReportIntervalMinutes(int value) {
+  _report_interval = value*60;
 }
 
 // handle an interrupt

--- a/NodeManager.cpp
+++ b/NodeManager.cpp
@@ -247,6 +247,9 @@ void Sensor::setTrackLastValue(bool value) {
 void Sensor::setForceUpdateMinutes(int value) {
   _force_update_timer->start(value,MINUTES);
 }
+void Sensor::setForceUpdateHours(int value) {
+  _force_update_timer->start(value,HOURS);
+}
 void Sensor::setValueType(int value) {
   _value_type = value;
 }
@@ -449,6 +452,7 @@ void Sensor::process(Request & request) {
     #endif
     case 16: setReportIntervalMinutes(request.getValueInt()); break;
     case 17: setReportIntervalSeconds(request.getValueInt()); break;
+    case 18: setForceUpdateHours(request.getValueInt()); break;
     default: return;
   }
   _send(_msg_service.set(function));

--- a/NodeManager.h
+++ b/NodeManager.h
@@ -409,13 +409,13 @@ class PowerManager {
 class Timer {
   public:
     Timer(NodeManager* node_manager);
-    // start the timer which will be over when interval passes by. Unit can be either CYCLES or MINUTES
-    void start(long target, int unit);
+    // start the timer which will be over when the configured target passes by
+    void start(int target, int unit);
     void start();
     // stop the timer
     void stop();
     // set the timer configuration but do not start it
-    void set(long target, int unit);
+    void set(int target, int unit);
     // update the timer. To be called at every cycle
     void update();
     // returns true if the time is over
@@ -434,12 +434,10 @@ class Timer {
     int getTarget();
    private:
     NodeManager* _node_manager;
-    long _target = 0;
+    int _target = 0;
     int _unit = 0;
-    float _elapsed = 0;
-    bool _use_millis = false;
+    long _elapsed = 0;
     long _last_millis = 0;
-    float _sleep_time = 0;
     bool _is_running = false;
     bool _is_configured = false;
 };

--- a/NodeManager.h
+++ b/NodeManager.h
@@ -14,10 +14,9 @@
 */
 
 // define sleep mode
-#define IDLE 0
+#define NO_SLEEP 0
 #define SLEEP 1
 #define WAIT 2
-#define ALWAYS_ON 3
 
 // define time unit
 #define SECONDS 0

--- a/NodeManager.h
+++ b/NodeManager.h
@@ -14,7 +14,7 @@
 */
 
 // define sleep mode
-#define NO_SLEEP 0
+#define AWAKE 0
 #define SLEEP 1
 #define WAIT 2
 
@@ -1448,7 +1448,7 @@ class NodeManager {
     #endif
     MyMessage _msg;
     void _send(MyMessage & msg);
-    int _sleep_mode = IDLE;
+    int _sleep_mode = AWAKE;
     int _sleep_time = 0;
     int _sleep_unit = MINUTES;
     int _sleep_interrupt_pin = -1;

--- a/NodeManager.h
+++ b/NodeManager.h
@@ -22,7 +22,6 @@
 #define MINUTES 1
 #define HOURS 2
 #define DAYS 3
-#define CYCLES 4
 
 // define on/off
 #define OFF 0
@@ -426,7 +425,6 @@ class Timer {
    private:
     NodeManager* _node_manager;
     int _target = 0;
-    int _unit = 0;
     long _elapsed = 0;
     long _last_millis = 0;
     bool _is_running = false;

--- a/NodeManager.h
+++ b/NodeManager.h
@@ -406,22 +406,25 @@ class Timer {
     void start();
     // stop the timer
     void stop();
+    // reset the timer
+    void reset();
+    // reset the timer and start over
+    void restart();
     // set the timer configuration but do not start it
     void set(int target, int unit);
+    void unset();
     // update the timer. To be called at every cycle
     void update();
-    // returns true if the time is over
+    // return true if the time is over
     bool isOver();
     // return true if the timer is running
     bool isRunning();
-    // returns true if the timer has been configured
+    // return true if the timer has been configured
     bool isConfigured();
-    // reset the timer and start over
-    void restart();
+    // return true if this is the first time the timer runs
+    bool isFirstRun();
     // return the current elapsed time
     float getElapsed();
-    // return the configured target
-    int getTarget();
    private:
     NodeManager* _node_manager;
     int _target = 0;
@@ -429,6 +432,7 @@ class Timer {
     long _last_millis = 0;
     bool _is_running = false;
     bool _is_configured = false;
+    bool _first_run = true;
 };
 
 /*

--- a/NodeManager.h
+++ b/NodeManager.h
@@ -489,9 +489,6 @@ class Sensor {
     void setSamplesInterval(int value);
     // [7] if true will report the measure only if different than the previous one (default: false)
     void setTrackLastValue(bool value);
-    // [8] if track last value is enabled, force to send an update after the configured number of cycles (default: -1)
-    void setForceUpdate(int value);
-    void setForceUpdateCycles(int value);
     // [9] if track last value is enabled, force to send an update after the configured number of minutes (default: -1)
     void setForceUpdateMinutes(int value);
     // [10] the value type of this sensor (default: TYPE_INTEGER)
@@ -513,9 +510,7 @@ class Sensor {
     int getValueInt();
     float getValueFloat();
     char* getValueString();
-    // [15] After how many cycles the sensor will report back its measure (default: 1 cycle)
-    void setReportIntervalCycles(int value);
-    // [16] After how many minutes the sensor will report back its measure (default: 1 cycle)
+    // [16] After how many minutes the sensor will report back its measure (default: 10 minutes)
     void setReportIntervalMinutes(int value);
     // process a remote request
     void process(Request & request);
@@ -1335,8 +1330,6 @@ class NodeManager {
       void setBatteryMin(float value);
       // [12] the expected vcc when the batter is fully charged, used to calculate the percentage (default: 3.3)
       void setBatteryMax(float value);
-      // [13] after how many sleeping cycles report the battery level to the controller. When reset the battery is always reported (default: -)
-      void setBatteryReportCycles(int value);
       // [14] after how many minutes report the battery level to the controller. When reset the battery is always reported (default: 60)
       void setBatteryReportMinutes(int value);
       // [15] if true, the battery level will be evaluated by measuring the internal vcc without the need to connect any pin, if false the voltage divider methon will be used (default: true)

--- a/NodeManager.h
+++ b/NodeManager.h
@@ -478,8 +478,10 @@ class Sensor {
     void setSamplesInterval(int value);
     // [7] if true will report the measure only if different than the previous one (default: false)
     void setTrackLastValue(bool value);
-    // [9] if track last value is enabled, force to send an update after the configured number of minutes (default: -1)
+    // [9] if track last value is enabled, force to send an update after the configured number of minutes
     void setForceUpdateMinutes(int value);
+    // [19] if track last value is enabled, force to send an update after the configured number of hours
+    void setForceUpdateHours(int value);
     // [10] the value type of this sensor (default: TYPE_INTEGER)
     void setValueType(int value);
     int getValueType();

--- a/NodeManager.h
+++ b/NodeManager.h
@@ -428,8 +428,6 @@ class Timer {
     void restart();
     // return the current elapsed time
     float getElapsed();
-    // return the configured unit
-    int getUnit();
     // return the configured target
     int getTarget();
    private:
@@ -1421,6 +1419,10 @@ class NodeManager {
     void setupInterrupts();
     // return the pin from which the last interrupt came
     int getLastInterruptPin();
+    // set the default interval in minutes all the sensors will report their measures. 
+    // If the same function is called on a specific sensor, this will not change the previously set value 
+    // For sleeping sensors, the elapsed time can be evaluated only upon wake up (default: 10)
+    void setReportIntervalMinutes(int value);
     // hook into the main sketch functions
     void before();
     void presentation();
@@ -1471,6 +1473,7 @@ class NodeManager {
     int _getInterruptInitialValue(int mode);
     bool _get_controller_config = true;
     int _is_metric = 1;
+    int _report_interval = 10*60;
     void _loadConfig();
     void _saveConfig(int what);
 };

--- a/NodeManager.h
+++ b/NodeManager.h
@@ -13,10 +13,9 @@
    Constants
 */
 
-// define sleep mode
+// define board status
 #define AWAKE 0
 #define SLEEP 1
-#define WAIT 2
 
 // define time unit
 #define SECONDS 0
@@ -38,17 +37,11 @@
 #define INTERRUPT_PIN_1 3
 #define INTERRUPT_PIN_2 2
 
-// define configuration settings that can be saved and loaded from the EEPROM
-#define SAVE_SLEEP_MODE 0
-#define SAVE_SLEEP_TIME 1
-#define SAVE_SLEEP_UNIT 2
-
 // define eeprom addresses
 #define EEPROM_SLEEP_SAVED 0
-#define EEPROM_SLEEP_MODE 1
-#define EEPROM_SLEEP_TIME_MAJOR 2
-#define EEPROM_SLEEP_TIME_MINOR 3
-#define EEPROM_SLEEP_UNIT 4
+#define EEPROM_SLEEP_1 5
+#define EEPROM_SLEEP_2 6
+#define EEPROM_SLEEP_3 7
 #define EEPROM_USER_START 100
 
 // define requests
@@ -510,6 +503,10 @@ class Sensor {
     char* getValueString();
     // [16] After how many minutes the sensor will report back its measure (default: 10 minutes)
     void setReportIntervalMinutes(int value);
+    // [17] After how many minutes the sensor will report back its measure (default: 10 minutes)
+    void setReportIntervalSeconds(int value);
+    // return true if the report interval has been already configured
+    bool isReportIntervalConfigured();
     // process a remote request
     void process(Request & request);
     // return the pin the interrupt is attached to
@@ -1341,18 +1338,15 @@ class NodeManager {
       // [2] Send a battery level report to the controller
       void batteryReport();
     #endif
-    // [3] define the way the node should behave. It can be (0) IDLE (stay awake withtout executing each sensors' loop), (1) SLEEP (go to sleep for the configured interval), (2) WAIT (wait for the configured interval), (3) ALWAYS_ON (stay awake and execute each sensors' loop)
-    void setSleepMode(int value);
-    void setMode(int value);
-    int getMode();
-    // [4] define for how long the board will sleep (default: 0)
-    void setSleepTime(int value);
-    int getSleepTime();
-    // [5] define the unit of SLEEP_TIME. It can be SECONDS, MINUTES, HOURS or DAYS (default: MINUTES)
-    void setSleepUnit(int value);
-    int getSleepUnit();
-    // configure the node's behavior, parameters are mode, time and unit
-    void setSleep(int value1, int value2, int value3);
+    // [3] set the duration (in seconds) of a sleep cycle
+    void setSleepSeconds(int value);
+    long getSleepSeconds();
+    // [4] set the duration (in minutes) of a sleep cycle
+    void setSleepMinutes(int value);
+    // [5] set the duration (in hours) of a sleep cycle
+    void setSleepHours(int value);
+    // [29] set the duration (in days) of a sleep cycle
+    void setSleepDays(int value);
     // [19] if enabled, when waking up from the interrupt, the board stops sleeping. Disable it when attaching e.g. a motion sensor (default: true)
     void setSleepInterruptPin(int value);
     // configure the interrupt pin and mode. Mode can be CHANGE, RISING, FALLING (default: MODE_NOT_DEFINED)
@@ -1450,9 +1444,8 @@ class NodeManager {
     #endif
     MyMessage _msg;
     void _send(MyMessage & msg);
-    int _sleep_mode = AWAKE;
-    int _sleep_time = 0;
-    int _sleep_unit = MINUTES;
+    int _status = AWAKE;
+    long _sleep_time = 0;
     int _sleep_interrupt_pin = -1;
     int _sleep_between_send = 0;
     int _retries = 1;
@@ -1473,9 +1466,9 @@ class NodeManager {
     int _getInterruptInitialValue(int mode);
     bool _get_controller_config = true;
     int _is_metric = 1;
-    int _report_interval = 10*60;
+    int _report_interval_seconds = 10*60;
     void _loadConfig();
-    void _saveConfig(int what);
+    void _saveConfig();
 };
 
 #endif

--- a/NodeManager.h
+++ b/NodeManager.h
@@ -1415,8 +1415,9 @@ class NodeManager {
     int getLastInterruptPin();
     // set the default interval in minutes all the sensors will report their measures. 
     // If the same function is called on a specific sensor, this will not change the previously set value 
-    // For sleeping sensors, the elapsed time can be evaluated only upon wake up (default: 10)
+    // For sleeping sensors, the elapsed time can be evaluated only upon wake up (default: 10 minutes)
     void setReportIntervalMinutes(int value);
+    void setReportIntervalSeconds(int value);
     // hook into the main sketch functions
     void before();
     void presentation();

--- a/NodeManager.ino
+++ b/NodeManager.ino
@@ -36,9 +36,16 @@ void before() {
   digitalWrite(4, LOW);
   pinMode(5, OUTPUT);
   digitalWrite(5, HIGH);
-  nodeManager.registerSensor(SENSOR_DHT22,6);
-  nodeManager.setReportIntervalSeconds(20);
-  nodeManager.setBatteryReportMinutes(1);
+    pinMode(7, OUTPUT);
+  digitalWrite(7, LOW);
+  pinMode(8, OUTPUT);
+  digitalWrite(8, HIGH);
+  int s = nodeManager.registerSensor(SENSOR_DHT22,6);
+  nodeManager.registerSensor(SENSOR_MOTION,3);
+  SensorDHT* dh = (SensorDHT*)nodeManager.get(s);
+  nodeManager.setReportIntervalMinutes(2);
+  nodeManager.setBatteryReportMinutes(3);
+  nodeManager.setSleepMinutes(1);
 
 
   /*

--- a/NodeManager.ino
+++ b/NodeManager.ino
@@ -32,19 +32,8 @@ void before() {
   /*
    * Register below your sensors
   */
-  pinMode(4, OUTPUT);
-  digitalWrite(4, LOW);
-  pinMode(5, OUTPUT);
-  digitalWrite(5, HIGH);
-    pinMode(7, OUTPUT);
-  digitalWrite(7, LOW);
-  pinMode(8, OUTPUT);
-  digitalWrite(8, HIGH);
-  nodeManager.registerSensor(SENSOR_THERMISTOR,A0);
-  nodeManager.registerSensor(SENSOR_MOTION,3);
-  nodeManager.setReportIntervalSeconds(20);
-  //nodeManager.setBatteryReportMinutes(1);
-  //nodeManager.setSleepSeconds(20);
+
+
 
 
   /*

--- a/NodeManager.ino
+++ b/NodeManager.ino
@@ -32,7 +32,13 @@ void before() {
   /*
    * Register below your sensors
   */
-
+  pinMode(4, OUTPUT);
+  digitalWrite(4, LOW);
+  pinMode(5, OUTPUT);
+  digitalWrite(5, HIGH);
+  nodeManager.registerSensor(SENSOR_DHT22,6);
+  nodeManager.setReportIntervalSeconds(20);
+  nodeManager.setBatteryReportMinutes(1);
 
 
   /*

--- a/NodeManager.ino
+++ b/NodeManager.ino
@@ -40,12 +40,11 @@ void before() {
   digitalWrite(7, LOW);
   pinMode(8, OUTPUT);
   digitalWrite(8, HIGH);
-  int s = nodeManager.registerSensor(SENSOR_DHT22,6);
+  nodeManager.registerSensor(SENSOR_THERMISTOR,A0);
   nodeManager.registerSensor(SENSOR_MOTION,3);
-  SensorDHT* dh = (SensorDHT*)nodeManager.get(s);
-  nodeManager.setReportIntervalMinutes(2);
-  nodeManager.setBatteryReportMinutes(3);
-  nodeManager.setSleepMinutes(1);
+  nodeManager.setReportIntervalSeconds(20);
+  //nodeManager.setBatteryReportMinutes(1);
+  //nodeManager.setSleepSeconds(20);
 
 
   /*

--- a/README.md
+++ b/README.md
@@ -219,8 +219,6 @@ Node Manager comes with a reasonable default configuration. If you want/need to 
       void setBatteryMin(float value);
       // [12] the expected vcc when the batter is fully charged, used to calculate the percentage (default: 3.3)
       void setBatteryMax(float value);
-      // [13] after how many sleeping cycles report the battery level to the controller. When reset the battery is always reported (default: -)
-      void setBatteryReportCycles(int value);
       // [14] after how many minutes report the battery level to the controller. When reset the battery is always reported (default: 60)
       void setBatteryReportMinutes(int value);
       // [15] if true, the battery level will be evaluated by measuring the internal vcc without the need to connect any pin, if false the voltage divider methon will be used (default: true)
@@ -424,9 +422,6 @@ The following methods are available for all the sensors:
     void setSamplesInterval(int value);
     // [7] if true will report the measure only if different than the previous one (default: false)
     void setTrackLastValue(bool value);
-    // [8] if track last value is enabled, force to send an update after the configured number of cycles (default: -1)
-    void setForceUpdate(int value);
-    void setForceUpdateCycles(int value);
     // [9] if track last value is enabled, force to send an update after the configured number of minutes (default: -1)
     void setForceUpdateMinutes(int value);
     // [10] the value type of this sensor (default: TYPE_INTEGER)
@@ -448,8 +443,6 @@ The following methods are available for all the sensors:
     int getValueInt();
     float getValueFloat();
     char* getValueString();
-    // [15] After how many cycles the sensor will report back its measure (default: 1 cycle)
-    void setReportIntervalCycles(int value);
     // [16] After how many minutes the sensor will report back its measure (default: 1 cycle)
     void setReportIntervalMinutes(int value);
     // process a remote request

--- a/README.md
+++ b/README.md
@@ -449,6 +449,8 @@ The following methods are available for all the sensors:
     char* getValueString();
     // [16] After how many minutes the sensor will report back its measure (default: 1 cycle)
     void setReportIntervalMinutes(int value);
+    // return true if the report interval has been already configured
+    bool isReportIntervalConfigured();
     // process a remote request
     void process(Request & request);
     // return the pin the interrupt is attached to

--- a/README.md
+++ b/README.md
@@ -308,6 +308,10 @@ Node Manager comes with a reasonable default configuration. If you want/need to 
     void setupInterrupts();
     // return the pin from which the last interrupt came
     int getLastInterruptPin();
+    // set the default interval in minutes all the sensors will report their measures. 
+    // If the same function is called on a specific sensor, this will not change the previously set value 
+    // For sleeping sensors, the elapsed time can be evaluated only upon wake up (default: 10)
+    void setReportIntervalMinutes(int value);
 ~~~
 
 For example

--- a/README.md
+++ b/README.md
@@ -450,8 +450,10 @@ The following methods are available for all the sensors and can be called on the
     void setSamplesInterval(int value);
     // [7] if true will report the measure only if different than the previous one (default: false)
     void setTrackLastValue(bool value);
-    // [9] if track last value is enabled, force to send an update after the configured number of minutes (default: -1)
+    // [9] if track last value is enabled, force to send an update after the configured number of minutes
     void setForceUpdateMinutes(int value);
+    // [19] if track last value is enabled, force to send an update after the configured number of hours
+    void setForceUpdateHours(int value);
     // [10] the value type of this sensor (default: TYPE_INTEGER)
     void setValueType(int value);
     int getValueType();

--- a/README.md
+++ b/README.md
@@ -232,22 +232,21 @@ Node Manager comes with a reasonable default configuration. If you want/need to 
       // [2] Send a battery level report to the controller
       void batteryReport();
     #endif
-    // [3] define the way the node should behave. It can be (0) IDLE (stay awake withtout executing each sensors' loop), (1) SLEEP (go to sleep for the configured interval), (2) WAIT (wait for the configured interval), (3) ALWAYS_ON (stay awake and execute each sensors' loop)
-    void setSleepMode(int value);
-    void setMode(int value);
-    int getMode();
-    // [4] define for how long the board will sleep (default: 0)
-    void setSleepTime(int value);
-    int getSleepTime();
-    // [5] define the unit of SLEEP_TIME. It can be SECONDS, MINUTES, HOURS or DAYS (default: MINUTES)
-    void setSleepUnit(int value);
-    int getSleepUnit();
-    // configure the node's behavior, parameters are mode, time and unit
-    void setSleep(int value1, int value2, int value3);
+    // [3] set the duration (in seconds) of a sleep cycle
+    void setSleepSeconds(int value);
+    long getSleepSeconds();
+    // [4] set the duration (in minutes) of a sleep cycle
+    void setSleepMinutes(int value);
+    // [5] set the duration (in hours) of a sleep cycle
+    void setSleepHours(int value);
+    // [29] set the duration (in days) of a sleep cycle
+    void setSleepDays(int value);
     // [19] if enabled, when waking up from the interrupt, the board stops sleeping. Disable it when attaching e.g. a motion sensor (default: true)
     void setSleepInterruptPin(int value);
     // configure the interrupt pin and mode. Mode can be CHANGE, RISING, FALLING (default: MODE_NOT_DEFINED)
-    void setInterrupt(int pin, int mode, int pull = -1);
+    void setInterrupt(int pin, int mode, int initial = -1);
+    // [28] ignore two consecutive interrupts if happening within this timeframe in milliseconds (default: 100)
+    void setInterruptMinDelta(long value);
     // [20] optionally sleep interval in milliseconds before sending each message to the radio network (default: 0)
     void setSleepBetweenSend(int value);
     int getSleepBetweenSend();
@@ -270,7 +269,7 @@ Node Manager comes with a reasonable default configuration. If you want/need to 
       // [24] manually turn the power on
       void powerOn();
       // [25] manually turn the power off
-      void powerOff(); 
+      void powerOff();
     #endif
     // [21] set this to true if you want destination node to send ack back to this node (default: false)
     void setAck(bool value);
@@ -310,8 +309,9 @@ Node Manager comes with a reasonable default configuration. If you want/need to 
     int getLastInterruptPin();
     // set the default interval in minutes all the sensors will report their measures. 
     // If the same function is called on a specific sensor, this will not change the previously set value 
-    // For sleeping sensors, the elapsed time can be evaluated only upon wake up (default: 10)
+    // For sleeping sensors, the elapsed time can be evaluated only upon wake up (default: 10 minutes)
     void setReportIntervalMinutes(int value);
+    void setReportIntervalSeconds(int value);
 ~~~
 
 For example
@@ -447,8 +447,10 @@ The following methods are available for all the sensors:
     int getValueInt();
     float getValueFloat();
     char* getValueString();
-    // [16] After how many minutes the sensor will report back its measure (default: 1 cycle)
+    // [16] After how many minutes the sensor will report back its measure (default: 10 minutes)
     void setReportIntervalMinutes(int value);
+    // [17] After how many minutes the sensor will report back its measure (default: 10 minutes)
+    void setReportIntervalSeconds(int value);
     // return true if the report interval has been already configured
     bool isReportIntervalConfigured();
     // process a remote request

--- a/README.md
+++ b/README.md
@@ -11,19 +11,19 @@ NodeManager includes the following main components:
 ## Features
 
 * Manage all the aspects of a sleeping cycle by leveraging smart sleep
-* Allow configuring the sleep mode and the sleep duration remotely
+* Allow configuring the node and any attached sensors remotely
 * Allow waking up a sleeping node remotely at the end of a sleeping cycle
 * Allow powering on each connected sensor only while the node is awake to save battery
-* Report battery level periodically and automatically
+* Report battery level periodically and automatically or on demand
 * Calculate battery level without requiring an additional pin and the resistors
-* Report battery voltage through a built-in sensor
-* Can report battery level on demand
 * Allow rebooting the board remotely
 * Provide out-of-the-box sensors personalities and automatically execute their main task at each cycle
+* Allow collecting and averaging multiple samples, tracking the last value and forcing periodic updates for any sensor
+* Provide buil-in capabilities to handle interrupt-based sensors 
 
 ## Installation
-* Download the package or clone the git repository at https://github.com/mysensors/NodeManager
-* Open the provided sketch template and save it under a different name
+* Download the package or clone the git repository from https://github.com/mysensors/NodeManager
+* Open the provided sketch and save it under a different name
 * Open `config.h` and customize both MySensors configuration and NodeManager global settings
 * Register your sensors in the sketch file
 * Upload the sketch to your arduino board
@@ -36,7 +36,7 @@ Please note NodeManager cannot be used as an arduino library since requires acce
 * Review the release notes in case there is any manual change required to the existing sketch or config.h file
 
 ## Configuration
-NodeManager configuration includes compile-time configuration directives (which can be set in config.h), runtime global and per-sensor configuration settings (which can be set in your sketch) and settings that can be customized remotely (via a special child id).
+NodeManager configuration includes compile-time configuration directives (which can be set in config.h), runtime global and per-sensor configuration settings (which can be set in your sketch).
 
 ### Setup MySensors
 Since NodeManager has to communicate with the MySensors gateway on your behalf, it has to know how to do it. Place on top of the `config.h` file all the MySensors typical directives you are used to set on top of your sketch so both your sketch AND NodeManager will be able to share the same configuration. For example:
@@ -123,38 +123,41 @@ Since NodeManager has to communicate with the MySensors gateway on your behalf, 
 
 ### Enable/Disable NodeManager's modules
 
-Those NodeManager's directives in the `config.h` file control which module/library/functionality will be made available to your sketch. Enable (e.g. set to 1) only what you need to ensure enough space is left to your custom code.
+The next step is to enable NodeManager's additional functionalities and the modules required for your sensors. The directives in the `config.h` file control which module/library/functionality will be made available to your sketch. Enable (e.g. set to 1) only what you need to ensure enough storage is left to your custom code.
 
 ~~~c
+/***********************************
+ * NodeManager configuration
+ */
+
 // if enabled, enable debug messages on serial port
 #define DEBUG 1
 
 // if enabled, enable the capability to power on sensors with the arduino's pins to save battery while sleeping
-#define POWER_MANAGER 1
+#define POWER_MANAGER 0
 // if enabled, will load the battery manager library to allow the battery level to be reported automatically or on demand
-#define BATTERY_MANAGER 1
+#define BATTERY_MANAGER 0
 // if enabled, allow modifying the configuration remotely by interacting with the configuration child id
-#define REMOTE_CONFIGURATION 1
-// if enabled, persist the configuration settings on EEPROM
+#define REMOTE_CONFIGURATION 0
+// if enabled, persist the remote configuration settings on EEPROM
 #define PERSIST 0
-
+// if enabled, a battery sensor will be created at BATTERY_CHILD_ID and will report vcc voltage together with the battery level percentage
+#define BATTERY_SENSOR 0
 // if enabled, send a SLEEPING and AWAKE service messages just before entering and just after leaving a sleep cycle and STARTED when starting/rebooting
 #define SERVICE_MESSAGES 0
-// if enabled, a battery sensor will be created at BATTERY_CHILD_ID and will report vcc voltage together with the battery level percentage
-#define BATTERY_SENSOR 1
 
 // Enable this module to use one of the following sensors: SENSOR_ANALOG_INPUT, SENSOR_LDR, SENSOR_THERMISTOR, SENSOR_ML8511, SENSOR_ACS712, SENSOR_RAIN_GAUGE, SENSOR_RAIN, SENSOR_SOIL_MOISTURE
 #define MODULE_ANALOG_INPUT 1
 // Enable this module to use one of the following sensors: SENSOR_DIGITAL_INPUT
-#define MODULE_DIGITAL_INPUT 1
+#define MODULE_DIGITAL_INPUT 0
 // Enable this module to use one of the following sensors: SENSOR_DIGITAL_OUTPUT, SENSOR_RELAY, SENSOR_LATCHING_RELAY
-#define MODULE_DIGITAL_OUTPUT 1
-// Enable this module to use one of the following sensors: SENSOR_SHT21
-#define MODULE_SHT21 0
+#define MODULE_DIGITAL_OUTPUT 0
 // Enable this module to use one of the following sensors: SENSOR_DHT11, SENSOR_DHT22, SENSOR_DHT21
 #define MODULE_DHT 0
+// Enable this module to use one of the following sensors: SENSOR_SHT21
+#define MODULE_SHT21 0
 // Enable this module to use one of the following sensors: SENSOR_SWITCH, SENSOR_DOOR, SENSOR_MOTION
-#define MODULE_SWITCH 0
+#define MODULE_SWITCH 1
 // Enable this module to use one of the following sensors: SENSOR_DS18B20
 #define MODULE_DS18B20 0
 // Enable this module to use one of the following sensors: SENSOR_BH1750
@@ -175,9 +178,9 @@ Those NodeManager's directives in the `config.h` file control which module/libra
 #define MODULE_MQ 0
 // Enable this module to use one of the following sensors: SENSOR_MHZ19
 #define MODULE_MHZ19 0
-// Enable this module to use one of the following sensors: SENSOR_AM2320
+// Enable this module to use one of the following sensors: SENSOR_AM2320    
 #define MODULE_AM2320 0
-// Enable this module to use one of the following sensors: SENSOR_TSL2561
+// Enable this module to use one of the following sensors: SENSOR_TSL2561    
 #define MODULE_TSL2561 0
 // Enable this module to use one of the following sensors: SENSOR_PT100
 #define MODULE_PT100 0
@@ -188,7 +191,7 @@ Those NodeManager's directives in the `config.h` file control which module/libra
 
 ### Installing the dependencies
 
-Some of the modules above rely on third party libraries. Those libraries are not included within NodeManager and have to be installed from the Arduino IDE Library Manager (Sketch -> Include Library -> Manager Libraries). You need to install the library ONLY if the module is enabled:
+Some of the modules above rely on third party libraries. Those libraries are not included within NodeManager and have to be installed from the Arduino IDE Library Manager (Sketch -> Include Library -> Manager Libraries) or manually. You need to install the library ONLY if the module is enabled:
 
 Module  | Required Library
  ------------- | -------------
@@ -208,7 +211,7 @@ MODULE_BMP280 | https://github.com/adafruit/Adafruit_BMP280_Library
 
 ### Configure NodeManager
 
-Node Manager comes with a reasonable default configuration. If you want/need to change its settings, this can be done in your sketch, inside the `before()` function and just before registering your sensors. The following methods are exposed for your convenience:
+The next step is to configure NodeManager with settings which will instruct how the node should behave. To do so, go to the main sketch, inside the `before()` function and add call one or more of the functions below just before registering your sensors. The following methods are exposed for your convenience and can be called on the `nodeManager` object already created for you:
 
 ~~~c
     // [10] send the same service message multiple times (default: 1)
@@ -314,14 +317,34 @@ Node Manager comes with a reasonable default configuration. If you want/need to 
     void setReportIntervalSeconds(int value);
 ~~~
 
-For example
+### Set reporting intervals and sleeping cycles
+
+If not instructed differently, the node will stay in awake, all the sensors will report every 10 minutes and the battery level will be automatically reported every 60 minutes. To change those settings, you can call the following functions on the nodeManager object:
+
+Function  | Description
+------------ | -------------
+setSleepSeconds()/setSleepMinutes()/setSleepHours()/setSleepDays() | the time interval the node will spend in a (smart) sleep cycle
+setReportIntervalMinutes() / setReportIntervalSeconds() | the time interval the node will report the measures of all the attached sensors
+setBatteryReportMinutes() | the time interval the node will report the battery level
+
+For example, to put the node to sleep in cycles of 10 minutes:
 
 ~~~c
-	nodeManager.setBatteryMin(1.8);
+	nodeManager.setSleepMinutes(10);
 ~~~
 
+If you need every sensor to report at a different time interval, you can call `setReportIntervalMinutes()` or `setReportIntervalSeconds()` on the sensor's object. For example to have a DHT sensor reporting every 60 seconds while all the other sensors every 20 minutes:
+~~~c
+int id = nodeManager.registerSensor(SENSOR_DHT22,6);
+SensorDHT* dht = (SensorDHT*)nodeManager.get(id);
+dht->setReportIntervalSeconds(60);
+nodeManager.setReportIntervalMinutes(20);
+~~~
+
+Please note, if you configure a sleep cycle, this may have an impact on the reporting interval since the sensor will be able to report its measures ONLY when awake. For example if you set a report interval of 5 minutes and a sleep cycle of 10 minutes, the sensors will report every 10 minutes.
+
 ### Register your sensors
-In your sketch, inside the `before()` function and just before calling `nodeManager.before()`, you can register your sensors against NodeManager. The following built-in sensor types are available:
+Once configured the node, it is time to tell NodeManager which sensors are attached to the board and where. In your sketch, inside the `before()` function and just before calling `nodeManager.before()`, you can register your sensors against NodeManager. The following built-in sensor types are available. Remember the corresponding module should be enabled in `config.h` for a successful compilation: 
 
 Sensor type  | Description
  ------------- | -------------
@@ -359,15 +382,15 @@ SENSOR_AM2320 | AM2320 sensors, return temperature/humidity based on the attache
 SENSOR_PT100 | High temperature sensor associated with DFRobot Driver, return the temperature in C° from the attached PT100 sensor
 SENSOR_BMP280 | BMP280 sensor, return temperature/pressure based on the attached BMP280 sensor
 
-To register a sensor simply call the NodeManager instance with the sensory type and the pin the sensor is conncted to. For example:
+To register a sensor simply call the NodeManager instance with the sensory type and the pin the sensor is conncted to and optionally a child id. For example:
 ~~~c
 	nodeManager.registerSensor(SENSOR_THERMISTOR,A2);
-	nodeManager.registerSensor(SENSOR_DOOR,3);
+	nodeManager.registerSensor(SENSOR_DOOR,3,1);
 ~~~
 
-Once registered, your job is done. NodeManager will assign a child id automatically, present each sensor for you to the controller, query each sensor and report the value back to the gateway/controller at at the end of each sleep cycle. An optional child id can be provided as a third argument if you want to assign it manually. For actuators (e.g. relays) those can be triggered by sending a `REQ` message to their assigned child id.
+Once registered, your job is done. NodeManager will assign a child id automatically if not instructed differently, present each sensor for you to the controller, query each sensor and report the measure back to the gateway/controller. For actuators (e.g. relays) those can be triggered by sending a `REQ` message with the expected type to their assigned child id.
 
-When called, registerSensor returns the child_id of the sensor so you will be able to retrieve it later if needed. If you want to set a child_id manually, this can be passed as third argument to the function.
+When called, registerSensor returns the child_id of the sensor so you will be able to retrieve it later if needed. Please note for sensors creating multiple child IDs (like a DHT sensor which creates a temperature and humidity sensor with different IDs), the last id is returned.
 
 #### Creating a custom sensor
 
@@ -398,13 +421,14 @@ Each built-in sensor class comes with reasonable default settings. In case you w
 To do so, use `nodeManager.getSensor(child_id)` which will return a pointer to the sensor. Remeber to cast it to the right class before calling their functions. For example:
 
 ~~~c
-	((SensorLatchingRelay*)nodeManager.getSensor(2))->setPulseWidth(50);
+	SensorLatchingRelay* relay = (SensorLatchingRelay*) nodeManager.getSensor(2);
+	relay->setPulseWidth(50);
 ~~~
 
 
 #### Sensor's general configuration
 
-The following methods are available for all the sensors:
+The following methods are available for all the sensors and can be called on the object reference as per the example above:
 ~~~c
     // [1] where the sensor is attached to (default: not set)
     void setPin(int value);
@@ -640,51 +664,43 @@ When `DEBUG` is enabled, detailed information is available through the serial po
 
 ### Communicate with NodeManager and its sensors
 
-You can interact with each registered sensor by asking to execute their main tasks by sending to the child id a `REQ` command (or a `SET` for output sensors like relays). For example to request the temperature to node_id 254 and child_id 1:
+You can interact with each registered sensor by sending to the child id a `REQ` command (or a `SET` for output sensors like relays). For example to request the temperature to node_id 254 and child_id 1:
 
 `254;1;2;0;0;`
 
-To activate a relay connected to the same node, child_id 100:
+To activate a relay connected to the same node, child_id 100 we need to send a `SET` command with payload set to 1:
 
 `254;100;1;0;2;1`
 
-No need to implement anything on your side since for built-in sensor types this is handled automatically. 
-Once the node will be sleeping, it will report automatically each measure at the end of every sleep cycle, unless configured otherwise.
+No need to implement anything on your side since for built-in sensors this is handled automatically. 
 
-NodeManager exposes also a configuration service by default on child_id 200 so you can interact with it by sending `V_CUSTOM` type of messages and commands within the payload. For each `REQ` message, the node will respond with a `SET` message if successful. 
-Almost all the functions made available through the API can be called remotely. To do so, the payload must be in the format `<function_id>[,<value_to_set>]` where function_id is the number between square brackets you can find in the description just above each function and, if the function takes and argument, this can be passed along in value_to_set. 
+NodeManager exposes also a configuration service which is by default on child_id 200 so you can interact with it by sending `V_CUSTOM` type of messages and commands within the payload. For each `REQ` message, the node will respond with a `SET` message if successful. 
+Almost all the functions made available through the API can be called remotely. To do so, the payload must be in the format `<function_id>[,<value_to_set>]` where `function_id` is the number between square brackets you can find in the description above and, if the function takes and argument, this can be passed along in `value_to_set`. 
 For example, to request a battery report, find the function you need to call remotely within the documentation:
 ~~~c
     // [2] Send a battery level report to the controller
     void batteryReport();
 ~~~
-In this case the function_id will be 2. To request a battery report to the node_id 100, send the following message:
+In this case `function_id` will be 2. To request a battery report to the node_id 100, send the following message:
 `<node_id>;<configuration_child_id>;<req>;0;<V_CUSTOM>;<function_id>`
 `100;200;2;0;48;2`
 
-The change the sleep time from e.g. 10 minutes as set in the sketch to 5 minutes:
+The change the sleep time to e.g. 10 minutes:
 ~~~c
-    // [4] define for how long the board will sleep (default: 0)
-    void setSleepTime(int value);
+    // [4] set the duration (in minutes) of a sleep cycle
+    void setSleepMinutes(int value);
 ~~~
 `<node_id>;<configuration_child_id>;<req>;0;<V_CUSTOM>;<function_id>,<value>`
-`100;200;2;0;48;4,5`
+`100;200;2;0;48;4,10`
 
-To ask the node to start sleeping (and waking up based on the previously configured interval):
-~~~c
-    // [3] define the way the node should behave. It can be (0) IDLE (stay awake withtout executing each sensors' loop), (1) SLEEP (go to sleep for the configured interval), (2) WAIT (wait for the configured interval), (3) ALWAYS_ON (stay awake and execute each sensors' loop)
-    void setSleepMode(int value);
-~~~
-`100;200;2;0;48;3,1`
-
-To wake up a node previously configured as sleeping, send the following just it wakes up next:
+To wake up a node previously configured as sleeping, send the following as the node wakes up next:
 ~~~c
     // [9] wake up the board
     void wakeup();
 ~~~
 `100;200;2;0;48;9`
 
-The same protocol can be used to execute remotely also sensor-specific functions. In this case the message has to be sent to the sensor's child_id, with a V_CUSTOM type of message. For example if you want to collect and average 10 samples for child_id 1:
+The same protocol can be used to execute remotely also sensor-specific functions. In this case the message has to be sent to the sensor's child_id, with a `V_CUSTOM` type of message. For example if you want to collect and average 10 samples for child_id 1:
 ~~~c
     // [5] For some sensors, the measurement can be queried multiple times and an average is returned (default: 1)
     void setSamples(int value);
@@ -698,14 +714,14 @@ If you want to decrease the temperature offset of a thermistor sensor to -2:
 ~~~
 `100;1;2;0;48;105,-2`
 
-Please note that anything set remotely will NOT persist a reboot apart from those provided to setSleepMode(), setSleepTime() and setSleepUnit() which are saved to the EEPROM (provided `PERSIST` is enabled).
+Please note that anything set remotely will NOT persist a reboot apart from those setting the sleep interval which are saved to the EEPROM (provided `PERSIST` is enabled).
 
 ## Understanding NodeManager: how it works
 
-A NodeManager object must be created and called from within your sketch during `before()`, `presentation()`, `loop()` and `receive()` to work properly. NodeManager will do the following during each phase:
+A NodeManager object is created for you at the beginning of your sketch and its main functions must called from within `before()`, `presentation()`, `loop()` and `receive()` to work properly. NodeManager will do the following during each phase:
 
 NodeManager::before():
-* Setup the interrupt pins to wake up the board based on the configured interrupts (e.g. stop sleeping when the pin is connected to ground or wake up and notify when a motion sensor has trigger)
+* Setup the interrupt pins to wake up the board based on the configured interrupts
 * If persistance is enabled, restore from the EEPROM the latest sleeping settings
 * Call `before()` of each registered sensor
 
@@ -720,16 +736,16 @@ Sensor::setup():
 * Call sensor-specific implementation of setup by invoking `onSetup()` to initialize the sensor
 
 NodeManager::loop():
-* If all the sensors are powered by an arduino pin, this is set to HIGH
+* If all the sensors are powered by an arduino pin, this is turned on
 * Call `loop()` of each registered sensor
-* If all the sensors are powered by an arduino pin, this is set to LOW
+* If all the sensors are powered by an arduino pin, this is turned off
 
 Sensor::loop():
-* If the sensor is powered by an arduino pin, this is set to HIGH
-* For each registered sensor, the sensor-specific `onLoop()` is called. If multiple samples are requested, this is run multiple times.
+* If the sensor is powered by an arduino pin, this is set to on
+* For each registered sensor, the sensor-specific `onLoop()` is called. If multiple samples are requested, this is run multiple times. `onLoop()` is not intended to send out any message but just sets a new value to a local variable
 * In case multiple samples have been collected, the average is calculated
 * A message is sent to the gateway with the calculated value. Depending on the configuration, this is not sent if it is the same as the previous value or sent anyway after a given number of cycles. These functionalies are not sensor-specific and common to all the sensors inheriting from the `Sensor` class.
-* If the sensor is powered by an arduino pin, this is set to LOW
+* If the sensor is powered by an arduino pin, this is turned off
 
 NodeManager::receive():
 * Receive a message from the radio network 
@@ -743,10 +759,10 @@ NodeManager::process():
 
 Sensor::process():
 * Process a sensor-generic incoming remote configuration request
-* Calls onProcess() for sensor-specific incoming remote configuration request
+* Calls `onProcess()` for sensor-specific incoming remote configuration request
 
 Sensor::interrupt():
-* Calls the sensor's implementation of onInterrupt() to handle the interrupt
+* Calls the sensor's implementation of `onInterrupt()` to handle the interrupt
 
 ## Examples
 All the examples below takes place within the before() function in the main sketch, just below the "Register below your sensors" comment.
@@ -761,7 +777,7 @@ Set battery minimum and maxium voltage. This will be used to calculate the level
 Instruct the board to sleep for 10 minutes at each cycle:
 
 ~~~c
-    nodeManager.setSleep(SLEEP,10,MINUTES);
+    nodeManager.setSleepMinutes(10);
 ~~~
 
 Configure a wake up pin. When pin 3 is connected to ground, the board will stop sleeping:
@@ -782,7 +798,7 @@ Register a thermistor sensor attached to pin A2. NodeManager will then send the 
    nodeManager.registerSensor(SENSOR_THERMISTOR,A2);
 ~~~
 
-Register a SHT21 temperature/humidity sensor; since using i2c for communicating with the sensor, the pins used are implicit (A4 and A5). NodeManager will then send the temperature and the humidity to the controller at the end of each sleeping cycle:
+Register a SHT21 temperature/humidity sensor; since using I2C for communicating with the sensor, the pins used are implicit (A4 and A5). NodeManager will then send the temperature and the humidity to the controller at the end of each sleeping cycle:
 
 ~~~c
    nodeManager.registerSensor(SENSOR_SHT21);
@@ -821,9 +837,9 @@ Register a latching relay connecting to pin 6 (set) and pin 7 (unset):
 
 The following sketch can be used to report the temperature and the light level based on a thermistor and LDR sensors attached to two analog pins of the arduino board (A1 and A2). Both the thermistor and the LDR are connected to ground on one side and to vcc via a resistor on the other so to measure the voltage drop across each of them through the analog pins. 
 
-The sensor will be put to sleep after startup and will report both the measures every 10 minutes. NodeManager will take care of presenting the sensors, managing the sleep cycle, reporting the battery level every 10 cycles and report the measures in the appropriate format. This sketch requires MODULE_ANALOG_INPUT enabled in the global config.h file.
+The sensor will be put to sleep after startup and will report both the measures every 10 minutes. NodeManager will take care of presenting the sensors, managing the sleep cycle, reporting the battery level every hour and report the measures in the appropriate format. This sketch requires MODULE_ANALOG_INPUT enabled in the global config.h file.
 
-Even if the sensor is sleeping most of the time, it can be potentially woke up by sending a V_CUSTOM message with a WAKEUP payload to NodeManager service child id (200 by default) just after having reported its heartbeat. At this point the node will report AWAKE and the user can interact with it by e.g. sending REQ messages to its child IDs, changing the duration of a sleep cycle with a V_CUSTOM message to the NodeManager service child id, etc.
+Even if the sensor is sleeping most of the time, it can be potentially woke up by sending a V_CUSTOM message to NodeManager service child id (200 by default) just after having reported its heartbeat. At this point the node will report awake and the user can interact with it by e.g. sending REQ messages to its child IDs, changing the duration of a sleep cycle, etc.
 
 ~~~c
 /*
@@ -857,7 +873,8 @@ void before() {
   /*
    * Register below your sensors
   */
-  nodeManager.setSleep(SLEEP,10,MINUTES); 
+  nodeManager.setSleepMinutes(10);
+  nodeManager.setReportIntervalMinutes(10);
   nodeManager.registerSensor(SENSOR_THERMISTOR,A1);
   nodeManager.registerSensor(SENSOR_LDR,A2);
   /*
@@ -939,7 +956,7 @@ void before() {
   /*
    * Register below your sensors
   */
-  nodeManager.setSleep(SLEEP,60,MINUTES); 
+  nodeManager.setSleepHours(1);
   nodeManager.registerSensor(SENSOR_MOTION,3);
 
   /*
@@ -1027,7 +1044,7 @@ void before() {
   */
   nodeManager.setBatteryMin(1.8);
   nodeManager.setBatteryMax(3.2);
-  nodeManager.setSleep(SLEEP,5,MINUTES);
+  nodeManager.setSleepMinutes(5);
   nodeManager.registerSensor(SENSOR_LATCHING_RELAY,6);
 
   /*
@@ -1118,7 +1135,8 @@ void before() {
    * Register below your sensors
   */
   analogReference(DEFAULT);
-  nodeManager.setSleep(SLEEP,10,MINUTES);
+  nodeManager.setSleepMinutes(10);
+  nodeManager.setReportIntervalMinutes(10);
   
   int rain = nodeManager.registerSensor(SENSOR_ANALOG_INPUT,A1);
   int soil = nodeManager.registerSensor(SENSOR_ANALOG_INPUT,A2);
@@ -1210,11 +1228,11 @@ Create a branch for the fix/feature you want to work on and apply changes to the
 * Create and switch to a new branch (give it a significant name, e.g. fix/enum-sensors): `git checkout -b <yourbranch>`
 * Do any required change to the code
 * Include all the files changed for your commit: `git add .`
-* Commit the changes: `git  commit -m"Use enum instead of define for defining each sensor #121"`
 * Ensure both the main sketch and the config.h file do not present any change
+* Commit the changes: `git  commit -m"Use enum instead of define for defining each sensor #121"`
 * Push the branch with the changes to your repository: `git push origin <yourbranch>`
 * Visit `https://github.com/<username>/NodeManager/branches` and click the "New pull request" button just aside your newly created branch
-* Fill in the request with a significant title and description and select the "development" branch from the main repository to be compared against your branch
+* Fill in the request with a significant title and description and select the "development" branch from the main repository to be compared against your branch. Ensure there is one or more issues the pull request will fix and make it explicit within the description
 * Submit the request and start the discussion
 * Any additional commits to your branch which will be presented within the same pull request
 * When the pull request is merged, delete your working branch: `git branch -D <yourbranch>`
@@ -1286,3 +1304,22 @@ v1.5:
 * Added receiveTime() wrapper in the main sketch
 * Fixed the logic for output sensors
 * Added common gateway settings in config.h
+
+v1.6:
+* Introduced new remote API to allow calling all NodeManager's and sensors' functions remotely
+* Decoupled reporting intervals from sleeping cycles
+* All intervals (measure/battery reports) are now time-based
+* Added support for BMP280 temperature and pressure sensor
+* Added support for RS485 serial transport 
+* Added support for TSL2561 light sensor
+* Added support for DHT21 temperature/humidity sensor
+* Added support for AM2320 temperature/humidity sensor
+* Added support for PT100 high temperature sensor
+* Added support for MH-Z19 CO2 sensor
+* Added buil-in rain and soil moisture analog sensors
+* SensorRainGauge now supports sleep mode
+* SensorSwitch now supports awake mode
+* SensorLatchingRealy now handles automatically both on and off commands
+* SensorMQ now depends on its own module
+* Added automatic off capability (safeguard) to SensorDigitalOutput
+* Any sensor can now access all NodeManager's functions

--- a/config.h
+++ b/config.h
@@ -98,11 +98,11 @@
 #define DEBUG 1
 
 // if enabled, enable the capability to power on sensors with the arduino's pins to save battery while sleeping
-#define POWER_MANAGER 1
+#define POWER_MANAGER 0
 // if enabled, will load the battery manager library to allow the battery level to be reported automatically or on demand
 #define BATTERY_MANAGER 1
 // if enabled, allow modifying the configuration remotely by interacting with the configuration child id
-#define REMOTE_CONFIGURATION 1
+#define REMOTE_CONFIGURATION 0
 // if enabled, persist the remote configuration settings on EEPROM
 #define PERSIST 0
 // if enabled, a battery sensor will be created at BATTERY_CHILD_ID and will report vcc voltage together with the battery level percentage
@@ -121,7 +121,7 @@
 // Enable this module to use one of the following sensors: SENSOR_SHT21
 #define MODULE_SHT21 0
 // Enable this module to use one of the following sensors: SENSOR_SWITCH, SENSOR_DOOR, SENSOR_MOTION
-#define MODULE_SWITCH 0
+#define MODULE_SWITCH 1
 // Enable this module to use one of the following sensors: SENSOR_DS18B20
 #define MODULE_DS18B20 0
 // Enable this module to use one of the following sensors: SENSOR_BH1750

--- a/config.h
+++ b/config.h
@@ -15,11 +15,11 @@
 // General settings
 #define MY_BAUD_RATE 9600
 //#define MY_DEBUG
-//#define MY_NODE_ID 100
+#define MY_NODE_ID 100
 
 // NRF24 radio settings
 #define MY_RADIO_NRF24
-//#define MY_RF24_ENABLE_ENCRYPTION
+#define MY_RF24_ENABLE_ENCRYPTION
 //#define MY_RF24_CHANNEL 76
 //#define MY_RF24_PA_LEVEL RF24_PA_HIGH
 //#define MY_DEBUG_VERBOSE_RF24
@@ -111,13 +111,13 @@
 #define SERVICE_MESSAGES 0
 
 // Enable this module to use one of the following sensors: SENSOR_ANALOG_INPUT, SENSOR_LDR, SENSOR_THERMISTOR, SENSOR_ML8511, SENSOR_ACS712, SENSOR_RAIN_GAUGE, SENSOR_RAIN, SENSOR_SOIL_MOISTURE
-#define MODULE_ANALOG_INPUT 1
+#define MODULE_ANALOG_INPUT 0
 // Enable this module to use one of the following sensors: SENSOR_DIGITAL_INPUT
-#define MODULE_DIGITAL_INPUT 1
+#define MODULE_DIGITAL_INPUT 0
 // Enable this module to use one of the following sensors: SENSOR_DIGITAL_OUTPUT, SENSOR_RELAY, SENSOR_LATCHING_RELAY
-#define MODULE_DIGITAL_OUTPUT 1
+#define MODULE_DIGITAL_OUTPUT 0
 // Enable this module to use one of the following sensors: SENSOR_DHT11, SENSOR_DHT22, SENSOR_DHT21
-#define MODULE_DHT 0
+#define MODULE_DHT 1
 // Enable this module to use one of the following sensors: SENSOR_SHT21
 #define MODULE_SHT21 0
 // Enable this module to use one of the following sensors: SENSOR_SWITCH, SENSOR_DOOR, SENSOR_MOTION

--- a/config.h
+++ b/config.h
@@ -100,24 +100,24 @@
 // if enabled, enable the capability to power on sensors with the arduino's pins to save battery while sleeping
 #define POWER_MANAGER 0
 // if enabled, will load the battery manager library to allow the battery level to be reported automatically or on demand
-#define BATTERY_MANAGER 1
+#define BATTERY_MANAGER 0
 // if enabled, allow modifying the configuration remotely by interacting with the configuration child id
 #define REMOTE_CONFIGURATION 0
 // if enabled, persist the remote configuration settings on EEPROM
 #define PERSIST 0
 // if enabled, a battery sensor will be created at BATTERY_CHILD_ID and will report vcc voltage together with the battery level percentage
-#define BATTERY_SENSOR 1
+#define BATTERY_SENSOR 0
 // if enabled, send a SLEEPING and AWAKE service messages just before entering and just after leaving a sleep cycle and STARTED when starting/rebooting
 #define SERVICE_MESSAGES 0
 
 // Enable this module to use one of the following sensors: SENSOR_ANALOG_INPUT, SENSOR_LDR, SENSOR_THERMISTOR, SENSOR_ML8511, SENSOR_ACS712, SENSOR_RAIN_GAUGE, SENSOR_RAIN, SENSOR_SOIL_MOISTURE
-#define MODULE_ANALOG_INPUT 0
+#define MODULE_ANALOG_INPUT 1
 // Enable this module to use one of the following sensors: SENSOR_DIGITAL_INPUT
 #define MODULE_DIGITAL_INPUT 0
 // Enable this module to use one of the following sensors: SENSOR_DIGITAL_OUTPUT, SENSOR_RELAY, SENSOR_LATCHING_RELAY
 #define MODULE_DIGITAL_OUTPUT 0
 // Enable this module to use one of the following sensors: SENSOR_DHT11, SENSOR_DHT22, SENSOR_DHT21
-#define MODULE_DHT 1
+#define MODULE_DHT 0
 // Enable this module to use one of the following sensors: SENSOR_SHT21
 #define MODULE_SHT21 0
 // Enable this module to use one of the following sensors: SENSOR_SWITCH, SENSOR_DOOR, SENSOR_MOTION

--- a/config.h
+++ b/config.h
@@ -15,11 +15,11 @@
 // General settings
 #define MY_BAUD_RATE 9600
 //#define MY_DEBUG
-#define MY_NODE_ID 100
+//#define MY_NODE_ID 100
 
 // NRF24 radio settings
 #define MY_RADIO_NRF24
-#define MY_RF24_ENABLE_ENCRYPTION
+//#define MY_RF24_ENABLE_ENCRYPTION
 //#define MY_RF24_CHANNEL 76
 //#define MY_RF24_PA_LEVEL RF24_PA_HIGH
 //#define MY_DEBUG_VERBOSE_RF24
@@ -98,30 +98,30 @@
 #define DEBUG 1
 
 // if enabled, enable the capability to power on sensors with the arduino's pins to save battery while sleeping
-#define POWER_MANAGER 0
+#define POWER_MANAGER 1
 // if enabled, will load the battery manager library to allow the battery level to be reported automatically or on demand
-#define BATTERY_MANAGER 0
+#define BATTERY_MANAGER 1
 // if enabled, allow modifying the configuration remotely by interacting with the configuration child id
-#define REMOTE_CONFIGURATION 0
+#define REMOTE_CONFIGURATION 1
 // if enabled, persist the remote configuration settings on EEPROM
 #define PERSIST 0
 // if enabled, a battery sensor will be created at BATTERY_CHILD_ID and will report vcc voltage together with the battery level percentage
-#define BATTERY_SENSOR 0
+#define BATTERY_SENSOR 1
 // if enabled, send a SLEEPING and AWAKE service messages just before entering and just after leaving a sleep cycle and STARTED when starting/rebooting
 #define SERVICE_MESSAGES 0
 
 // Enable this module to use one of the following sensors: SENSOR_ANALOG_INPUT, SENSOR_LDR, SENSOR_THERMISTOR, SENSOR_ML8511, SENSOR_ACS712, SENSOR_RAIN_GAUGE, SENSOR_RAIN, SENSOR_SOIL_MOISTURE
 #define MODULE_ANALOG_INPUT 1
 // Enable this module to use one of the following sensors: SENSOR_DIGITAL_INPUT
-#define MODULE_DIGITAL_INPUT 0
+#define MODULE_DIGITAL_INPUT 1
 // Enable this module to use one of the following sensors: SENSOR_DIGITAL_OUTPUT, SENSOR_RELAY, SENSOR_LATCHING_RELAY
-#define MODULE_DIGITAL_OUTPUT 0
+#define MODULE_DIGITAL_OUTPUT 1
 // Enable this module to use one of the following sensors: SENSOR_DHT11, SENSOR_DHT22, SENSOR_DHT21
 #define MODULE_DHT 0
 // Enable this module to use one of the following sensors: SENSOR_SHT21
 #define MODULE_SHT21 0
 // Enable this module to use one of the following sensors: SENSOR_SWITCH, SENSOR_DOOR, SENSOR_MOTION
-#define MODULE_SWITCH 1
+#define MODULE_SWITCH 0
 // Enable this module to use one of the following sensors: SENSOR_DS18B20
 #define MODULE_DS18B20 0
 // Enable this module to use one of the following sensors: SENSOR_BH1750


### PR DESCRIPTION
This PR redefines the default behavior the board operates:
* Decouples reporting intervals from sleeping cycles
* Makes available only SLEEP and AWAKE modes (removes ALWAYS_ON and WAIT). AWAKE is the default, when setSleepSeconds()/setSleepMinutes()/setSleepHours()/setSleepDays() is called, mode is automatically set to SLEEP and smart sleep is used behind the scene
* simplifies remote configuration allowing to call setSleepXXX() functions through the standard new remote API. If zero is provided to a sleeping node, mode changes to AWAKE
* Reporting interval is driven by setReportIntervalMinutes() / setReportIntervalSeconds(). This can be global when called on the NodeManager class or customized for every sensor (default to 10 minutes)
* All the functions related to sleeping cycles have been deprecated (setBatteryReportCycles(), setForceUpdateCycles() and setReportIntervalCycles())
* Battery reports are still defined with setBatteryReportMinutes() (default to 60 minutes)

Fixes #153, #179, #184 