### PR TITLE
Added signal sensor

### DIFF
--- a/NodeManager.cpp
+++ b/NodeManager.cpp
@@ -303,15 +303,26 @@ char* Sensor::getValueString() {
   return _last_value_string;
 }
 
+// After how many seconds the sensor will report back its measure
+void Sensor::setReportIntervalSeconds(int value) {
+  _report_timer->start(value,SECONDS);
+}
+
 // After how many minutes the sensor will report back its measure 
 void Sensor::setReportIntervalMinutes(int value) {
   _report_timer->start(value,MINUTES);
 }
 
-// After how many seconds the sensor will report back its measure
-void Sensor::setReportIntervalSeconds(int value) {
-  _report_timer->start(value,SECONDS);
+// After how many minutes the sensor will report back its measure 
+void Sensor::setReportIntervalHours(int value) {
+  _report_timer->start(value,HOURS);
 }
+
+// After how many minutes the sensor will report back its measure 
+void Sensor::setReportIntervalDays(int value) {
+  _report_timer->start(value,DAYS);
+}
+
 
 // return true if the report interval has been already configured
 bool Sensor::isReportIntervalConfigured() {
@@ -471,6 +482,8 @@ void Sensor::process(Request & request) {
     #endif
     case 16: setReportIntervalMinutes(request.getValueInt()); break;
     case 17: setReportIntervalSeconds(request.getValueInt()); break;
+    case 19: setReportIntervalHours(request.getValueInt()); break;
+    case 20: setReportIntervalDays(request.getValueInt()); break;
     case 18: setForceUpdateHours(request.getValueInt()); break;
     default: return;
   }
@@ -2957,8 +2970,17 @@ int NodeManager::getRetries() {
   void NodeManager::setBatteryMax(float value) {
     _battery_max = value;
   }
+  void NodeManager::setBatteryReportSeconds(int value) {
+    _battery_report_timer.set(value,SECONDS);
+  }
   void NodeManager::setBatteryReportMinutes(int value) {
     _battery_report_timer.set(value,MINUTES);
+  }
+  void NodeManager::setBatteryReportHours(int value) {
+    _battery_report_timer.set(value,HOURS);
+  }
+  void NodeManager::setBatteryReportDays(int value) {
+    _battery_report_timer.set(value,DAYS);
   }
   void NodeManager::setBatteryInternalVcc(bool value) {
     _battery_internal_vcc = value;
@@ -3355,7 +3377,9 @@ void NodeManager::before() {
   }
   // print out MySensors' library capabilities
   #if DEBUG == 1
-    Serial.print(F("LIB R="));
+    Serial.print(F("LIB V="));
+    Serial.print(MYSENSORS_LIBRARY_VERSION);
+    Serial.print(F(" R="));
     Serial.print(MY_CAP_RADIO);
     #ifdef MY_CAP_ENCR
       Serial.print(F(" E="));
@@ -3635,9 +3659,19 @@ void NodeManager::process(Request & request) {
     case 32: setADCOff(); break;
     #if SIGNAL_SENSOR == 1 && defined(MY_SIGNAL_REPORT_ENABLED)
       case 33: setSignalReportMinutes(request.getValueInt()); break;
+      case 43: setSignalReportSeconds(request.getValueInt()); break;
+      case 44: setSignalReportHours(request.getValueInt()); break;
+      case 45: setSignalReportDays(request.getValueInt()); break;
       case 34: setSignalCommand(request.getValueInt()); break;
       case 35: signalReport(); break;
     #endif
+    case 36: setReportIntervalSeconds(request.getValueInt()); break;
+    case 37: setReportIntervalMinutes(request.getValueInt()); break;
+    case 38: setReportIntervalHours(request.getValueInt()); break;
+    case 39: setReportIntervalDays(request.getValueInt()); break;
+    case 40: setBatteryReportSeconds(request.getValueInt()); break;
+    case 41: setBatteryReportHours(request.getValueInt()); break;
+    case 42: setBatteryReportDays(request.getValueInt()); break;
     default: return; 
   }
   _send(_msg.set(function));
@@ -3833,8 +3867,17 @@ void NodeManager::sleepOrWait(long value) {
 }
 
 #if SIGNAL_SENSOR == 1 && defined(MY_SIGNAL_REPORT_ENABLED)
+  void NodeManager::setSignalReportSeconds(int value) {
+    _signal_report_timer.set(value,SECONDS);
+  }
   void NodeManager::setSignalReportMinutes(int value) {
     _signal_report_timer.set(value,MINUTES);
+  }
+  void NodeManager::setSignalReportHours(int value) {
+    _signal_report_timer.set(value,HOURS);
+  }
+  void NodeManager::setSignalReportDays(int value) {
+    _signal_report_timer.set(value,DAYS);
   }
   void NodeManager::setSignalCommand(int value) {
     _signal_command = value;
@@ -3843,7 +3886,7 @@ void NodeManager::sleepOrWait(long value) {
     int16_t value = transportGetSignalReport(_signal_command);
     #if DEBUG == 1
       Serial.print(F("SIG V="));
-      Serial.print(value);
+      Serial.println(value);
     #endif
     // report signal level
     MyMessage signal_msg(SIGNAL_CHILD_ID, V_LEVEL);

--- a/NodeManager.h
+++ b/NodeManager.h
@@ -80,9 +80,13 @@
 #ifndef SERVICE_MESSAGES
   #define SERVICE_MESSAGES 0
 #endif
-// if enabled, a battery sensor will be created at BATTERY_CHILD_ID and will report vcc voltage together with the battery level percentage
+// if enabled, a battery sensor will be created at BATTERY_CHILD_ID (201 by default) and will report vcc voltage together with the battery level percentage
 #ifndef BATTERY_SENSOR
   #define BATTERY_SENSOR 1
+#endif
+// if enabled, a RSSI sensor will be created at SIGNAL_CHILD_ID (202 by default) and will report the signal quality of the transport layer
+#ifndef SIGNAL_SENSOR
+  #define SIGNAL_SENSOR 1
 #endif
 
 // the child id used to allow remote configuration
@@ -94,8 +98,8 @@
   #define BATTERY_CHILD_ID 201
 #endif
 // the child id used to report the rssi level to the controller
-#ifndef RSSI_CHILD_ID
-  #define RSSI_CHILD_ID 202
+#ifndef SIGNAL_CHILD_ID
+  #define SIGNAL_CHILD_ID 202
 #endif
 // define the maximum number of sensors that can be managed
 #ifndef MAX_SENSORS
@@ -1484,8 +1488,10 @@ class NodeManager {
     // set the default interval in minutes all the sensors will report their measures. 
     // If the same function is called on a specific sensor, this will not change the previously set value 
     // For sleeping sensors, the elapsed time can be evaluated only upon wake up (default: 10 minutes)
-    void setReportIntervalMinutes(int value);
     void setReportIntervalSeconds(int value);
+    void setReportIntervalMinutes(int value);
+    void setReportIntervalHours(int value);
+    void setReportIntervalDays(int value);
     // [30] if set and when the board is battery powered, sleep() is always called instead of wait() (default: true)
     void setSleepOrWait(bool value);
     // sleep if the node is a battery powered or wait if it is not for the given number of milliseconds 
@@ -1494,6 +1500,14 @@ class NodeManager {
     void setRebootPin(int value);
     // [32] turn the ADC off so to save 0.2 mA
     void setADCOff();
+    #if SIGNAL_SENSOR == 1 && defined(MY_SIGNAL_REPORT_ENABLED)
+      // [33] How frequenly to send a signal report to the controller (default: 60)
+      void setSignalReportMinutes(int value);
+      // [34] define which signal report to send. Possible values are SR_UPLINK_QUALITY, SR_TX_POWER_LEVEL, SR_TX_POWER_PERCENT, SR_TX_RSSI, SR_RX_RSSI, SR_TX_SNR, SR_RX_SNR (default: SR_RX_RSSI)
+      void setSignalCommand(int value);
+      // [35] report the signal level to the controller
+      void signalReport();
+    #endif
     // hook into the main sketch functions
     void before();
     void presentation();
@@ -1518,6 +1532,10 @@ class NodeManager {
       // to optionally controller power pins
       PowerManager _powerManager;
       bool _auto_power_pins = true;
+    #endif
+    #if SIGNAL_SENSOR == 1 && defined(MY_SIGNAL_REPORT_ENABLED)
+      Timer _signal_report_timer = Timer(this);
+      int _signal_command = SR_RX_RSSI;
     #endif
     MyMessage _msg;
     void _send(MyMessage & msg);

--- a/NodeManager.h
+++ b/NodeManager.h
@@ -333,6 +333,7 @@ enum supported_sensors {
 #include <core/MySensorsCore.h>
 #include <core/MyCapabilities.h>
 #include <core/MyTransport.h>
+#include <core/Version.h>
 
 // include third party libraries
 #if MODULE_DHT == 1
@@ -532,10 +533,14 @@ class Sensor {
     int getValueInt();
     float getValueFloat();
     char* getValueString();
-    // [16] After how many minutes the sensor will report back its measure (default: 10 minutes)
-    void setReportIntervalMinutes(int value);
     // [17] After how many minutes the sensor will report back its measure (default: 10 minutes)
     void setReportIntervalSeconds(int value);
+    // [16] After how many minutes the sensor will report back its measure (default: 10 minutes)
+    void setReportIntervalMinutes(int value);
+    // [19] After how many hours the sensor will report back its measure (default: 10 minutes)
+    void setReportIntervalHours(int value);
+    // [20] After how many days the sensor will report back its measure (default: 10 minutes)
+    void setReportIntervalDays(int value);
     // return true if the report interval has been already configured
     bool isReportIntervalConfigured();
     // process a remote request
@@ -1397,8 +1402,14 @@ class NodeManager {
       void setBatteryMin(float value);
       // [12] the expected vcc when the batter is fully charged, used to calculate the percentage (default: 3.3)
       void setBatteryMax(float value);
-      // [14] after how many minutes report the battery level to the controller. When reset the battery is always reported (default: 60)
+      // [14] after how many minutes report the battery level to the controller. When reset the battery is always reported (default: 60 minutes)
       void setBatteryReportMinutes(int value);
+      // [40] after how many minutes report the battery level to the controller. When reset the battery is always reported (default: 60 minutes)
+      void setBatteryReportSeconds(int value);
+      // [41] after how many minutes report the battery level to the controller. When reset the battery is always reported (default: 60 minutes)
+      void setBatteryReportHours(int value);
+      // [42] after how many minutes report the battery level to the controller. When reset the battery is always reported (default: 60 minutes)
+      void setBatteryReportDays(int value);
       // [15] if true, the battery level will be evaluated by measuring the internal vcc without the need to connect any pin, if false the voltage divider methon will be used (default: true)
       void setBatteryInternalVcc(bool value);
       // [16] if setBatteryInternalVcc() is set to false, the analog pin to which the battery's vcc is attached (https://www.mysensors.org/build/battery) (default: -1)
@@ -1485,12 +1496,13 @@ class NodeManager {
     void setupInterrupts();
     // return the pin from which the last interrupt came
     int getLastInterruptPin();
-    // set the default interval in minutes all the sensors will report their measures. 
-    // If the same function is called on a specific sensor, this will not change the previously set value 
-    // For sleeping sensors, the elapsed time can be evaluated only upon wake up (default: 10 minutes)
+    // [36] set the default interval in minutes all the sensors will report their measures. If the same function is called on a specific sensor, this will not change the previously set value. or sleeping sensors, the elapsed time can be evaluated only upon wake up (default: 10 minutes)
     void setReportIntervalSeconds(int value);
+    // [37] set the default interval in minutes all the sensors will report their measures. If the same function is called on a specific sensor, this will not change the previously set value. or sleeping sensors, the elapsed time can be evaluated only upon wake up (default: 10 minutes)
     void setReportIntervalMinutes(int value);
+    // [38] set the default interval in minutes all the sensors will report their measures. If the same function is called on a specific sensor, this will not change the previously set value. or sleeping sensors, the elapsed time can be evaluated only upon wake up (default: 10 minutes)
     void setReportIntervalHours(int value);
+    // [39] set the default interval in minutes all the sensors will report their measures. If the same function is called on a specific sensor, this will not change the previously set value. or sleeping sensors, the elapsed time can be evaluated only upon wake up (default: 10 minutes)
     void setReportIntervalDays(int value);
     // [30] if set and when the board is battery powered, sleep() is always called instead of wait() (default: true)
     void setSleepOrWait(bool value);
@@ -1501,8 +1513,14 @@ class NodeManager {
     // [32] turn the ADC off so to save 0.2 mA
     void setADCOff();
     #if SIGNAL_SENSOR == 1 && defined(MY_SIGNAL_REPORT_ENABLED)
-      // [33] How frequenly to send a signal report to the controller (default: 60)
+      // [33] How frequenly to send a signal report to the controller (default: 60 minutes)
       void setSignalReportMinutes(int value);
+      // [43] How frequenly to send a signal report to the controller (default: 60 minutes)
+      void setSignalReportSeconds(int value);
+      // [44] How frequenly to send a signal report to the controller (default: 60 minutes)
+      void setSignalReportHours(int value);
+      // [45] How frequenly to send a signal report to the controller (default: 60 minutes)
+      void setSignalReportDays(int value);
       // [34] define which signal report to send. Possible values are SR_UPLINK_QUALITY, SR_TX_POWER_LEVEL, SR_TX_POWER_PERCENT, SR_TX_RSSI, SR_RX_RSSI, SR_TX_SNR, SR_RX_SNR (default: SR_RX_RSSI)
       void setSignalCommand(int value);
       // [35] report the signal level to the controller

--- a/NodeManager.h
+++ b/NodeManager.h
@@ -93,6 +93,10 @@
 #ifndef BATTERY_CHILD_ID
   #define BATTERY_CHILD_ID 201
 #endif
+// the child id used to report the rssi level to the controller
+#ifndef RSSI_CHILD_ID
+  #define RSSI_CHILD_ID 202
+#endif
 // define the maximum number of sensors that can be managed
 #ifndef MAX_SENSORS
   #define MAX_SENSORS 10
@@ -324,6 +328,7 @@ enum supported_sensors {
 // include MySensors libraries
 #include <core/MySensorsCore.h>
 #include <core/MyCapabilities.h>
+#include <core/MyTransport.h>
 
 // include third party libraries
 #if MODULE_DHT == 1

--- a/NodeManager.ino
+++ b/NodeManager.ino
@@ -33,8 +33,7 @@ void before() {
   /*
    * Register below your sensors
   */
-  nodeManager.registerSensor(SENSOR_THERMISTOR,A1);
-  nodeManager.setReportIntervalSeconds(10);
+
 
 
   /*

--- a/NodeManager.ino
+++ b/NodeManager.ino
@@ -33,8 +33,8 @@ void before() {
   /*
    * Register below your sensors
   */
-
-
+  nodeManager.registerSensor(SENSOR_THERMISTOR,A1);
+  nodeManager.setReportIntervalSeconds(10);
 
 
   /*

--- a/config.h
+++ b/config.h
@@ -15,11 +15,11 @@
 // General settings
 #define MY_BAUD_RATE 9600
 //#define MY_DEBUG
-#define MY_NODE_ID 100
+//#define MY_NODE_ID 100
 //#define MY_SMART_SLEEP_WAIT_DURATION_MS 500
 
 // NRF24 radio settings
-//#define MY_RADIO_NRF24
+#define MY_RADIO_NRF24
 //#define MY_RF24_ENABLE_ENCRYPTION
 //#define MY_RF24_CHANNEL 76
 //#define MY_RF24_PA_LEVEL RF24_PA_HIGH
@@ -27,11 +27,11 @@
 //#define MY_RF24_DATARATE RF24_250KBPS
 
 // RFM69 radio settings
-#define MY_RADIO_RFM69
-#define MY_RFM69_FREQUENCY RFM69_868MHZ
-#define MY_IS_RFM69HW
+//#define MY_RADIO_RFM69
+//#define MY_RFM69_FREQUENCY RF69_868MHZ
+//#define MY_IS_RFM69HW
 //#define MY_DEBUG_VERBOSE_RFM69
-#define MY_RFM69_NEW_DRIVER
+//#define MY_RFM69_NEW_DRIVER
 //#define MY_RFM69_ENABLE_ENCRYPTION
 //#define MY_RFM69_NETWORKID 100
 //#define MY_RF69_IRQ_PIN D1

--- a/config.h
+++ b/config.h
@@ -120,8 +120,8 @@
 #define PERSIST 0
 // if enabled, a battery sensor will be created at BATTERY_CHILD_ID (201 by default) and will report vcc voltage together with the battery level percentage
 #define BATTERY_SENSOR 1
-// if enabled, a RSSI sensor will be created at RSSI_CHILD_ID and will report the signal quality of the transport layer
-#define RSSI_SENSOR 1
+// if enabled, a signal sensor will be created at RSSI_CHILD_ID (202 by default) and will report the signal quality of the transport layer
+#define SIGNAL_SENSOR 1
 // if enabled, send a SLEEPING and AWAKE service messages just before entering and just after leaving a sleep cycle and STARTED when starting/rebooting
 #define SERVICE_MESSAGES 0
 

--- a/config.h
+++ b/config.h
@@ -15,11 +15,11 @@
 // General settings
 #define MY_BAUD_RATE 9600
 //#define MY_DEBUG
-//#define MY_NODE_ID 100
+#define MY_NODE_ID 100
 //#define MY_SMART_SLEEP_WAIT_DURATION_MS 500
 
 // NRF24 radio settings
-#define MY_RADIO_NRF24
+//#define MY_RADIO_NRF24
 //#define MY_RF24_ENABLE_ENCRYPTION
 //#define MY_RF24_CHANNEL 76
 //#define MY_RF24_PA_LEVEL RF24_PA_HIGH
@@ -27,11 +27,11 @@
 //#define MY_RF24_DATARATE RF24_250KBPS
 
 // RFM69 radio settings
-//#define MY_RADIO_RFM69
-//#define MY_RFM69_FREQUENCY RF69_868MHZ
-//#define MY_IS_RFM69HW
+#define MY_RADIO_RFM69
+#define MY_RFM69_FREQUENCY RFM69_868MHZ
+#define MY_IS_RFM69HW
 //#define MY_DEBUG_VERBOSE_RFM69
-//#define MY_RFM69_NEW_DRIVER
+#define MY_RFM69_NEW_DRIVER
 //#define MY_RFM69_ENABLE_ENCRYPTION
 //#define MY_RFM69_NETWORKID 100
 //#define MY_RF69_IRQ_PIN D1
@@ -118,8 +118,10 @@
 #define REMOTE_CONFIGURATION 1
 // if enabled, persist the remote configuration settings on EEPROM
 #define PERSIST 0
-// if enabled, a battery sensor will be created at BATTERY_CHILD_ID and will report vcc voltage together with the battery level percentage
+// if enabled, a battery sensor will be created at BATTERY_CHILD_ID (201 by default) and will report vcc voltage together with the battery level percentage
 #define BATTERY_SENSOR 1
+// if enabled, a RSSI sensor will be created at RSSI_CHILD_ID and will report the signal quality of the transport layer
+#define RSSI_SENSOR 1
 // if enabled, send a SLEEPING and AWAKE service messages just before entering and just after leaving a sleep cycle and STARTED when starting/rebooting
 #define SERVICE_MESSAGES 0
 


### PR DESCRIPTION
Fixes #99 

* Added SIGNAL_SENSOR in config.h
* Added SIGNAL_CHILD_ID, by default at 202
* The child presents itself as S_SOUND and reports V_LEVEL type of messages
* Added a timer which is used to report signal level
* Which signal level is reported is configurable. Can be SR_UPLINK_QUALITY, SR_TX_POWER_LEVEL, SR_TX_POWER_PERCENT, SR_TX_RSSI, SR_RX_RSSI, SR_TX_SNR, SR_RX_SNR (default: SR_RX_RSSI)
* Signal level will be reported by default every 60 minutes
* v2.2.0 transportGetSignalReport() is used under the hood. With v2.1.1 and previous versions, MY_SIGNAL_REPORT_ENABLED is not defined and the functions will not be made available

The following functions have been made available:
```
      // [33] How frequenly to send a signal report to the controller (default: 60 minutes)
      void setSignalReportMinutes(int value);
      // [43] How frequenly to send a signal report to the controller (default: 60 minutes)
      void setSignalReportSeconds(int value);
      // [44] How frequenly to send a signal report to the controller (default: 60 minutes)
      void setSignalReportHours(int value);
      // [45] How frequenly to send a signal report to the controller (default: 60 minutes)
      void setSignalReportDays(int value);
      // [34] define which signal report to send. Possible values are SR_UPLINK_QUALITY, SR_TX_POWER_LEVEL, SR_TX_POWER_PERCENT, SR_TX_RSSI, SR_RX_RSSI, SR_TX_SNR, SR_RX_SNR (default: SR_RX_RSSI)
      void setSignalCommand(int value);
      // [35] report the signal level to the controller
      void signalReport();
```