### PR TITLE
Support for Power/Meter pulse sensors

### DIFF
--- a/NodeManager.cpp
+++ b/NodeManager.cpp
@@ -902,7 +902,7 @@ void SensorRainGauge::onSetup() {
 
 // what to do during loop
 void SensorRainGauge::onLoop() {
-  // do not execute loop if called by an interrupt
+  // do not report anything if called by an interrupt
   if (_node_manager->getLastInterruptPin() == _interrupt_pin) return;
   // time to report the rain so far
   _value_float = _count * _single_tip;

--- a/NodeManager.cpp
+++ b/NodeManager.cpp
@@ -2970,6 +2970,28 @@ SensorRainGauge::SensorRainGauge(NodeManager* node_manager, int child_id, int pi
   setType(V_RAIN);
   setPulseFactor(9.09);
 }
+
+/*
+   SensorPowerMeter
+*/
+// contructor
+SensorPowerMeter::SensorPowerMeter(NodeManager* node_manager, int child_id, int pin): SensorPulseMeter(node_manager,child_id, pin) {
+  setPresentation(S_POWER);
+  setType(V_KWH);
+  setValueType(TYPE_DOUBLE);
+  setPulseFactor(1000);
+}
+
+/*
+   SensorWaterMeter
+*/
+// contructor
+SensorWaterMeter::SensorWaterMeter(NodeManager* node_manager, int child_id, int pin): SensorPulseMeter(node_manager,child_id, pin) {
+  setPresentation(S_WATER);
+  setType(V_VOLUME);
+  setValueType(TYPE_DOUBLE);
+  setPulseFactor(1000);
+}
 #endif
 
 /*******************************************
@@ -3190,9 +3212,7 @@ int NodeManager::registerSensor(int sensor_type, int pin, int child_id) {
     }
   #endif
   #if MODULE_BH1750 == 1
-    else if (sensor_type == SENSOR_BH1750) {
-      return registerSensor(new SensorBH1750(this,child_id));
-    }
+    else if (sensor_type == SENSOR_BH1750) return registerSensor(new SensorBH1750(this,child_id));
   #endif
   #if MODULE_MLX90614 == 1
     else if (sensor_type == SENSOR_MLX90614) {
@@ -3247,9 +3267,7 @@ int NodeManager::registerSensor(int sensor_type, int pin, int child_id) {
     }
   #endif
   #if MODULE_SONOFF == 1
-    else if (sensor_type == SENSOR_SONOFF) {
-      return registerSensor(new SensorSonoff(this,child_id));
-    }
+    else if (sensor_type == SENSOR_SONOFF) return registerSensor(new SensorSonoff(this,child_id));
   #endif
   #if MODULE_BMP085 == 1
     else if (sensor_type == SENSOR_BMP085) {
@@ -3271,9 +3289,7 @@ int NodeManager::registerSensor(int sensor_type, int pin, int child_id) {
     }
   #endif
   #if MODULE_HCSR04 == 1
-    else if (sensor_type == SENSOR_HCSR04) {
-      return registerSensor(new SensorHCSR04(this,child_id, pin));
-    }
+    else if (sensor_type == SENSOR_HCSR04) return registerSensor(new SensorHCSR04(this,child_id, pin));
   #endif
   #if MODULE_MCP9808 == 1
     else if (sensor_type == SENSOR_MCP9808) {
@@ -3289,14 +3305,10 @@ int NodeManager::registerSensor(int sensor_type, int pin, int child_id) {
     }
   #endif
   #if MODULE_MQ == 1
-    else if (sensor_type == SENSOR_MQ) {
-      return registerSensor(new SensorMQ(this,child_id, pin));
-    }
+    else if (sensor_type == SENSOR_MQ) return registerSensor(new SensorMQ(this,child_id, pin));
   #endif
   #if MODULE_MHZ19 == 1
-    else if (sensor_type == SENSOR_MHZ19) {
-      return registerSensor(new SensorMHZ19(this, child_id, pin));
-    }
+    else if (sensor_type == SENSOR_MHZ19) return registerSensor(new SensorMHZ19(this, child_id, pin));
   #endif
   #if MODULE_AM2320 == 1
     else if (sensor_type == SENSOR_AM2320) {
@@ -3309,25 +3321,18 @@ int NodeManager::registerSensor(int sensor_type, int pin, int child_id) {
     }
   #endif
   #if MODULE_TSL2561 == 1 
-    else if (sensor_type == SENSOR_TSL2561) {    
-      // register light sensor
-      return registerSensor(new SensorTSL2561(this,child_id));
-    }
+    else if (sensor_type == SENSOR_TSL2561) return registerSensor(new SensorTSL2561(this,child_id));
   #endif
   #if MODULE_PT100 == 1 
-    else if (sensor_type == SENSOR_PT100) {   
-      // register temperature sensor
-      return registerSensor(new SensorPT100(this,child_id,pin));
-    }
+    else if (sensor_type == SENSOR_PT100) return registerSensor(new SensorPT100(this,child_id,pin));
   #endif
   #if MODULE_DIMMER == 1 
-    else if (sensor_type == SENSOR_DIMMER) {
-      // register the dimmer sensor
-      return registerSensor(new SensorDimmer(this,child_id,pin));
-    }
+    else if (sensor_type == SENSOR_DIMMER) return registerSensor(new SensorDimmer(this,child_id,pin));
   #endif
   #if MODULE_PULSE_METER == 1 
     else if (sensor_type == SENSOR_RAIN_GAUGE) return registerSensor(new SensorRainGauge(this,child_id,pin));
+    else if (sensor_type == SENSOR_POWER_METER) return registerSensor(new SensorPowerMeter(this,child_id,pin));
+    else if (sensor_type == SENSOR_WATER_METER) return registerSensor(new SensorWaterMeter(this,child_id,pin));
   #endif
   else {
     #if DEBUG == 1

--- a/NodeManager.h
+++ b/NodeManager.h
@@ -203,7 +203,7 @@
 #ifndef MODULE_DIMMER
   #define MODULE_DIMMER 0
 #endif
-// Enable this module to use one of the following sensors: SENSOR_RAIN_GAUGE
+// Enable this module to use one of the following sensors: SENSOR_RAIN_GAUGE, SENSOR_POWER_METER, SENSOR_WATER_METER
 #ifndef MODULE_PULSE_METER
   #define MODULE_PULSE_METER 0
 #endif
@@ -321,6 +321,8 @@ enum supported_sensors {
   #if MODULE_PULSE_METER == 1
     // rain gauge sensor
     SENSOR_RAIN_GAUGE,
+    SENSOR_POWER_METER, 
+    SENSOR_WATER_METER,
   #endif
 };
  

--- a/NodeManager.h
+++ b/NodeManager.h
@@ -321,7 +321,9 @@ enum supported_sensors {
   #if MODULE_PULSE_METER == 1
     // rain gauge sensor
     SENSOR_RAIN_GAUGE,
+    // power meter pulse sensor
     SENSOR_POWER_METER, 
+    // water meter pulse sensor
     SENSOR_WATER_METER,
   #endif
 };
@@ -1399,11 +1401,11 @@ class SensorPulseMeter: public Sensor {
     void onProcess(Request & request);
     void onInterrupt();
   protected:
-    long _count = 0;
+    long _count = 20;
     float _pulse_factor;
     int _initial_value = HIGH;
     int _interrupt_mode = FALLING;
-    float _getTotal();
+    void _reportTotal();
 };
 
 /*

--- a/NodeManager.h
+++ b/NodeManager.h
@@ -118,7 +118,7 @@
    Default module settings
 */
 
-// Enable this module to use one of the following sensors: SENSOR_ANALOG_INPUT, SENSOR_LDR, SENSOR_THERMISTOR, SENSOR_ML8511, SENSOR_ACS712, SENSOR_RAIN_GAUGE, SENSOR_RAIN, SENSOR_SOIL_MOISTURE
+// Enable this module to use one of the following sensors: SENSOR_ANALOG_INPUT, SENSOR_LDR, SENSOR_THERMISTOR, SENSOR_ML8511, SENSOR_ACS712, SENSOR_RAIN, SENSOR_SOIL_MOISTURE
 #ifndef MODULE_ANALOG_INPUT
   #define MODULE_ANALOG_INPUT 0
 #endif
@@ -202,6 +202,10 @@
 #ifndef MODULE_DIMMER
   #define MODULE_DIMMER 0
 #endif
+// Enable this module to use one of the following sensors: SENSOR_RAIN_GAUGE
+#ifndef MODULE_PULSE_METER
+  #define MODULE_PULSE_METER 0
+#endif
 
 /***********************************
    Supported Sensors
@@ -218,8 +222,6 @@ enum supported_sensors {
     SENSOR_ML8511,
     // Current sensor
     SENSOR_ACS712,
-    // rain gauge sensor
-    SENSOR_RAIN_GAUGE,
     // Rain sensor, return the percentage of rain from an attached analog sensor
     SENSOR_RAIN,
     // Soil moisture sensor, return the percentage of moisture from an attached analog sensor
@@ -314,6 +316,10 @@ enum supported_sensors {
   #if MODULE_DIMMER == 1
     // Generic dimmer sensor used to drive a pwm output
     SENSOR_DIMMER,
+  #endif
+  #if MODULE_PULSE_METER == 1
+    // rain gauge sensor
+    SENSOR_RAIN_GAUGE,
   #endif
 };
  
@@ -707,30 +713,6 @@ class SensorACS712: public Sensor {
   protected:
     int _ACS_offset = 2500;
     int _mv_per_amp = 185;
-};
-
-/*
-    SensorRainGauge
-*/
-
-class SensorRainGauge: public Sensor {
-  public:
-    SensorRainGauge(NodeManager* node_manager, int child_id, int pin);
-    // [102] set how many mm of rain to count for each tip (default: 0.11)
-    void setSingleTip(float value);
-    // set initial value - internal pull up (default: HIGH)
-    void setInitialValue(int value);
-    // define what to do at each stage of the sketch
-    void onBefore();
-    void onSetup();
-    void onLoop();
-    void onReceive(const MyMessage & message);
-    void onProcess(Request & request);
-    void onInterrupt();
-  protected:
-    long _count = 0;
-    float _single_tip = 0.11;
-    int _initial_value = HIGH;
 };
 
 /*
@@ -1385,6 +1367,36 @@ class SensorDimmer: public Sensor {
     int _duration = 1000;
     int _step_duration = 100;
     float _getEasing(float t, float b, float c, float d);
+};
+#endif
+
+/*
+    SensorPulseMeter
+*/
+#if MODULE_PULSE_METER == 1
+class SensorPulseMeter: public Sensor {
+  public:
+    SensorPulseMeter(NodeManager* node_manager, int child_id, int pin);
+    // [102] set how many mm of rain to count for each tip (default: 0.11)
+    void setSingleTip(float value);
+    // set initial value - internal pull up (default: HIGH)
+    void setInitialValue(int value);
+    // define what to do at each stage of the sketch
+    void onBefore();
+    void onSetup();
+    void onLoop();
+    void onReceive(const MyMessage & message);
+    void onProcess(Request & request);
+    void onInterrupt();
+  protected:
+    long _count = 0;
+    float _single_tip = 0.11;
+    int _initial_value = HIGH;
+};
+
+class SensorRainGauge: public SensorPulseMeter {
+  public:
+    SensorRainGauge(NodeManager* node_manager, int child_id, int pin);
 };
 #endif
 

--- a/NodeManager.h
+++ b/NodeManager.h
@@ -31,6 +31,7 @@
 #define TYPE_INTEGER 0
 #define TYPE_FLOAT 1
 #define TYPE_STRING 2
+#define TYPE_DOUBLE 2
 
 // define interrupt pins
 #define INTERRUPT_PIN_1 3
@@ -525,6 +526,8 @@ class Sensor {
     int getValueType();
     // [11] for float values, set the float precision (default: 2)
     void  setFloatPrecision(int value);
+    // [21] for double values, set the double precision (default: 4)
+    void  setDoublePrecision(int value);
     #if POWER_MANAGER == 1
       // to save battery the sensor can be optionally connected to two pins which will act as vcc and ground and activated on demand
       void setPowerPins(int ground_pin, int vcc_pin, int wait_time = 50);
@@ -583,8 +586,11 @@ class Sensor {
     bool _track_last_value = false;
     int _value_type = TYPE_INTEGER;
     int _float_precision = 2;
+    int _double_precision = 4;
     int _value_int = -1;
     float _value_float = -1;
+    double _value_double = -1;
+    double _last_value_double = -1;
     char * _value_string = "";
     int _last_value_int = -1;
     float _last_value_float = -1;
@@ -1398,9 +1404,28 @@ class SensorPulseMeter: public Sensor {
     float _getTotal();
 };
 
+/*
+    SensorRainGauge
+*/
 class SensorRainGauge: public SensorPulseMeter {
   public:
     SensorRainGauge(NodeManager* node_manager, int child_id, int pin);
+};
+
+/*
+    SensorPowerMeter
+*/
+class SensorPowerMeter: public SensorPulseMeter {
+  public:
+    SensorPowerMeter(NodeManager* node_manager, int child_id, int pin);
+};
+
+/*
+    SensorWaterMeter
+*/
+class SensorWaterMeter: public SensorPulseMeter {
+  public:
+    SensorWaterMeter(NodeManager* node_manager, int child_id, int pin);
 };
 #endif
 

--- a/NodeManager.h
+++ b/NodeManager.h
@@ -1377,10 +1377,12 @@ class SensorDimmer: public Sensor {
 class SensorPulseMeter: public Sensor {
   public:
     SensorPulseMeter(NodeManager* node_manager, int child_id, int pin);
-    // [102] set how many mm of rain to count for each tip (default: 0.11)
-    void setSingleTip(float value);
+    // [102] set how many pulses for each unit (e.g. 1000 pulses for 1 kwh of power, 9 pulses for 1 mm of rain, etc.)
+    void setPulseFactor(float value);
     // set initial value - internal pull up (default: HIGH)
     void setInitialValue(int value);
+    // set the interrupt mode to attach to (default: FALLING)
+    void setInterruptMode(int value);
     // define what to do at each stage of the sketch
     void onBefore();
     void onSetup();
@@ -1390,8 +1392,10 @@ class SensorPulseMeter: public Sensor {
     void onInterrupt();
   protected:
     long _count = 0;
-    float _single_tip = 0.11;
+    float _pulse_factor;
     int _initial_value = HIGH;
+    int _interrupt_mode = FALLING;
+    float _getTotal();
 };
 
 class SensorRainGauge: public SensorPulseMeter {

--- a/NodeManager.ino
+++ b/NodeManager.ino
@@ -33,7 +33,12 @@ void before() {
   /*
    * Register below your sensors
   */
+   pinMode(6, OUTPUT);
+   digitalWrite(6,LOW);
+   pinMode(7, OUTPUT);
+   digitalWrite(7,HIGH);
 
+nodeManager.registerSensor(SENSOR_RAIN_GAUGE,3);
 
 
   /*

--- a/NodeManager.ino
+++ b/NodeManager.ino
@@ -33,13 +33,8 @@ void before() {
   /*
    * Register below your sensors
   */
-   pinMode(6, OUTPUT);
-   digitalWrite(6,LOW);
-   pinMode(7, OUTPUT);
-   digitalWrite(7,HIGH);
 
-nodeManager.registerSensor(SENSOR_RAIN_GAUGE,3);
-nodeManager.setReportIntervalSeconds(30);
+
 
   /*
    * Register above your sensors

--- a/NodeManager.ino
+++ b/NodeManager.ino
@@ -39,7 +39,7 @@ void before() {
    digitalWrite(7,HIGH);
 
 nodeManager.registerSensor(SENSOR_RAIN_GAUGE,3);
-
+nodeManager.setReportIntervalSeconds(30);
 
   /*
    * Register above your sensors

--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ The next step is to enable NodeManager's additional functionalities and the modu
 // if enabled, send a SLEEPING and AWAKE service messages just before entering and just after leaving a sleep cycle and STARTED when starting/rebooting
 #define SERVICE_MESSAGES 0
 
-// Enable this module to use one of the following sensors: SENSOR_ANALOG_INPUT, SENSOR_LDR, SENSOR_THERMISTOR, SENSOR_ML8511, SENSOR_ACS712, SENSOR_RAIN_GAUGE, SENSOR_RAIN, SENSOR_SOIL_MOISTURE
+// Enable this module to use one of the following sensors: SENSOR_ANALOG_INPUT, SENSOR_LDR, SENSOR_THERMISTOR, SENSOR_ML8511, SENSOR_ACS712, SENSOR_RAIN, SENSOR_SOIL_MOISTURE
 #define MODULE_ANALOG_INPUT 1
 // Enable this module to use one of the following sensors: SENSOR_DIGITAL_INPUT
 #define MODULE_DIGITAL_INPUT 1
@@ -214,6 +214,8 @@ The next step is to enable NodeManager's additional functionalities and the modu
 #define MODULE_BMP280 0
 // Enable this module to use one of the following sensors: SENSOR_DIMMER
 #define MODULE_DIMMER 0
+// Enable this module to use one of the following sensors: SENSOR_RAIN_GAUGE, SENSOR_POWER_METER, SENSOR_WATER_METER
+#define MODULE_PULSE_METER 0
 ~~~
 
 ### Installing the dependencies
@@ -441,6 +443,8 @@ SENSOR_AM2320 | AM2320 sensors, return temperature/humidity based on the attache
 SENSOR_PT100 | High temperature sensor associated with DFRobot Driver, return the temperature in C° from the attached PT100 sensor
 SENSOR_BMP280 | BMP280 sensor, return temperature/pressure based on the attached BMP280 sensor
 SENSOR_DIMMER | Generic dimmer sensor used to drive a pwm output
+SENSOR_POWER_METER | Power meter pulse sensor
+SENSOR_WATER_METER | Water meter pulse sensor
 
 To register a sensor simply call the NodeManager instance with the sensory type and the pin the sensor is conncted to and optionally a child id. For example:
 ~~~c
@@ -519,6 +523,8 @@ The following methods are available for all the sensors and can be called on the
     int getValueType();
     // [11] for float values, set the float precision (default: 2)
     void  setFloatPrecision(int value);
+    // [21] for double values, set the double precision (default: 4)
+    void  setDoublePrecision(int value);
     #if POWER_MANAGER == 1
       // to save battery the sensor can be optionally connected to two pins which will act as vcc and ground and activated on demand
       void setPowerPins(int ground_pin, int vcc_pin, int wait_time = 50);
@@ -617,12 +623,14 @@ Each sensor class can expose additional methods.
     void setOffset(int value);
 ~~~
 
-* SensorRainGauge
+* SensorRainGauge / SensorPowerMeter / SensorWaterMeter
 ~~~c
-    // [102] set how many mm of rain to count for each tip (default: 0.11)
-    void setSingleTip(float value);
+    // [102] set how many pulses for each unit (e.g. 1000 pulses for 1 kwh of power, 9 pulses for 1 mm of rain, etc.)
+    void setPulseFactor(float value);
     // set initial value - internal pull up (default: HIGH)
     void setInitialValue(int value);
+    // set the interrupt mode to attach to (default: FALLING)
+    void setInterruptMode(int value);
 ~~~
 
 * SensorDigitalOutput / SensorRelay
@@ -1396,6 +1404,7 @@ v1.6:
 * Added support for MH-Z19 CO2 sensor
 * Added buil-in rain and soil moisture analog sensors
 * Added support for generic dimmer sensor (PWM output)
+* Added support for power and water meter pulse sensors
 * Radio signal level is reported automatically and on demand through child 202
 * SensorRainGauge now supports sleep mode
 * SensorSwitch now supports awake mode

--- a/config.h
+++ b/config.h
@@ -167,7 +167,7 @@
 #define MODULE_BMP280 0
 // Enable this module to use one of the following sensors: SENSOR_DIMMER
 #define MODULE_DIMMER 0
-// Enable this module to use one of the following sensors: SENSOR_RAIN_GAUGE
+// Enable this module to use one of the following sensors: SENSOR_RAIN_GAUGE, SENSOR_POWER_METER, SENSOR_WATER_METER
 #define MODULE_PULSE_METER 1
 
 #endif

--- a/config.h
+++ b/config.h
@@ -15,12 +15,12 @@
 // General settings
 #define MY_BAUD_RATE 9600
 //#define MY_DEBUG
-//#define MY_NODE_ID 100
+#define MY_NODE_ID 100
 //#define MY_SMART_SLEEP_WAIT_DURATION_MS 500
 
 // NRF24 radio settings
 #define MY_RADIO_NRF24
-//#define MY_RF24_ENABLE_ENCRYPTION
+#define MY_RF24_ENABLE_ENCRYPTION
 //#define MY_RF24_CHANNEL 76
 //#define MY_RF24_PA_LEVEL RF24_PA_HIGH
 //#define MY_DEBUG_VERBOSE_RF24
@@ -125,12 +125,12 @@
 // if enabled, send a SLEEPING and AWAKE service messages just before entering and just after leaving a sleep cycle and STARTED when starting/rebooting
 #define SERVICE_MESSAGES 0
 
-// Enable this module to use one of the following sensors: SENSOR_ANALOG_INPUT, SENSOR_LDR, SENSOR_THERMISTOR, SENSOR_ML8511, SENSOR_ACS712, SENSOR_RAIN_GAUGE, SENSOR_RAIN, SENSOR_SOIL_MOISTURE
-#define MODULE_ANALOG_INPUT 1
+// Enable this module to use one of the following sensors: SENSOR_ANALOG_INPUT, SENSOR_LDR, SENSOR_THERMISTOR, SENSOR_ML8511, SENSOR_ACS712, SENSOR_RAIN, SENSOR_SOIL_MOISTURE
+#define MODULE_ANALOG_INPUT 0
 // Enable this module to use one of the following sensors: SENSOR_DIGITAL_INPUT
-#define MODULE_DIGITAL_INPUT 1
+#define MODULE_DIGITAL_INPUT 0
 // Enable this module to use one of the following sensors: SENSOR_DIGITAL_OUTPUT, SENSOR_RELAY, SENSOR_LATCHING_RELAY
-#define MODULE_DIGITAL_OUTPUT 1
+#define MODULE_DIGITAL_OUTPUT 0
 // Enable this module to use one of the following sensors: SENSOR_DHT11, SENSOR_DHT22, SENSOR_DHT21
 #define MODULE_DHT 0
 // Enable this module to use one of the following sensors: SENSOR_SHT21
@@ -167,6 +167,8 @@
 #define MODULE_BMP280 0
 // Enable this module to use one of the following sensors: SENSOR_DIMMER
 #define MODULE_DIMMER 0
+// Enable this module to use one of the following sensors: SENSOR_RAIN_GAUGE
+#define MODULE_PULSE_METER 1
 
 #endif
 

--- a/config.h
+++ b/config.h
@@ -15,12 +15,12 @@
 // General settings
 #define MY_BAUD_RATE 9600
 //#define MY_DEBUG
-#define MY_NODE_ID 100
+//#define MY_NODE_ID 100
 //#define MY_SMART_SLEEP_WAIT_DURATION_MS 500
 
 // NRF24 radio settings
 #define MY_RADIO_NRF24
-#define MY_RF24_ENABLE_ENCRYPTION
+//#define MY_RF24_ENABLE_ENCRYPTION
 //#define MY_RF24_CHANNEL 76
 //#define MY_RF24_PA_LEVEL RF24_PA_HIGH
 //#define MY_DEBUG_VERBOSE_RF24
@@ -126,11 +126,11 @@
 #define SERVICE_MESSAGES 0
 
 // Enable this module to use one of the following sensors: SENSOR_ANALOG_INPUT, SENSOR_LDR, SENSOR_THERMISTOR, SENSOR_ML8511, SENSOR_ACS712, SENSOR_RAIN, SENSOR_SOIL_MOISTURE
-#define MODULE_ANALOG_INPUT 0
+#define MODULE_ANALOG_INPUT 1
 // Enable this module to use one of the following sensors: SENSOR_DIGITAL_INPUT
-#define MODULE_DIGITAL_INPUT 0
+#define MODULE_DIGITAL_INPUT 1
 // Enable this module to use one of the following sensors: SENSOR_DIGITAL_OUTPUT, SENSOR_RELAY, SENSOR_LATCHING_RELAY
-#define MODULE_DIGITAL_OUTPUT 0
+#define MODULE_DIGITAL_OUTPUT 1
 // Enable this module to use one of the following sensors: SENSOR_DHT11, SENSOR_DHT22, SENSOR_DHT21
 #define MODULE_DHT 0
 // Enable this module to use one of the following sensors: SENSOR_SHT21
@@ -168,7 +168,7 @@
 // Enable this module to use one of the following sensors: SENSOR_DIMMER
 #define MODULE_DIMMER 0
 // Enable this module to use one of the following sensors: SENSOR_RAIN_GAUGE, SENSOR_POWER_METER, SENSOR_WATER_METER
-#define MODULE_PULSE_METER 1
+#define MODULE_PULSE_METER 0
 
 #endif
 


### PR DESCRIPTION
Fixes #96 

* Since both power meter and water meter sensors work with a logic similar to SensorRainGauge, this has been generalized into a SensorPulseMeter class 
* SENSOR_RAIN_GAUGE now depends on MODULE_PULSE and setSingleTip() has been converted into setPulseFactor() where pulse_factor = 1 / single_tip
* SENSOR_POWER_METER and SENSOR_WATER_METER have been added depending on MODULE_PULSE
* Added setPulseFactor() and setInterruptMode() to SensorPulseMeter  class
* Added SensorPowerMeter and SensorWaterMeter classes with reasonable default values
* Since this has to work with both sleeping and non-sleeping nodes, we cannot rely on the elapsed time so current consumption is not reported (e.g. will report kwh and not watt, volume and not flow)
* The sensor reports the delta from the last report, it will not request the current value from the controller like in the examples (otherwise we would depend on a controller's capability)
