### PR TITLE
Allow to set power savings mode of BH1750 light level sensor

### DIFF
--- a/NodeManager.cpp
+++ b/NodeManager.cpp
@@ -1568,6 +1568,10 @@ SensorBH1750::SensorBH1750(NodeManager* node_manager, int child_id): Sensor(node
   _lightSensor = new BH1750();
 }
 
+void SensorBH1750::setMode(uint8_t mode) {
+  _lightSensor->configure(mode);
+}
+
 // what to do during before
 void SensorBH1750::onBefore() {
   _lightSensor->begin();
@@ -1596,6 +1600,12 @@ void SensorBH1750::onReceive(const MyMessage & message) {
 
 // what to do when receiving a remote message
 void SensorBH1750::onProcess(Request & request) {
+  int function = request.getFunction();
+  switch(function) {
+    case 101: setMode(request.getValueInt()); break;
+    default: return;
+  }
+  _send(_msg_service.set(function));
 }
 
 

--- a/NodeManager.h
+++ b/NodeManager.h
@@ -972,7 +972,7 @@ class SensorDs18b20: public Sensor {
 class SensorBH1750: public Sensor {
   public:
     SensorBH1750(NodeManager* node_manager, int child_id);
-    // set sensor reading mode, e.g. BH1750_ONE_TIME_HIGH_RES_MODE
+    // [101] set sensor reading mode, e.g. BH1750_ONE_TIME_HIGH_RES_MODE
     void setMode(uint8_t mode);
     // define what to do at each stage of the sketch
     void onBefore();

--- a/NodeManager.h
+++ b/NodeManager.h
@@ -972,6 +972,8 @@ class SensorDs18b20: public Sensor {
 class SensorBH1750: public Sensor {
   public:
     SensorBH1750(NodeManager* node_manager, int child_id);
+    // set sensor reading mode, e.g. BH1750_ONE_TIME_HIGH_RES_MODE
+    void setMode(uint8_t mode);
     // define what to do at each stage of the sketch
     void onBefore();
     void onSetup();

--- a/README.md
+++ b/README.md
@@ -687,7 +687,7 @@ Each sensor class can expose additional methods.
 
 *  SensorBH1750
 ~~~c
-    // set sensor reading mode, e.g. BH1750_ONE_TIME_HIGH_RES_MODE
+    // [101] set sensor reading mode, e.g. BH1750_ONE_TIME_HIGH_RES_MODE
     void setMode(uint8_t mode);
 ~~~
 

--- a/README.md
+++ b/README.md
@@ -685,6 +685,12 @@ Each sensor class can expose additional methods.
     DeviceAddress* getDeviceAddress();
 ~~~
 
+*  SensorBH1750
+~~~c
+    // set sensor reading mode, e.g. BH1750_ONE_TIME_HIGH_RES_MODE
+    void setMode(uint8_t mode);
+~~~
+
 *  SensorBME280 / SensorBMP085 / SensorBMP280
 ~~~c
     // [101] define how many pressure samples to keep track of for calculating the forecast (default: 5)


### PR DESCRIPTION
According to the sources of the Arduino BH1750 library ([see here](https://github.com/mysensors/MySensorsArduinoExamples/blob/master/libraries/BH1750/BH1750.h#L63)), the sensor is started by default in the high resolution mode without any energy savings activated.  

The underlying library allows to change this setting to allow for power savings, but fortunately this is not exposed by NodeManager. This pull request changes this and adds a possibility to modify this setting, e.g. by calling:

```
int light = nodeManager.registerSensor(SENSOR_BH1750);

SensorBH1750* lightSensor = ((SensorBH1750*) nodeManager.getSensor(light));
lightSensor->setMode(BH1750_ONE_TIME_LOW_RES_MODE);
```