### PR TITLE
Support for SHT31 temperature and humidity sensor

### DIFF
--- a/NodeManager.cpp
+++ b/NodeManager.cpp
@@ -3006,6 +3006,84 @@ SensorWaterMeter::SensorWaterMeter(NodeManager* node_manager, int child_id, int 
 }
 #endif
 
+/*
+   SensorSHT31
+*/
+#if MODULE_SHT31 == 1
+// contructor
+SensorSHT31::SensorSHT31(NodeManager* node_manager, int child_id, Adafruit_SHT31* sht31, int sensor_type): Sensor(node_manager,child_id,A2) {
+  _sht31 = sht31;
+  // store the sensor type (0: temperature, 1: humidity)
+  _sensor_type = sensor_type;
+  if (_sensor_type == SensorSHT31::TEMPERATURE) {
+    // temperature sensor
+    setPresentation(S_TEMP);
+    setType(V_TEMP);
+    setValueType(TYPE_FLOAT);
+  }
+  else if (_sensor_type == SensorSHT31::HUMIDITY) {
+    // humidity sensor
+    setPresentation(S_HUM);
+    setType(V_HUM);
+    setValueType(TYPE_FLOAT);
+  }
+}
+
+// what to do during before
+void SensorSHT31::onBefore() {
+}
+
+// what to do during setup
+void SensorSHT31::onSetup() {
+}
+
+// what to do during loop
+void SensorSHT31::onLoop() {
+  // temperature sensor
+  if (_sensor_type == SensorSHT31::TEMPERATURE) {
+    // read the temperature
+    float temperature = _sht31->readTemperature();
+    // convert it
+    temperature = _node_manager->celsiusToFahrenheit(temperature);
+    #if DEBUG == 1
+      Serial.print(F("SHT I="));
+      Serial.print(_child_id);
+      Serial.print(F(" T="));
+      Serial.println(temperature);
+    #endif
+    // store the value
+    if (! isnan(temperature)) _value_float = temperature;
+  }
+  // Humidity Sensor
+  else if (_sensor_type == SensorSHT31::HUMIDITY) {
+    // read humidity
+    float humidity = _sht31->readHumidity();
+    if (isnan(humidity)) return;
+    #if DEBUG == 1
+      Serial.print(F("SHT I="));
+      Serial.print(_child_id);
+      Serial.print(F(" H="));
+      Serial.println(humidity);
+    #endif
+    // store the value
+    if (! isnan(humidity)) _value_float = humidity;
+  }
+}
+
+// what to do as the main task when receiving a message
+void SensorSHT31::onReceive(const MyMessage & message) {
+  if (message.getCommand() == C_REQ) onLoop();
+}
+
+// what to do when receiving a remote message
+void SensorSHT31::onProcess(Request & request) {
+}
+
+// what to do when receiving an interrupt
+void SensorSHT31::onInterrupt() {
+}
+#endif
+
 /*******************************************
    NodeManager
 */
@@ -3345,6 +3423,22 @@ int NodeManager::registerSensor(int sensor_type, int pin, int child_id) {
     else if (sensor_type == SENSOR_RAIN_GAUGE) return registerSensor(new SensorRainGauge(this,child_id,pin));
     else if (sensor_type == SENSOR_POWER_METER) return registerSensor(new SensorPowerMeter(this,child_id,pin));
     else if (sensor_type == SENSOR_WATER_METER) return registerSensor(new SensorWaterMeter(this,child_id,pin));
+  #endif
+  #if MODULE_SHT31 == 1
+    else if (sensor_type == SENSOR_SHT31) {
+      Adafruit_SHT31* sht31 = new Adafruit_SHT31();
+      if (! sht31->begin(0x44)) { // Set to 0x45 for alternate i2c addr
+        #if DEBUG == 1
+          Serial.println(F("NO SHT31"));
+        #endif
+        return -1;
+      }
+      // register temperature sensor
+      registerSensor(new SensorSHT31(this,child_id,sht31,SensorSHT31::TEMPERATURE));
+      // register humidity sensor
+      child_id = _getAvailableChildId();
+      return registerSensor(new SensorSHT31(this,child_id,sht31,SensorSHT31::HUMIDITY));
+    }
   #endif
   else {
     #if DEBUG == 1

--- a/NodeManager.h
+++ b/NodeManager.h
@@ -207,6 +207,10 @@
 #ifndef MODULE_PULSE_METER
   #define MODULE_PULSE_METER 0
 #endif
+// Enable this module to use one of the following sensors: SENSOR_SHT31
+#ifndef MODULE_SHT31
+  #define MODULE_SHT31 0
+#endif
 
 /***********************************
    Supported Sensors
@@ -326,6 +330,10 @@ enum supported_sensors {
     // water meter pulse sensor
     SENSOR_WATER_METER,
   #endif
+  #if MODULE_SHT31 == 1
+    // SHT31 temperature and humidity sensor
+    SENSOR_SHT31,
+  #endif
 };
  
 /***********************************
@@ -407,6 +415,11 @@ enum supported_sensors {
 #endif
 #if MODULE_DIMMER == 1
   #include <math.h>
+#endif
+#if MODULE_SHT31 == 1
+  #include <Arduino.h>
+  #include <Wire.h>
+  #include "Adafruit_SHT31.h"
 #endif
 
 /*******************************************************************
@@ -1432,6 +1445,30 @@ class SensorPowerMeter: public SensorPulseMeter {
 class SensorWaterMeter: public SensorPulseMeter {
   public:
     SensorWaterMeter(NodeManager* node_manager, int child_id, int pin);
+};
+#endif
+
+/*
+   SensorSHT31: temperature and humidity sensor
+*/
+#if MODULE_SHT31 == 1
+class SensorSHT31: public Sensor {
+  public:
+    SensorSHT31(NodeManager* node_manager, int child_id, Adafruit_SHT31* sht31, int sensor_type);
+    // define what to do at each stage of the sketch
+    void onBefore();
+    void onSetup();
+    void onLoop();
+    void onReceive(const MyMessage & message);
+    void onProcess(Request & request);
+    void onInterrupt();
+    // constants
+    const static int TEMPERATURE = 0;
+    const static int HUMIDITY = 1;
+  protected:
+    float _offset = 0;
+    int _sensor_type = 0;
+    Adafruit_SHT31* _sht31;
 };
 #endif
 

--- a/NodeManager.ino
+++ b/NodeManager.ino
@@ -34,7 +34,7 @@ void before() {
    * Register below your sensors
   */
   
-  
+
 
   
   /*

--- a/README.md
+++ b/README.md
@@ -218,6 +218,8 @@ The next step is to enable NodeManager's additional functionalities and the modu
 #define MODULE_DIMMER 0
 // Enable this module to use one of the following sensors: SENSOR_RAIN_GAUGE, SENSOR_POWER_METER, SENSOR_WATER_METER
 #define MODULE_PULSE_METER 0
+// Enable this module to use one of the following sensors: SENSOR_SHT31
+#define MODULE_SHT31 0
 ~~~
 
 ### Installing the dependencies
@@ -239,6 +241,7 @@ MODULE_MCP9808 | https://github.com/adafruit/Adafruit_MCP9808_Library
 MODULE_AM2320 | https://github.com/thakshak/AM2320
 MODULE_TSL2561 | https://github.com/adafruit/TSL2561-Arduino-Library
 MODULE_BMP280 | https://github.com/adafruit/Adafruit_BMP280_Library
+MODULE_SHT31 | https://github.com/adafruit/Adafruit_SHT31
 
 ### Configure NodeManager
 
@@ -447,6 +450,7 @@ SENSOR_BMP280 | BMP280 sensor, return temperature/pressure based on the attached
 SENSOR_DIMMER | Generic dimmer sensor used to drive a pwm output
 SENSOR_POWER_METER | Power meter pulse sensor
 SENSOR_WATER_METER | Water meter pulse sensor
+SENSOR_SHT31 | SHT31 sensor, return temperature/humidity based on the attached SHT31 sensor
 
 To register a sensor simply call the NodeManager instance with the sensory type and the pin the sensor is conncted to and optionally a child id. For example:
 ~~~c

--- a/config.h
+++ b/config.h
@@ -171,6 +171,8 @@
 #define MODULE_DIMMER 0
 // Enable this module to use one of the following sensors: SENSOR_RAIN_GAUGE, SENSOR_POWER_METER, SENSOR_WATER_METER
 #define MODULE_PULSE_METER 0
+// Enable this module to use one of the following sensors: SENSOR_SHT31
+#define MODULE_SHT31 0
 
 #endif
 


### PR DESCRIPTION
This PR is to add support for the SHT31 temperature and humidity sensor. Fixes #213.
Depends on: https://github.com/adafruit/Adafruit_SHT31
Enable the module `#define MODULE_SHT31 1` in config.h and register the sensor with `nodeManager.registerSensor(SENSOR_SHT31);` in the main sketch.

It does NOT auto-detect the i2c address and uses 0x44 by default
