### PR TITLE
Correct Request Class memory allocation

### DIFF
--- a/NodeManager.cpp
+++ b/NodeManager.cpp
@@ -164,25 +164,23 @@ float Timer::getElapsed() {
 */
 
 Request::Request(const char* string) {
-	char* ptr;
-	// copy to working area
-	strcpy((char*)&_value, string);
-	// tokenize the string and split function from value
-	strtok_r(_value, ",", &ptr);
-	// get function code
-	_function = atoi(_value);
-	// move user data to working area
-	strcpy(_value, ptr);
-#if DEBUG == 1
-	Serial.print(F("REQ F="));
-	Serial.print(getFunction());
-	Serial.print(F(" I="));
-	Serial.print(getValueInt());
-	Serial.print(F(" F="));
-	Serial.print(getValueFloat());
-	Serial.print(F(" S="));
-	Serial.println(getValueString());
-#endif
+  char str[10];
+  char* ptr;
+  strcpy(str,string);
+  // tokenize the string and split function from value
+  strtok_r(str,",",&ptr);
+  _function = atoi(str);
+  strcpy(_value,ptr);
+  #if DEBUG == 1
+    Serial.print(F("REQ F="));
+    Serial.print(getFunction());
+    Serial.print(F(" I="));
+    Serial.print(getValueInt());
+    Serial.print(F(" F="));
+    Serial.print(getValueFloat());
+    Serial.print(F(" S="));
+    Serial.println(getValueString());
+  #endif
 }
 
 // return the parsed function
@@ -4083,22 +4081,15 @@ int NodeManager::_getInterruptInitialValue(int mode) {
   return -1;
 }
 
-// Local union used to split _sleep_time into bytes
-typedef union {
-	long    long_value;
-	uint8_t byte_arrray[4];
-} tLongByteArrayCombo;
-
 // load the configuration stored in the eeprom
 void NodeManager::_loadConfig() {
   if (loadState(EEPROM_SLEEP_SAVED) == 1) {
-	tLongByteArrayCombo c;
-	c.byte_arrray[0] = loadState(EEPROM_SLEEP_1);
-	c.byte_arrray[1] = loadState(EEPROM_SLEEP_2);
-	c.byte_arrray[2] = loadState(EEPROM_SLEEP_3);
-	c.byte_arrray[3] = 0;
-	_sleep_time = c.long_value;
-	#if DEBUG == 1
+    // load sleep settings
+    int bit_1 = loadState(EEPROM_SLEEP_1);
+    int bit_2 = loadState(EEPROM_SLEEP_2);
+    int bit_3 = loadState(EEPROM_SLEEP_3);
+    _sleep_time = bit_3*255*255 + bit_2*255 + bit_1;
+    #if DEBUG == 1
       Serial.print(F("LOADSLP T="));
       Serial.println(_sleep_time);
     #endif
@@ -4108,10 +4099,20 @@ void NodeManager::_loadConfig() {
 // save the configuration in the eeprom
 void NodeManager::_saveConfig() {
   if (_sleep_time == 0) return;
-  tLongByteArrayCombo c;
-  c.long_value = _sleep_time;
-  saveState(EEPROM_SLEEP_1, c.byte_arrray[0]);
-  saveState(EEPROM_SLEEP_2, c.byte_arrray[1]);
-  saveState(EEPROM_SLEEP_3, c.byte_arrray[2]);
-  saveState(EEPROM_SLEEP_SAVED, 1);
+  // encode the sleep time in 3 bits
+  int bit_1, bit_2, bit_3 = 0;
+  bit_1 = _sleep_time;
+  if (bit_1 >= 255) {
+    bit_2 = (int)bit_1/255;
+    bit_1 = bit_1 - bit_2*255;
+  }
+  if (bit_2 >= 255) {
+    bit_3 = (int)bit_2/255;
+    bit_2 = bit_2 - bit_3*255;
+  }
+  // save the 3 bits
+  saveState(EEPROM_SLEEP_SAVED,1);
+  saveState(EEPROM_SLEEP_1,bit_1);
+  saveState(EEPROM_SLEEP_2,bit_2);
+  saveState(EEPROM_SLEEP_3,bit_3);
 }

--- a/NodeManager.cpp
+++ b/NodeManager.cpp
@@ -164,12 +164,14 @@ float Timer::getElapsed() {
 */
 
 Request::Request(const char* string) {
-  char str[10];
   char* ptr;
-  strcpy(str,string);
+  // copy to working area
+  strcpy((char*)&_value, string);
   // tokenize the string and split function from value
-  strtok_r(str,",",&ptr);
-  _function = atoi(str);
+  strtok_r(_value, ",", &ptr);
+  // get function code
+  _function = atoi(_value);
+  // move user data to working area
   strcpy(_value,ptr);
   #if DEBUG == 1
     Serial.print(F("REQ F="));

--- a/NodeManager.h
+++ b/NodeManager.h
@@ -492,7 +492,8 @@ class Request {
    private:
     NodeManager* _node_manager;
     int _function;
-    char* _value;
+	// Size of buffer to prevent overrun 
+    char _value[MAX_PAYLOAD+1];
 };
 
 /***************************************

--- a/NodeManager.h
+++ b/NodeManager.h
@@ -492,8 +492,7 @@ class Request {
    private:
     NodeManager* _node_manager;
     int _function;
-	// Size of buffer to prevent overrun 
-    char _value[MAX_PAYLOAD+1];
+    char* _value;
 };
 
 /***************************************


### PR DESCRIPTION
Change « Request Class » memory allocation, issue #214

- Add buffer « char _value[MAX_PAYLOAD+1] » to keep request data
- Buffer size is to prevent buffer overrun
