### PR TITLE
Fix compiler warnings

### DIFF
--- a/NodeManager.cpp
+++ b/NodeManager.cpp
@@ -3350,7 +3350,7 @@ int NodeManager::registerSensor(int sensor_type, int pin, int child_id) {
 
 // attach a built-in or custom sensor to this manager
 int NodeManager::registerSensor(Sensor* sensor) {
-  if (sensor->getChildId() > MAX_SENSORS) return;
+  if (sensor->getChildId() > MAX_SENSORS) return -1;
   #if DEBUG == 1
     Serial.print(F("REG I="));
     Serial.print(sensor->getChildId());
@@ -3390,7 +3390,7 @@ Sensor* NodeManager::getSensor(int child_id) {
 
 // assign a different child id to a sensor'
 bool NodeManager::renameSensor(int old_child_id, int new_child_id) {
-  if (old_child_id > MAX_SENSORS || new_child_id > MAX_SENSORS) return;
+  if (old_child_id > MAX_SENSORS || new_child_id > MAX_SENSORS) return false;
   // ensure the old id exists and the new is available
   if (_sensors[old_child_id] == 0 || _sensors[new_child_id] != 0) return false;
   // assign the sensor to new id

--- a/NodeManager.cpp
+++ b/NodeManager.cpp
@@ -249,7 +249,7 @@ void Sensor::setType(int value) {
 int Sensor::getType() {
   return _type;
 }
-void Sensor::setDescription(char* value) {
+void Sensor::setDescription(const char* value) {
   _description = value;
 }
 void Sensor::setSamples(int value) {

--- a/NodeManager.cpp
+++ b/NodeManager.cpp
@@ -2233,9 +2233,9 @@ void SensorMCP9808::onInterrupt() {
  */
 #if MODULE_MQ == 1
 
-static float SensorMQ::_default_LPGCurve[3] = {2.3,0.21,-0.47};
-static float SensorMQ::_default_COCurve[3] = {2.3,0.72,-0.34};
-static float SensorMQ::_default_SmokeCurve[3] = {2.3,0.53,-0.44};
+float SensorMQ::_default_LPGCurve[3] = {2.3,0.21,-0.47};
+float SensorMQ::_default_COCurve[3] = {2.3,0.72,-0.34};
+float SensorMQ::_default_SmokeCurve[3] = {2.3,0.53,-0.44};
 
 SensorMQ::SensorMQ(NodeManager* node_manager, int child_id, int pin): Sensor(node_manager,child_id,pin) {
   setPresentation(S_AIR_QUALITY);

--- a/NodeManager.h
+++ b/NodeManager.h
@@ -515,7 +515,7 @@ class Sensor {
     void setType(int value);
     int getType();
     // [4] description of the sensor (default: '')
-    void setDescription(char *value);
+    void setDescription(const char *value);
     // [5] For some sensors, the measurement can be queried multiple times and an average is returned (default: 1)
     void setSamples(int value);
     // [6] If more then one sample has to be taken, set the interval in milliseconds between measurements (default: 0)
@@ -584,7 +584,7 @@ class Sensor {
     int _child_id;
     int _presentation = S_CUSTOM;
     int _type = V_CUSTOM;
-    char* _description = "";
+    const char* _description = "";
     int _samples = 1;
     int _samples_interval = 0;
     bool _track_last_value = false;


### PR DESCRIPTION
- Use const char* for description (is read-only anyway)
- Warning in MH-Z19 (const was wrongly placed)
- Missing return values