### PR TITLE
Implement VL53L0X laser time-of-flight distance sensor, including (optional) sleep pin

### DIFF
--- a/NodeManager.ino
+++ b/NodeManager.ino
@@ -75,6 +75,7 @@ SensorRainGauge     | 1     | MODULE_PULSE_METER    | Rain gauge sensor         
 SensorPowerMeter    | 1     | MODULE_PULSE_METER    | Power meter pulse sensor                                                                          | -
 SensorWaterMeter    | 1     | MODULE_PULSE_METER    | Water meter pulse sensor                                                                          | -
 SensorPlantowerPMS  | 3     | MODULE_PMS            | Plantower PMS particulate matter sensors (reporting PM<=1.0, PM<=2.5 and PM<=10.0 in µg/m³)       | https://github.com/fu-hsi/pms
+SensorVL53L0X       | 1     | MODULE_VL53L0X        | VL53L0X laser time-of-flight distance sensor via I²C, sleep pin supported (optional)              | https://github.com/pololu/vl53l0x-arduino
 
 */
 
@@ -209,6 +210,7 @@ SensorPlantowerPMS  | 3     | MODULE_PMS            | Plantower PMS particulate 
 //#define MODULE_DIMMER
 //#define MODULE_PULSE_METER
 //#define MODULE_PMS
+//#define MODULE_VL53L0X
 
 /***********************************
  * Load NodeManager Library
@@ -266,6 +268,7 @@ NodeManager node;
 //SensorPowerMeter powerMeter(node,3);
 //SensorWaterMeter waterMeter(node,3);
 //SensorPlantowerPMS pms(node,6,7);
+//SensorVL53L0X vl53l0x(node, /*XSHUT_PIN=*/2);
 
 /***********************************
  * Main Sketch

--- a/NodeManagerLibrary.h
+++ b/NodeManagerLibrary.h
@@ -148,6 +148,10 @@
   #include <PMS.h>
   #include <SoftwareSerial.h> 
 #endif
+#ifdef MODULE_VL53L0X
+  #include <Wire.h>
+  #include <VL53L0X.h>
+#endif
 
 /*******************************************************************
    Classes
@@ -1338,6 +1342,25 @@ class SensorPlantowerPMS: public Sensor {
     bool _valuesRead = false;
     bool _valuesReadError = false;
 };
+#endif
+
+/*
+ * VL53L0X Laser distance sensor
+ */
+#ifdef MODULE_VL53L0X
+class SensorVL53L0X: public Sensor {
+  public:
+    SensorVL53L0X(NodeManager& node_manager, int xshut_pin);
+    // define what to do at each stage of the sketch
+    void onBefore();
+    void onSetup();
+    void onLoop(Child* child);
+    void onReceive(MyMessage* message);
+  protected:
+    int _getDistance();
+    VL53L0X *_lox;
+};
+
 #endif
 
 /***************************************

--- a/NodeManagerLibrary.ino
+++ b/NodeManagerLibrary.ino
@@ -3060,6 +3060,83 @@ void SensorPlantowerPMS::onReceive(MyMessage* message) {
 #endif
 
 /*
+ * VL53L0X Laser distance sensor
+ */
+#ifdef MODULE_VL53L0X
+// constructor
+SensorVL53L0X::SensorVL53L0X(NodeManager& node_manager, int xshut_pin): Sensor(node_manager, xshut_pin) {
+  _name = "VL53L0X";
+  if (_pin > 0) {
+    pinMode(_pin, OUTPUT); // Put sensor in deep sleep until the loop
+    digitalWrite(_pin, LOW);
+  }
+}
+
+void SensorVL53L0X::onBefore() {
+  // register the child
+  new ChildInt(this, _node->getAvailableChildId(), S_DISTANCE, V_DISTANCE, "Dist");
+  _lox = new VL53L0X();
+}
+
+void SensorVL53L0X::onSetup() {
+  if (_lox) {
+    Wire.begin();
+  }
+}
+
+int SensorVL53L0X::_getDistance() {
+  int distance = -1;
+
+  if (_lox) {
+    // The XSHUT pin puts the sensor into deep sleep when pulled to LOW;
+    // To wake up, do NOT write HIGH (=3.3V or 5V) to the pin, as the sensor
+    // uses only 2.8V and is not 5V-tolerant. Instead, set the pin to INPUT.
+    if (_pin >= 0) {
+      pinMode(_pin, INPUT);
+      sleep(5); // Transition from HW standby to SW standby might take up to 1.5 ms => use 5ms to be on the safe side
+    }
+    _lox->init();
+    _lox->setTimeout(500);
+    distance = _lox->readRangeSingleMillimeters();
+    if (_pin >= 0) {
+      digitalWrite(_pin, LOW);
+      pinMode(_pin, OUTPUT);
+    }
+  }
+
+//  if (measure.RangeStatus == 0) {  // only 0  data
+  if (_lox->timeoutOccurred()) {
+    distance = -1;
+  }
+  return distance;
+}
+
+void SensorVL53L0X::onLoop(Child *child) {
+  int val = _getDistance();
+  ((ChildInt*)child)->setValueInt(val);
+  #ifdef NODEMANAGER_DEBUG
+    Serial.print(_name);
+    Serial.print(F(" I="));
+    Serial.print(child->child_id);
+    Serial.print(F(" D="));
+    if (val>=0) {
+      Serial.print(val);
+      Serial.println(F("mm"));
+    } else {
+      Serial.println(F("OOR"));
+    }
+  #endif
+}
+
+// what to do as the main task when receiving a message
+void SensorVL53L0X::onReceive(MyMessage* message) {
+  Child* child = getChild(message->sensor);
+  if (child == nullptr) return;
+  if (message->getCommand() == C_REQ && message->type == child->type) onLoop(child);
+}
+#endif
+
+/*
    SensorConfiguration
 */
 // contructor

--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ SensorRainGauge     | 1     | MODULE_PULSE_METER    | Rain gauge sensor         
 SensorPowerMeter    | 1     | MODULE_PULSE_METER    | Power meter pulse sensor                                                                          | -
 SensorWaterMeter    | 1     | MODULE_PULSE_METER    | Water meter pulse sensor                                                                          | -
 SensorPlantowerPMS  | 3     | MODULE_PMS            | Plantower PMS particulate matter sensors (reporting PM<=1.0, PM<=2.5 and PM<=10.0 in µg/m³)       | https://github.com/fu-hsi/pms
+SensorVL53L0X       | 1     | MODULE_VL53L0X        | VL53L0X laser time-of-flight distance sensor via I²C, sleep pin supported (optional)              | https://github.com/pololu/vl53l0x-arduino
 
 ## Installation
 


### PR DESCRIPTION
This sensor uses the Pololu VL53L0X library to talk to the sensor. Currently, there are no configurable settings, the sensor always simply returns the distance in mm (or 8192 for Out-of-range and -1 for measurement timeout).