### PR TITLE
Add support for SSD1306-based OLED I²C displays (monochrome, up to 128x64 pixel)

### DIFF
--- a/NodeManager.ino
+++ b/NodeManager.ino
@@ -75,6 +75,7 @@ SensorRainGauge     | 1     | MODULE_PULSE_METER    | Rain gauge sensor         
 SensorPowerMeter    | 1     | MODULE_PULSE_METER    | Power meter pulse sensor                                                                          | -
 SensorWaterMeter    | 1     | MODULE_PULSE_METER    | Water meter pulse sensor                                                                          | -
 SensorPlantowerPMS  | 3     | MODULE_PMS            | Plantower PMS particulate matter sensors (reporting PM<=1.0, PM<=2.5 and PM<=10.0 in µg/m³)       | https://github.com/fu-hsi/pms
+DisplaySSD1306      | 1     | MODULE_SSD1306        | SSD1306 128x64 OLED display (I²C); By default displays values of all sensors and children         | https://github.com/greiman/SSD1306Ascii.git
 
 */
 
@@ -209,6 +210,7 @@ SensorPlantowerPMS  | 3     | MODULE_PMS            | Plantower PMS particulate 
 //#define MODULE_DIMMER
 //#define MODULE_PULSE_METER
 //#define MODULE_PMS
+//#define MODULE_SSD1306
 
 /***********************************
  * Load NodeManager Library
@@ -266,6 +268,7 @@ NodeManager node;
 //SensorPowerMeter powerMeter(node,3);
 //SensorWaterMeter waterMeter(node,3);
 //SensorPlantowerPMS pms(node,6,7);
+//DisplaySSD1306 ssd1306(node, &Adafruit128x64, /*I2C_ADDRESS=*/0x3C);
 
 /***********************************
  * Main Sketch

--- a/NodeManagerLibrary.h
+++ b/NodeManagerLibrary.h
@@ -148,6 +148,10 @@
   #include <PMS.h>
   #include <SoftwareSerial.h> 
 #endif
+#ifdef MODULE_SSD1306
+  #include <SSD1306Ascii.h>
+  #include <SSD1306AsciiAvrI2c.h>
+#endif
 
 /*******************************************************************
    Classes
@@ -319,6 +323,7 @@ class Child {
     Timer* force_update_timer;
     virtual void sendValue();
     virtual bool isNewValue();
+    virtual void printOn(Print& p);
   protected:
     int _samples = 0;
     Sensor* _sensor;
@@ -331,6 +336,7 @@ class ChildInt: public Child {
     int getValueInt();
     void sendValue();
     bool isNewValue();
+    void printOn(Print& p);
   private:
     int _value;
     int _last_value;
@@ -344,6 +350,7 @@ class ChildFloat: public Child {
     float getValueFloat();
     void sendValue();
     bool isNewValue();
+    void printOn(Print& p);
   private:
     float _value;
     float _last_value;
@@ -357,6 +364,7 @@ class ChildDouble: public Child {
     double getValueDouble();
     void sendValue();
     bool isNewValue();
+    void printOn(Print& p);
   private:
     double _value;
     double _last_value;
@@ -370,6 +378,7 @@ class ChildString: public Child {
     const char* getValueString();
     void sendValue();
     bool isNewValue();
+    void printOn(Print& p);
   private:
     const char* _value = "";
     const char* _last_value = "";
@@ -1338,6 +1347,44 @@ class SensorPlantowerPMS: public Sensor {
     bool _valuesRead = false;
     bool _valuesReadError = false;
 };
+#endif
+
+/*
+ * SSD1306 OLED display
+ */
+#ifdef MODULE_SSD1306
+class DisplaySSD1306: public Sensor {
+  public:
+    DisplaySSD1306(NodeManager& node_manager, const DevType* dev, uint8_t i2caddress = 0x3C);
+    // set text font (default: &Adafruit5x7)
+    void setFont(const uint8_t* font);
+    // [102] set the contrast of the display (0-255)
+    void setContrast(uint8_t value);
+    // [103] set the displayed text
+    void setText(const char* value);
+    // [104] Rotate the display 180 degree (use rotate=false to revert)
+    void rotateDisplay(bool rotate = true);
+    // [105] Text font size (possible are 1 and 2; default is 1)
+    void setFontSize(int fontsize);
+    // [106] Text caption font size (possible are 1 and 2; default is 2)
+    void setHeaderFontSize(int fontsize);
+    // [107] Invert display (black text on color background; use invert=false to revert)
+    void invertDisplay(bool invert = true);
+    // define what to do at each stage of the sketch
+    void onBefore();
+    void onSetup();
+    void onLoop(Child* child);
+    void onReceive(MyMessage* message);
+    void updateDisplay();
+  protected:
+    virtual void _display(const char*displaystr = 0);
+    SSD1306AsciiAvrI2c *_oled;
+    const DevType* _dev;
+    uint8_t _i2caddress = 0x3c;
+    int _fontsize = 1;
+    int _caption_fontsize = 2;
+};
+
 #endif
 
 /***************************************

--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ SensorRainGauge     | 1     | MODULE_PULSE_METER    | Rain gauge sensor         
 SensorPowerMeter    | 1     | MODULE_PULSE_METER    | Power meter pulse sensor                                                                          | -
 SensorWaterMeter    | 1     | MODULE_PULSE_METER    | Water meter pulse sensor                                                                          | -
 SensorPlantowerPMS  | 3     | MODULE_PMS            | Plantower PMS particulate matter sensors (reporting PM<=1.0, PM<=2.5 and PM<=10.0 in µg/m³)       | https://github.com/fu-hsi/pms
+DisplaySSD1306      | 1     | MODULE_SSD1306        | SSD1306 128x64 OLED display (I²C); By default displays values of all sensors and children         | https://github.com/greiman/SSD1306Ascii.git
 
 ## Installation
 
@@ -497,6 +498,20 @@ Each sensor class exposes additional methods.
     void setInitialValue(int value);
     // set the interrupt mode to attach to (default: FALLING)
     void setInterruptMode(int value);
+~~~
+
+* DisplaySSD1306
+~~~c
+    // [102] set the contrast of the display (0-255)
+    void setContrast(uint8_t value);
+    // [104] Rotate the display 180 degree (use rotate=false to revert)
+    void rotateDisplay(bool rotate = true);
+    // [105] Text font size (possible are 1 and 2; default is 1)
+    void setFontSize(int fontsize);
+    // [106] Text caption font size (possible are 1 and 2; default is 2)
+    void setHeaderFontSize(int fontsize);
+    // [107] Invert display (black text on color background; use invert=false to revert)
+    void invertDisplay(bool invert = true);
 ~~~
 
 ### Remote API


### PR DESCRIPTION
- Class DisplaySSD1306(node_manager, dev, i2caddress) added
- One string child (display caption, by default written in double font size)
- Customizable (also remotely via SensorConfiguration): Font size, caption font size, rotation (0/180 degree), contrast, inverted display
- Customziable (NOT through SensorConfiguration): Display caption text (Request does not support strings) => one has to hard-code the optional display caption in the sketch...
- By default, all names and values of ALL sensors+children of the node manager are displayed.
- To show different text on the display, one has to sub-class DisplaySSD1306 and re-implement _display(const char*captionstr = 0)
- Added virtual function printOn(Print& p) to the Child class and its subclasses, since this was the only clean way to display the child's value to the display (or more generally to any Print-derived class, like Serial, SoftwareSerial, this OLED display, etc.)
- Base library is the very light-weight SSD1306Ascii library, which does NOT use a display buffer and is meant only for text. (Other SSD1306 libraries use a display buffer, which requires at least 1024 bytes of SRAM, which is not available with NodeManager on lower-end arduinos).
    o) Drawback is that one has to make sure that each line is written to the very end. So instead of
          _oled->println(F("Text"));
       one needs to use
           _oled->print(F("Text"));
           _oled->clearToEOL();
           _oled->println();
       Otherwise letters on screen are NOT erased in that line.