### PR TITLE
Fix debugging in SensorPlantowerPMS; Also fix loop function

### DIFF
--- a/NodeManagerLibrary.h
+++ b/NodeManagerLibrary.h
@@ -1325,7 +1325,6 @@ class SensorPlantowerPMS: public Sensor {
     // define what to do at each stage of the sketch
     void onBefore();
     void onSetup();
-    void loop(MyMessage* message);
     void onLoop(Child* child);
     void onReceive(MyMessage* message);
   protected:

--- a/NodeManagerLibrary.ino
+++ b/NodeManagerLibrary.ino
@@ -3008,15 +3008,12 @@ void SensorPlantowerPMS::onSetup() {
   _ser->begin(9600);
 }
 
-// Clean _valuesRead flag at the beginning so the onLoop function knows when to read values (should be done only once for all children)
-void SensorPlantowerPMS::loop(MyMessage* message) {
-  _valuesRead = false;
-  _valuesReadError = false;
-  Sensor::loop(message);
-}
-
 // what to do during loop
 void SensorPlantowerPMS::onLoop(Child* child) {
+  if (child == children.get(1)) {
+    _valuesRead = false;
+    _valuesReadError = false;
+  }
   // Read the ppm values
   if (!_valuesRead || _valuesReadError) {
     _valuesReadError = !_pms->read(_data, 1000);
@@ -3042,7 +3039,7 @@ void SensorPlantowerPMS::onLoop(Child* child) {
   }
   // store the value
   ((ChildInt*)child)->setValueInt(val);
-  #if DEBUG == 1
+  #ifdef NODEMANAGER_DEBUG
     Serial.print(_name);
     Serial.print(F(" I="));
     Serial.print(child->child_id);

--- a/NodeManagerLibrary.ino
+++ b/NodeManagerLibrary.ino
@@ -2996,9 +2996,9 @@ SensorPlantowerPMS::SensorPlantowerPMS(NodeManager& node_manager, int rxpin, int
 // what to do during before
 void SensorPlantowerPMS::onBefore() {
   // register the child
-  new ChildInt(this, _node->getAvailableChildId(), S_AIR_QUALITY, V_LEVEL, "PM1.0");
-  new ChildInt(this, _node->getAvailableChildId(), S_AIR_QUALITY, V_LEVEL, "PM2.5");
-  new ChildInt(this, _node->getAvailableChildId(), S_AIR_QUALITY, V_LEVEL, "PM10.0");
+  new ChildInt(this, _node->getAvailableChildId(), S_DUST, V_LEVEL, "PM1.0");
+  new ChildInt(this, _node->getAvailableChildId(), S_DUST, V_LEVEL, "PM2.5");
+  new ChildInt(this, _node->getAvailableChildId(), S_DUST, V_LEVEL, "PM10.0");
 }
 
 // what to do during setup


### PR DESCRIPTION
As the loop(MyMessage*) method of Sensor is not virtual, derived sensors cannot override it. Instead of setting a flag at the beginning of loop(..), we have to check in onLoop(...) whether the child argument is the first child and in that case set the flag to prevent multiple sensor readouts for one reading.