### PR TITLE
Memory Optimization: Add function to List class to pre-allocate a given size

### DIFF
--- a/NodeManagerLibrary.h
+++ b/NodeManagerLibrary.h
@@ -165,14 +165,12 @@ public:
     _internalArray = NULL;
     _endPosition = 0;
     _allocBlocks = 0;
-    _preAllocBlocks = 0;
   }
   ~List() {
     delete[] _internalArray;
     _internalArray = NULL;
     _endPosition = 0;
     _allocBlocks = 0;
-    _preAllocBlocks = 0;
   }
   void push(T item) {
     if (_endPosition == _allocBlocks) _AllocOneBlock(false);
@@ -182,7 +180,7 @@ public:
   void pop() {
     if (_endPosition == 0) return;
     --_endPosition;
-    if (_allocBlocks > _preAllocBlocks) _DeAllocOneBlock(false);
+    _DeAllocOneBlock(false);
   }
   T get(int position) {
     position = position -1;
@@ -193,11 +191,18 @@ public:
   inline iterator end() { return _internalArray + _endPosition; }
   inline bool empty() { return (_endPosition == 0); }
   inline unsigned int size() { return _endPosition; }
+  void allocateBlocks(int alloc) {
+    _allocBlocks = alloc;
+    T* newArray = new T[_allocBlocks];
+    for (int i = 0; i < _endPosition; ++i) newArray[i] = _internalArray[i];
+    delete[] _internalArray;
+    _internalArray = newArray;
+  }
+
 private:
   T* _internalArray;
   int _endPosition;
   int _allocBlocks;
-  int _preAllocBlocks;
   void _AllocOneBlock(bool shiftItems) {
     ++_allocBlocks;
     T* newArray = new T[_allocBlocks];
@@ -1345,7 +1350,7 @@ class SensorPlantowerPMS: public Sensor {
 */
 class NodeManager {
   public:
-    NodeManager();
+    NodeManager(int sensorcount = 0);
     // [10] send the same message multiple times (default: 1)
     void setRetries(int value);
     int getRetries();

--- a/NodeManagerLibrary.ino
+++ b/NodeManagerLibrary.ino
@@ -2995,6 +2995,8 @@ SensorPlantowerPMS::SensorPlantowerPMS(NodeManager& node_manager, int rxpin, int
 
 // what to do during before
 void SensorPlantowerPMS::onBefore() {
+  // Allocate memory for all children at once (to prevent memory fragmentation)
+  children.allocateBlocks(3);
   // register the child
   new ChildInt(this, _node->getAvailableChildId(), S_AIR_QUALITY, V_LEVEL, "PM1.0");
   new ChildInt(this, _node->getAvailableChildId(), S_AIR_QUALITY, V_LEVEL, "PM2.5");
@@ -3351,9 +3353,12 @@ void SensorConfiguration::onReceive(MyMessage* message) {
 */
 
 // initialize the node manager
-NodeManager::NodeManager() {
+NodeManager::NodeManager(int sensorcount) {
   // setup the message container
   _message = MyMessage();
+  if (sensorcount>0) {
+    sensors.allocateBlocks(sensorcount);
+  }
 }
 
 int NodeManager::_last_interrupt_pin = -1;


### PR DESCRIPTION
The List class is a candidate to cause some heap fragmentation as the list grows,
as it will always try to re-allocate a new suitable buffer and release the old.
As the NodeManager holds the sensors in a List, each new sensor causes the list
storage to be released and re-allocated. Similarly, sensors with multiple children
currently re-allocate space for the child pointers with each new child. If the list
of sensors and/or the list of children of a sensor is known beforehand, this patch
provides the List::allocateBlocks function to allocate exactly the required memory
once at the beginning so that no heap fragmentation is caused by the list.

Adviced changes to existing code:
- Change "NodeManager node;" to "NodeManager node(3);" in NodeManager.ino, where the
  argument is the required number of sensors (including battery, configuration, etc.)
- In custom sensor implementation with multiple children, add "children.allocateBlocks(3);"
  in the onBefore() method before any of the children are created.