### PR TITLE
Memory Optimization: Add NO_MODULE_POWER_MANAGER to remove all traces of the power manager

### DIFF
--- a/NodeManager.ino
+++ b/NodeManager.ino
@@ -183,6 +183,7 @@ SensorPlantowerPMS  | 3     | MODULE_PMS            | Plantower PMS particulate 
  * NodeManager modules
  */
 
+//#define NO_MODULE_POWER_MANAGER
 //#define MODULE_ANALOG_INPUT
 //#define MODULE_THERMISTOR
 //#define MODULE_ML8511

--- a/NodeManagerLibrary.h
+++ b/NodeManagerLibrary.h
@@ -223,6 +223,7 @@ private:
    PowerManager
 */
 
+#ifndef NO_MODULE_POWER_MANAGER
 class PowerManager {
   public:
     PowerManager(int ground_pin, int vcc_pin, int wait_time = 50);
@@ -238,6 +239,7 @@ class PowerManager {
     int _ground_pin = -1;
     long _wait = 0;
 };
+#endif
 
 /*
    Timer
@@ -396,12 +398,14 @@ class Sensor {
     void setTrackLastValue(bool value);
     // [9] if track last value is enabled, force to send an update after the configured number of minutes
     void setForceUpdateMinutes(int value);
+#ifndef NO_MODULE_POWER_MANAGER
     // to save battery the sensor can be optionally connected to two pins which will act as vcc and ground and activated on demand
     void setPowerPins(int ground_pin, int vcc_pin, int wait_time = 50);
     // [13] manually turn the power on
     void powerOn();
     // [14] manually turn the power off
     void powerOff();
+#endif
     // [17] After how many minutes the sensor will report back its measure (default: 10 minutes)
     void setReportIntervalSeconds(int value);
     // [16] After how many minutes the sensor will report back its measure (default: 10 minutes)
@@ -416,8 +420,10 @@ class Sensor {
     int getInterruptPin();
     // listen for interrupts on the given pin so interrupt() will be called when occurring
     void setInterrupt(int pin, int mode, int initial);
+#ifndef NO_MODULE_POWER_MANAGER
     // set a previously configured PowerManager to the sensor so to powering it up with custom pins
     void setPowerManager(PowerManager& powerManager);
+#endif
     // list of configured child
     List<Child*> children;
     // define what to do at each stage of the sketch
@@ -444,7 +450,9 @@ class Sensor {
     int _samples_interval = 0;
     bool _track_last_value = false;
     int _interrupt_pin = -1;
+#ifndef NO_MODULE_POWER_MANAGER
     PowerManager* _powerManager = nullptr;
+#endif
     Timer* _report_timer;
 };
 
@@ -1370,11 +1378,13 @@ class NodeManager {
     // register a sensor
     void registerSensor(Sensor* sensor);
     // to save battery the sensor can be optionally connected to two pins which will act as vcc and ground and activated on demand
+#ifndef NO_MODULE_POWER_MANAGER
     void setPowerPins(int ground_pin, int vcc_pin, int wait_time = 50);
     // [24] manually turn the power on
     void powerOn();
     // [25] manually turn the power off
     void powerOff();
+#endif
     // [21] set this to true if you want destination node to send ack back to this node (default: false)
     void setAck(bool value);
     bool getAck();
@@ -1440,13 +1450,17 @@ class NodeManager {
     void sendMessage(int child_id, int type, float value);
     void sendMessage(int child_id, int type, double value);
     void sendMessage(int child_id, int type, const char* value);
+#ifndef NO_MODULE_POWER_MANAGER
     void setPowerManager(PowerManager& powerManager);
+#endif
     int getAvailableChildId();
     List<Sensor*> sensors;
     Child* getChild(int child_id);
     Sensor* getSensorWithChild(int child_id);
   private:
+#ifndef NO_MODULE_POWER_MANAGER
     PowerManager* _powerManager = nullptr;
+#endif
     MyMessage _message;
     void _sendMessage(int child_id, int type);
     int _status = AWAKE;

--- a/NodeManagerLibrary.ino
+++ b/NodeManagerLibrary.ino
@@ -6,6 +6,7 @@
    PowerManager
 */
 
+#ifndef NO_MODULE_POWER_MANAGER
 PowerManager::PowerManager(int ground_pin, int vcc_pin, int wait_time) {
   setPowerPins(ground_pin, vcc_pin, wait_time);
 }
@@ -57,6 +58,7 @@ void PowerManager::powerOff() {
   // power off the sensor by turning low the vcc pin
   digitalWrite(_vcc_pin, LOW);
 }
+#endif
 
 /******************************************
     Timer
@@ -412,6 +414,7 @@ void Sensor::setForceUpdateMinutes(int value) {
     child->force_update_timer->start(value,MINUTES);
   }
 }
+#ifndef NO_MODULE_POWER_MANAGER
 void Sensor::setPowerPins(int ground_pin, int vcc_pin, int wait_time) {
   if (_powerManager == nullptr) return;
   _powerManager->setPowerPins(ground_pin, vcc_pin, wait_time);
@@ -424,6 +427,7 @@ void Sensor::powerOff() {
   if (_powerManager == nullptr) return;
   _powerManager->powerOff();
 }
+#endif
 int Sensor::getInterruptPin() {
   return _interrupt_pin;
 }
@@ -516,7 +520,9 @@ void Sensor::loop(MyMessage* message) {
     }
   }
   // turn the sensor on
+#ifndef NO_MODULE_POWER_MANAGER
   powerOn();
+#endif
   // iterates over all the children
   for (List<Child*>::iterator itr = children.begin(); itr != children.end(); ++itr) {
     Child* child = *itr;
@@ -542,7 +548,9 @@ void Sensor::loop(MyMessage* message) {
         child->sendValue();
   }
   // turn the sensor off
+#ifndef NO_MODULE_POWER_MANAGER
   powerOff();
+#endif
   // if called from loop(), restart the report timer if over
   if (message == nullptr && _report_timer->isRunning() && _report_timer->isOver()) _report_timer->restart();
 }
@@ -568,10 +576,11 @@ Child* Sensor::getChild(int child_id) {
   return nullptr;
 }
 
+#ifndef NO_MODULE_POWER_MANAGER
 void Sensor::setPowerManager(PowerManager& powerManager) {
   _powerManager = &powerManager;
 }
-
+#endif
 
 // virtual functions
 void Sensor::onBefore() {}
@@ -3108,8 +3117,10 @@ void SensorConfiguration::onReceive(MyMessage* message) {
       case 20: _node->setSleepBetweenSend(request.getValueInt()); break;
       case 21: _node->setAck(request.getValueInt()); break;
       case 22: _node->setIsMetric(request.getValueInt()); break;
+#ifndef NO_MODULE_POWER_MANAGER
       case 24: _node->powerOn(); break;
       case 25: _node->powerOff(); break;
+#endif
       case 27: _node->saveToMemory(0,request.getValueInt()); break;
       case 28: _node->setInterruptMinDelta(request.getValueInt()); break;
       case 30: _node->setSleepOrWait(request.getValueInt()); break;
@@ -3134,8 +3145,10 @@ void SensorConfiguration::onReceive(MyMessage* message) {
         case 6: sensor->setSamplesInterval(request.getValueInt()); break;
         case 7: sensor->setTrackLastValue(request.getValueInt()); break;
         case 9: sensor->setForceUpdateMinutes(request.getValueInt()); break;
+#ifndef NO_MODULE_POWER_MANAGER
         case 13: sensor->powerOn(); break;
         case 14: sensor->powerOff(); break;
+#endif
         case 16: sensor->setReportIntervalMinutes(request.getValueInt()); break;
         case 17: sensor->setReportIntervalSeconds(request.getValueInt()); break;
         case 19: sensor->setReportIntervalHours(request.getValueInt()); break;
@@ -3406,6 +3419,7 @@ void NodeManager::setInterrupt(int pin, int mode, int initial) {
 void NodeManager::setInterruptMinDelta(long value) {
   _interrupt_min_delta = value;
 }
+#ifndef NO_MODULE_POWER_MANAGER
 void NodeManager::setPowerPins(int ground_pin, int vcc_pin, int wait_time) {
   if (_powerManager == nullptr) return;
   _powerManager->setPowerPins(ground_pin, vcc_pin, wait_time);
@@ -3418,6 +3432,7 @@ void NodeManager::powerOff() {
   if (_powerManager == nullptr) return;
   _powerManager->powerOff();
 }
+#endif
 void NodeManager::setSleepBetweenSend(int value) {
   _sleep_between_send = value;
 }
@@ -3553,7 +3568,9 @@ void NodeManager::setup() {
 // run the main function for all the register sensors
 void NodeManager::loop() {
   // turn on the pin powering all the sensors
+#ifndef NO_MODULE_POWER_MANAGER
   powerOn();
+#endif
   // run loop for all the registered sensors
   for (List<Sensor*>::iterator itr = sensors.begin(); itr != sensors.end(); ++itr) {
     Sensor* sensor = *itr;
@@ -3572,7 +3589,9 @@ void NodeManager::loop() {
     }
   }
   // turn off the pin powering all the sensors
+#ifndef NO_MODULE_POWER_MANAGER
   powerOff();
+#endif
   // continue/start sleeping as requested
   if (isSleepingNode()) _sleep();
 }
@@ -3595,11 +3614,15 @@ void NodeManager::receive(MyMessage &message) {
   Sensor* sensor = getSensorWithChild(message.sensor);
   if (sensor != nullptr) {
     // turn on the pin powering all the sensors
+#ifndef NO_MODULE_POWER_MANAGER
     powerOn();
+#endif
     // call the sensor's receive()
     sensor->receive(message);
     // turn off the pin powering all the sensors
+#ifndef NO_MODULE_POWER_MANAGER
     powerOff();
+#endif
   }
 }
 
@@ -3874,9 +3897,11 @@ void NodeManager::_sendMessage(int child_id, int type) {
   }
 }
 
+#ifndef NO_MODULE_POWER_MANAGER
 void NodeManager::setPowerManager(PowerManager& powerManager) {
   _powerManager = &powerManager;
 }
+#endif
 
 // return the requested child 
 Child* NodeManager::getChild(int child_id) {


### PR DESCRIPTION
Currently, each Child and the NodeManager itself hold a pointer to the power manager, even if no power manager is ever needed or desired. This patch adds a NO_MODULE_POWER_MANAGER flag, which will not compile the power manager and also remove all code and variables related to the power manager. This saves at lease one pointer per child plus one pointer in the NodeManager. So with 10 sensors, at least 22 bytes of SRAM and some flash are saved.