### PR TITLE
Architecture review (2)

### DIFF
--- a/NodeManager.ino
+++ b/NodeManager.ino
@@ -192,7 +192,7 @@ SensorVL53L0X       | 1     | MODULE_VL53L0X        | VL53L0X laser time-of-flig
 //#define MODULE_DIGITAL_INPUT
 //#define MODULE_DIGITAL_OUTPUT
 //#define MODULE_DHT
-//#define MODULE_SHT21
+#define MODULE_SHT21
 //#define MODULE_SWITCH
 //#define MODULE_DS18B20
 //#define MODULE_BH1750
@@ -245,7 +245,7 @@ NodeManager node;
 //SensorLatchingRelay latching(node,6);
 //SensorDHT11 dht11(node,6);
 //SensorDHT22 dht22(node,6);
-//SensorSHT21 sht21(node);
+SensorSHT21 sht21(node);
 //SensorHTU21D htu21(node);
 //SensorSwitch sensorSwitch(node,3);
 //SensorDoor door(node,3);
@@ -284,12 +284,13 @@ void before() {
   * Configure your sensors below
   */
 
+  node.setReportIntervalSeconds(10);
   //node.setReportIntervalMinutes(5);
   //node.setSleepMinutes(5);
   
   //node.setPowerManager(power);
   //battery.setReportIntervalMinutes(30);
-  //sht.children.get(1)->child_id = 5;
+  sht21.children.get(1)->child_id = 5;
 
   
   /*

--- a/NodeManager.ino
+++ b/NodeManager.ino
@@ -220,7 +220,8 @@ SensorVL53L0X       | 1     | USE_VL53L0X        | VL53L0X laser time-of-flight 
 
 //#define DISABLE_POWER_MANAGER
 //#define DISABLE_INTERRUPTS
-#define DISABLE_TRACK_LAST_VALUE
+//#define DISABLE_TRACK_LAST_VALUE
+#define DISABLE_EEPROM
 
 /***********************************
  * Load NodeManager Library

--- a/NodeManager.ino
+++ b/NodeManager.ino
@@ -76,7 +76,7 @@ SensorPowerMeter    | 1     | USE_PULSE_METER    | Power meter pulse sensor     
 SensorWaterMeter    | 1     | USE_PULSE_METER    | Water meter pulse sensor                                                                          | -
 SensorPlantowerPMS  | 3     | USE_PMS            | Plantower PMS particulate matter sensors (reporting PM<=1.0, PM<=2.5 and PM<=10.0 in µg/m³)       | https://github.com/fu-hsi/pms
 SensorVL53L0X       | 1     | USE_VL53L0X        | VL53L0X laser time-of-flight distance sensor via I²C, sleep pin supported (optional)              | https://github.com/pololu/vl53l0x-arduino
-
+DisplaySSD1306      | 1     | USE_SSD1306        | SSD1306 128x64 OLED display (I²C); By default displays values of all sensors and children         | https://github.com/greiman/SSD1306Ascii.git
 */
 
 /**********************************
@@ -215,6 +215,7 @@ SensorVL53L0X       | 1     | USE_VL53L0X        | VL53L0X laser time-of-flight 
 //#define USE_PULSE_METER
 //#define USE_PMS
 //#define USE_VL53L0X
+#define USE_SSD1306
 
 /***********************************
  * NodeManager advanced settings
@@ -282,6 +283,7 @@ NodeManager node;
 //SensorWaterMeter waterMeter(node,3);
 //SensorPlantowerPMS pms(node,6,7);
 //SensorVL53L0X vl53l0x(node, /*XSHUT_PIN=*/2);
+DisplaySSD1306 ssd1306(node);
 
 /***********************************
  * Main Sketch

--- a/NodeManager.ino
+++ b/NodeManager.ino
@@ -191,7 +191,7 @@ SensorVL53L0X       | 1     | USE_VL53L0X        | VL53L0X laser time-of-flight 
 //#define USE_DIGITAL_INPUT
 //#define USE_DIGITAL_OUTPUT
 //#define USE_DHT
-#define USE_SHT21
+//#define USE_SHT21
 //#define USE_SWITCH
 //#define USE_DS18B20
 //#define USE_BH1750
@@ -199,7 +199,7 @@ SensorVL53L0X       | 1     | USE_VL53L0X        | VL53L0X laser time-of-flight 
 //#define USE_BME280
 //#define USE_BMP085
 //#define USE_BMP280
-//#define USE_SONOFF
+#define USE_SONOFF
 //#define USE_HCSR04
 //#define USE_MCP9808
 //#define USE_MQ
@@ -230,9 +230,9 @@ NodeManager node;
  * Add your sensors below
  */
 
-//SensorBattery battery(node);
+SensorBattery battery(node);
 //SensorConfiguration configuration(node);
-//SensorSignal signal(node);
+SensorSignal signal(node);
 //PowerManager power(5,6);
 
 //SensorAnalogInput analog(node,A0);
@@ -248,7 +248,7 @@ NodeManager node;
 //SensorLatchingRelay latching(node,6);
 //SensorDHT11 dht11(node,6);
 //SensorDHT22 dht22(node,6);
-SensorSHT21 sht21(node);
+//SensorSHT21 sht21(node);
 //SensorHTU21D htu21(node);
 //SensorSwitch sensorSwitch(node,3);
 //SensorDoor door(node,3);
@@ -259,7 +259,7 @@ SensorSHT21 sht21(node);
 //SensorBME280 bme280(node);
 //SensorBMP085 bmp085(node);
 //SensorBMP280 bmp280(node);
-//SensorSonoff sonoff(node);
+SensorSonoff sonoff(node);
 //SensorHCSR04 hcsr04(node,6);
 //SensorMCP9808 mcp9808(node);
 //SensorMQ mq(node,A0);
@@ -293,7 +293,7 @@ void before() {
   
   //node.setPowerManager(power);
   //battery.setReportIntervalMinutes(30);
-  sht21.children.get(1)->child_id = 5;
+  //sht21.children.get(1)->child_id = 5;
 
   
   /*

--- a/NodeManager.ino
+++ b/NodeManager.ino
@@ -33,49 +33,49 @@ To use a buil-in sensor:
 Once created, the sensor will automatically present one or more child to the gateway and controller.
 A list of buil-in sensors, module to enable, required dependencies and the number of child automatically created is presented below:
 
-Sensor Name         |#Child | Module to enable      | Description                                                                                       | Dependencies
---------------------|-------|-----------------------|---------------------------------------------------------------------------------------------------|----------------------------------------------------------
-SensorBattery       | 1     | -                     | Built-in sensor for automatic battery reporting                                                   | - 
-SensorSignal        | 1     | -                     | Built-in sensor for automatic signal level reporting                                              | -
-SensorConfiguration | 1     | -                     | Built-in sensor for OTA remote configuration of any registered sensor                             | -
-SensorAnalogInput   | 1     | MODULE_ANALOG_INPUT   | Generic analog sensor, return a pin's analog value or its percentage                              | -
-SensorLDR           | 1     | MODULE_ANALOG_INPUT   | LDR sensor, return the light level of an attached light resistor in percentage                    | -
-SensorRain          | 1     | MODULE_ANALOG_INPUT   | Rain sensor, return the percentage of rain from an attached analog sensor                         | -
-SensorSoilMoisture  | 1     | MODULE_ANALOG_INPUT   | Soil moisture sensor, return the percentage of moisture from an attached analog sensor            | -
-SensorThermistor    | 1     | MODULE_THERMISTOR     | Thermistor sensor, return the temperature based on the attached thermistor                        | -
-SensorML8511        | 1     | MODULE_ML8511         | ML8511 sensor, return UV intensity                                                                | -
-SensorACS712        | 1     | MODULE_ACS712         | ACS712 sensor, measure the current going through the attached module                              | -
-SensorDigitalInput  | 1     | MODULE_DIGITAL_INPUT  | Generic digital sensor, return a pin's digital value                                              | -
-SensorDigitalOutput | 1     | MODULE_DIGITAL_OUTPUT | Generic digital output sensor, allows setting the digital output of a pin to the requested value  | -
-SensorRelay         | 1     | MODULE_DIGITAL_OUTPUT | Relay sensor, allows activating the relay                                                         | -
-SensorLatchingRelay | 1     | MODULE_DIGITAL_OUTPUT | Latching Relay sensor, allows activating the relay with a pulse                                   | -
-SensorDHT11         | 2     | MODULE_DHT            | DHT11 sensor, return temperature/humidity based on the attached DHT sensor                        | https://github.com/mysensors/MySensorsArduinoExamples/tree/master/libraries/DHT
-SensorDHT22         | 2     | MODULE_DHT            | DHT22 sensor, return temperature/humidity based on the attached DHT sensor                        | https://github.com/mysensors/MySensorsArduinoExamples/tree/master/libraries/DHT
-SensorSHT21         | 2     | MODULE_SHT21          | SHT21 sensor, return temperature/humidity based on the attached SHT21 sensor                      | https://github.com/SodaqMoja/Sodaq_SHT2x
-SensorHTU21D        | 2     | MODULE_SHT21          | HTU21D sensor, return temperature/humidity based on the attached HTU21D sensor                    | https://github.com/SodaqMoja/Sodaq_SHT2x
-SensorSwitch        | 1     | MODULE_SWITCH         | Generic switch, wake up the board when a pin changes status                                       | -
-SensorDoor          | 1     | MODULE_SWITCH         | Door sensor, wake up the board and report when an attached magnetic sensor has been opened/closed | -
-SensorMotion        | 1     | MODULE_SWITCH         | Motion sensor, wake up the board and report when an attached PIR has triggered                    | -
-SensorDs18b20       | 1+    |  MODULE_DS18B20       | DS18B20 sensor, return the temperature based on the attached sensor                               | https://github.com/milesburton/Arduino-Temperature-Control-Library
-SensorBH1750        | 1     | MODULE_BH1750         | BH1750 sensor, return light level in lux                                                          | https://github.com/claws/BH1750
-SensorMLX90614      | 2     | MODULE_MLX90614       | MLX90614 contactless temperature sensor, return ambient and object temperature                    | https://github.com/adafruit/Adafruit-MLX90614-Library
-SensorBME280        | 4     | MODULE_BME280         | BME280 sensor, return temperature/humidity/pressure based on the attached BME280 sensor           | https://github.com/adafruit/Adafruit_BME280_Library
-SensorBMP085        | 3     | MODULE_BMP085         | BMP085/BMP180 sensor, return temperature and pressure                                             | https://github.com/adafruit/Adafruit-BMP085-Library
-SensorBMP280        | 3     | MODULE_BMP280         | BMP280 sensor, return temperature/pressure based on the attached BMP280 sensor                    | https://github.com/adafruit/Adafruit_BMP280_Library
-SensorSonoff        | 1     | MODULE_SONOFF         | Sonoff wireless smart switch                                                                      | https://github.com/thomasfredericks/Bounce2
-SensorHCSR04        | 1     | MODULE_HCSR04         | HC-SR04 sensor, return the distance between the sensor and an object                              | https://github.com/mysensors/MySensorsArduinoExamples/tree/master/libraries/NewPing
-SensorMCP9808       | 1     | MODULE_MCP9808        | MCP9808 sensor, measure the temperature through the attached module                               | https://github.com/adafruit/Adafruit_MCP9808_Library
-SensorMQ            | 1     | MODULE_MQ             | MQ sensor, return ppm of the target gas                                                           | -
-SensorMHZ19         | 1     | MODULE_MHZ19          | MH-Z19 CO2 sensor via UART (SoftwareSerial, default on pins 6(Rx) and 7(Tx)                       | -
-SensorAM2320        | 2     | MODULE_AM2320         | AM2320 sensors, return temperature/humidity based on the attached AM2320 sensor                   | https://github.com/thakshak/AM2320
-SensorTSL2561       | 1     | MODULE_TSL2561        | TSL2561 sensor, return light in lux                                                               | https://github.com/adafruit/TSL2561-Arduino-Library
-SensorPT100         | 1     | MODULE_PT100          | DFRobot Driver high temperature sensor, return the temperature from the attached PT100 sensor     | -
-SensorDimmer        | 1     | MODULE_DIMMER         | Generic dimmer sensor used to drive a pwm output                                                  | -
-SensorRainGauge     | 1     | MODULE_PULSE_METER    | Rain gauge sensor                                                                                 | -
-SensorPowerMeter    | 1     | MODULE_PULSE_METER    | Power meter pulse sensor                                                                          | -
-SensorWaterMeter    | 1     | MODULE_PULSE_METER    | Water meter pulse sensor                                                                          | -
-SensorPlantowerPMS  | 3     | MODULE_PMS            | Plantower PMS particulate matter sensors (reporting PM<=1.0, PM<=2.5 and PM<=10.0 in µg/m³)       | https://github.com/fu-hsi/pms
-SensorVL53L0X       | 1     | MODULE_VL53L0X        | VL53L0X laser time-of-flight distance sensor via I²C, sleep pin supported (optional)              | https://github.com/pololu/vl53l0x-arduino
+Sensor Name         |#Child | Module to enable   | Description                                                                                       | Dependencies
+--------------------|-------|--------------------|---------------------------------------------------------------------------------------------------|----------------------------------------------------------
+SensorBattery       | 1     | -                  | Built-in sensor for automatic battery reporting                                                   | - 
+SensorSignal        | 1     | -                  | Built-in sensor for automatic signal level reporting                                              | -
+SensorConfiguration | 1     | -                  | Built-in sensor for OTA remote configuration of any registered sensor                             | -
+SensorAnalogInput   | 1     | USE_ANALOG_INPUT   | Generic analog sensor, return a pin's analog value or its percentage                              | -
+SensorLDR           | 1     | USE_ANALOG_INPUT   | LDR sensor, return the light level of an attached light resistor in percentage                    | -
+SensorRain          | 1     | USE_ANALOG_INPUT   | Rain sensor, return the percentage of rain from an attached analog sensor                         | -
+SensorSoilMoisture  | 1     | USE_ANALOG_INPUT   | Soil moisture sensor, return the percentage of moisture from an attached analog sensor            | -
+SensorThermistor    | 1     | USE_THERMISTOR     | Thermistor sensor, return the temperature based on the attached thermistor                        | -
+SensorML8511        | 1     | USE_ML8511         | ML8511 sensor, return UV intensity                                                                | -
+SensorACS712        | 1     | USE_ACS712         | ACS712 sensor, measure the current going through the attached module                              | -
+SensorDigitalInput  | 1     | USE_DIGITAL_INPUT  | Generic digital sensor, return a pin's digital value                                              | -
+SensorDigitalOutput | 1     | USE_DIGITAL_OUTPUT | Generic digital output sensor, allows setting the digital output of a pin to the requested value  | -
+SensorRelay         | 1     | USE_DIGITAL_OUTPUT | Relay sensor, allows activating the relay                                                         | -
+SensorLatchingRelay | 1     | USE_DIGITAL_OUTPUT | Latching Relay sensor, allows activating the relay with a pulse                                   | -
+SensorDHT11         | 2     | USE_DHT            | DHT11 sensor, return temperature/humidity based on the attached DHT sensor                        | https://github.com/mysensors/MySensorsArduinoExamples/tree/master/libraries/DHT
+SensorDHT22         | 2     | USE_DHT            | DHT22 sensor, return temperature/humidity based on the attached DHT sensor                        | https://github.com/mysensors/MySensorsArduinoExamples/tree/master/libraries/DHT
+SensorSHT21         | 2     | USE_SHT21          | SHT21 sensor, return temperature/humidity based on the attached SHT21 sensor                      | https://github.com/SodaqMoja/Sodaq_SHT2x
+SensorHTU21D        | 2     | USE_SHT21          | HTU21D sensor, return temperature/humidity based on the attached HTU21D sensor                    | https://github.com/SodaqMoja/Sodaq_SHT2x
+SensorSwitch        | 1     | USE_SWITCH         | Generic switch, wake up the board when a pin changes status                                       | -
+SensorDoor          | 1     | USE_SWITCH         | Door sensor, wake up the board and report when an attached magnetic sensor has been opened/closed | -
+SensorMotion        | 1     | USE_SWITCH         | Motion sensor, wake up the board and report when an attached PIR has triggered                    | -
+SensorDs18b20       | 1+    | USE_DS18B20        | DS18B20 sensor, return the temperature based on the attached sensor                               | https://github.com/milesburton/Arduino-Temperature-Control-Library
+SensorBH1750        | 1     | USE_BH1750         | BH1750 sensor, return light level in lux                                                          | https://github.com/claws/BH1750
+SensorMLX90614      | 2     | USE_MLX90614       | MLX90614 contactless temperature sensor, return ambient and object temperature                    | https://github.com/adafruit/Adafruit-MLX90614-Library
+SensorBME280        | 4     | USE_BME280         | BME280 sensor, return temperature/humidity/pressure based on the attached BME280 sensor           | https://github.com/adafruit/Adafruit_BME280_Library
+SensorBMP085        | 3     | USE_BMP085         | BMP085/BMP180 sensor, return temperature and pressure                                             | https://github.com/adafruit/Adafruit-BMP085-Library
+SensorBMP280        | 3     | USE_BMP280         | BMP280 sensor, return temperature/pressure based on the attached BMP280 sensor                    | https://github.com/adafruit/Adafruit_BMP280_Library
+SensorSonoff        | 1     | USE_SONOFF         | Sonoff wireless smart switch                                                                      | https://github.com/thomasfredericks/Bounce2
+SensorHCSR04        | 1     | USE_HCSR04         | HC-SR04 sensor, return the distance between the sensor and an object                              | https://github.com/mysensors/MySensorsArduinoExamples/tree/master/libraries/NewPing
+SensorMCP9808       | 1     | USE_MCP9808        | MCP9808 sensor, measure the temperature through the attached module                               | https://github.com/adafruit/Adafruit_MCP9808_Library
+SensorMQ            | 1     | USE_MQ             | MQ sensor, return ppm of the target gas                                                           | -
+SensorMHZ19         | 1     | USE_MHZ19          | MH-Z19 CO2 sensor via UART (SoftwareSerial, default on pins 6(Rx) and 7(Tx)                       | -
+SensorAM2320        | 2     | USE_AM2320         | AM2320 sensors, return temperature/humidity based on the attached AM2320 sensor                   | https://github.com/thakshak/AM2320
+SensorTSL2561       | 1     | USE_TSL2561        | TSL2561 sensor, return light in lux                                                               | https://github.com/adafruit/TSL2561-Arduino-Library
+SensorPT100         | 1     | USE_PT100          | DFRobot Driver high temperature sensor, return the temperature from the attached PT100 sensor     | -
+SensorDimmer        | 1     | USE_DIMMER         | Generic dimmer sensor used to drive a pwm output                                                  | -
+SensorRainGauge     | 1     | USE_PULSE_METER    | Rain gauge sensor                                                                                 | -
+SensorPowerMeter    | 1     | USE_PULSE_METER    | Power meter pulse sensor                                                                          | -
+SensorWaterMeter    | 1     | USE_PULSE_METER    | Water meter pulse sensor                                                                          | -
+SensorPlantowerPMS  | 3     | USE_PMS            | Plantower PMS particulate matter sensors (reporting PM<=1.0, PM<=2.5 and PM<=10.0 in µg/m³)       | https://github.com/fu-hsi/pms
+SensorVL53L0X       | 1     | USE_VL53L0X        | VL53L0X laser time-of-flight distance sensor via I²C, sleep pin supported (optional)              | https://github.com/pololu/vl53l0x-arduino
 
 */
 
@@ -181,36 +181,36 @@ SensorVL53L0X       | 1     | MODULE_VL53L0X        | VL53L0X laser time-of-flig
 //#define MY_DEFAULT_TX_LED_PIN  6
 
 /***********************************
- * NodeManager sensors
+ * NodeManager modules
  */
 
-//#define MODULE_ANALOG_INPUT
-//#define MODULE_THERMISTOR
-//#define MODULE_ML8511
-//#define MODULE_ACS712
-//#define MODULE_DIGITAL_INPUT
-//#define MODULE_DIGITAL_OUTPUT
-//#define MODULE_DHT
-#define MODULE_SHT21
-//#define MODULE_SWITCH
-//#define MODULE_DS18B20
-//#define MODULE_BH1750
-//#define MODULE_MLX90614
-//#define MODULE_BME280
-//#define MODULE_BMP085
-//#define MODULE_BMP280
-//#define MODULE_SONOFF
-//#define MODULE_HCSR04
-//#define MODULE_MCP9808
-//#define MODULE_MQ
-//#define MODULE_MHZ19
-//#define MODULE_AM2320
-//#define MODULE_TSL2561
-//#define MODULE_PT100
-//#define MODULE_DIMMER
-//#define MODULE_PULSE_METER
-//#define MODULE_PMS
-//#define MODULE_VL53L0X
+//#define USE_ANALOG_INPUT
+//#define USE_THERMISTOR
+//#define USE_ML8511
+//#define USE_ACS712
+//#define USE_DIGITAL_INPUT
+//#define USE_DIGITAL_OUTPUT
+//#define USE_DHT
+#define USE_SHT21
+//#define USE_SWITCH
+//#define USE_DS18B20
+//#define USE_BH1750
+//#define USE_MLX90614
+//#define USE_BME280
+//#define USE_BMP085
+//#define USE_BMP280
+//#define USE_SONOFF
+//#define USE_HCSR04
+//#define USE_MCP9808
+//#define USE_MQ
+//#define USE_MHZ19
+//#define USE_AM2320
+//#define USE_TSL2561
+//#define USE_PT100
+//#define USE_DIMMER
+//#define USE_PULSE_METER
+//#define USE_PMS
+//#define USE_VL53L0X
 
 /***********************************
  * NodeManager advanced settings

--- a/NodeManager.ino
+++ b/NodeManager.ino
@@ -77,7 +77,7 @@ SensorWaterMeter    | 1     | USE_PULSE_METER    | Water meter pulse sensor     
 SensorPlantowerPMS  | 3     | USE_PMS            | Plantower PMS particulate matter sensors (reporting PM<=1.0, PM<=2.5 and PM<=10.0 in µg/m³)       | https://github.com/fu-hsi/pms
 SensorVL53L0X       | 1     | USE_VL53L0X        | VL53L0X laser time-of-flight distance sensor via I²C, sleep pin supported (optional)              | https://github.com/pololu/vl53l0x-arduino
 DisplaySSD1306      | 1     | USE_SSD1306        | SSD1306 128x64 OLED display (I²C); By default displays values of all sensors and children         | https://github.com/greiman/SSD1306Ascii.git
-*/
+SensorSHT31         | 2     | USE_SHT31          | SHT31 sensor, return temperature/humidity based on the attached SHT31 sensor                      | https://github.com/adafruit/Adafruit_SHT31
 
 /**********************************
  * MySensors node configuration
@@ -215,7 +215,8 @@ DisplaySSD1306      | 1     | USE_SSD1306        | SSD1306 128x64 OLED display (
 //#define USE_PULSE_METER
 //#define USE_PMS
 //#define USE_VL53L0X
-#define USE_SSD1306
+//#define USE_SSD1306
+//#define USE_SHT31
 
 /***********************************
  * NodeManager advanced settings
@@ -240,11 +241,13 @@ NodeManager node;
  * Add your sensors below
  */
 
+// built-in sensors
 //SensorBattery battery(node);
 //SensorConfiguration configuration(node);
 //SensorSignal signal(node);
 //PowerManager power(5,6);
 
+// Attached sensors
 //SensorAnalogInput analog(node,A0);
 //SensorLDR ldr(node,A0);
 //SensorRain rain(node,A0);
@@ -283,7 +286,10 @@ NodeManager node;
 //SensorWaterMeter waterMeter(node,3);
 //SensorPlantowerPMS pms(node,6,7);
 //SensorVL53L0X vl53l0x(node, /*XSHUT_PIN=*/2);
-DisplaySSD1306 ssd1306(node);
+//SensorSHT31 sht31(node);
+
+// Other devies
+//DisplaySSD1306 ssd1306(node);
 
 /***********************************
  * Main Sketch

--- a/NodeManager.ino
+++ b/NodeManager.ino
@@ -217,7 +217,9 @@ SensorVL53L0X       | 1     | USE_VL53L0X        | VL53L0X laser time-of-flight 
  */
 
 #define NODEMANAGER_DEBUG
+
 //#define DISABLE_POWER_MANAGER
+//#define DISABLE_INTERRUPTS
 
 /***********************************
  * Load NodeManager Library

--- a/NodeManager.ino
+++ b/NodeManager.ino
@@ -221,7 +221,8 @@ SensorVL53L0X       | 1     | USE_VL53L0X        | VL53L0X laser time-of-flight 
 //#define DISABLE_POWER_MANAGER
 //#define DISABLE_INTERRUPTS
 //#define DISABLE_TRACK_LAST_VALUE
-#define DISABLE_EEPROM
+//#define DISABLE_EEPROM
+#define DISABLE_SLEEP
 
 /***********************************
  * Load NodeManager Library

--- a/NodeManager.ino
+++ b/NodeManager.ino
@@ -86,11 +86,8 @@ SensorVL53L0X       | 1     | USE_VL53L0X        | VL53L0X laser time-of-flight 
 // General settings
 #define SKETCH_NAME "NodeManager"
 #define SKETCH_VERSION "1.0"
-#define MY_BAUD_RATE 9600
 //#define MY_DEBUG
 //#define MY_NODE_ID 99
-//#define MY_SMART_SLEEP_WAIT_DURATION_MS 500
-#define MY_SPLASH_SCREEN_DISABLED
 
 // NRF24 radio settings
 #define MY_RADIO_NRF24
@@ -132,6 +129,13 @@ SensorVL53L0X       | 1     | USE_VL53L0X        | VL53L0X laser time-of-flight 
 //#define OTA_WAIT_PERIOD 300
 //#define FIRMWARE_MAX_REQUESTS 2
 //#define MY_OTA_RETRY 2
+
+// Advanced settings
+#define MY_BAUD_RATE 9600
+//#define MY_SMART_SLEEP_WAIT_DURATION_MS 500
+#define MY_SPLASH_SCREEN_DISABLED
+//#define MY_DISABLE_RAM_ROUTING_TABLE_FEATURE
+//#define MY_DISABLE_SIGNAL_REPORT
 
 /**********************************
  * MySensors gateway configuration
@@ -222,7 +226,7 @@ SensorVL53L0X       | 1     | USE_VL53L0X        | VL53L0X laser time-of-flight 
 //#define DISABLE_INTERRUPTS
 //#define DISABLE_TRACK_LAST_VALUE
 //#define DISABLE_EEPROM
-#define DISABLE_SLEEP
+//#define DISABLE_SLEEP
 
 /***********************************
  * Load NodeManager Library
@@ -299,7 +303,6 @@ void before() {
   //node.setPowerManager(power);
   //battery.setReportIntervalMinutes(30);
   //sht21.children.get(1)->child_id = 5;
-
   
   /*
   * Configure your sensors above

--- a/NodeManager.ino
+++ b/NodeManager.ino
@@ -199,7 +199,7 @@ SensorVL53L0X       | 1     | USE_VL53L0X        | VL53L0X laser time-of-flight 
 //#define USE_BME280
 //#define USE_BMP085
 //#define USE_BMP280
-#define USE_SONOFF
+//#define USE_SONOFF
 //#define USE_HCSR04
 //#define USE_MCP9808
 //#define USE_MQ
@@ -230,9 +230,9 @@ NodeManager node;
  * Add your sensors below
  */
 
-SensorBattery battery(node);
+//SensorBattery battery(node);
 //SensorConfiguration configuration(node);
-SensorSignal signal(node);
+//SensorSignal signal(node);
 //PowerManager power(5,6);
 
 //SensorAnalogInput analog(node,A0);
@@ -259,7 +259,7 @@ SensorSignal signal(node);
 //SensorBME280 bme280(node);
 //SensorBMP085 bmp085(node);
 //SensorBMP280 bmp280(node);
-SensorSonoff sonoff(node);
+//SensorSonoff sonoff(node);
 //SensorHCSR04 hcsr04(node,6);
 //SensorMCP9808 mcp9808(node);
 //SensorMQ mq(node,A0);
@@ -287,7 +287,7 @@ void before() {
   * Configure your sensors below
   */
 
-  node.setReportIntervalSeconds(10);
+  //node.setReportIntervalSeconds(10);
   //node.setReportIntervalMinutes(5);
   //node.setSleepMinutes(5);
   

--- a/NodeManager.ino
+++ b/NodeManager.ino
@@ -181,10 +181,9 @@ SensorVL53L0X       | 1     | MODULE_VL53L0X        | VL53L0X laser time-of-flig
 //#define MY_DEFAULT_TX_LED_PIN  6
 
 /***********************************
- * NodeManager modules
+ * NodeManager sensors
  */
 
-//#define NO_MODULE_POWER_MANAGER
 //#define MODULE_ANALOG_INPUT
 //#define MODULE_THERMISTOR
 //#define MODULE_ML8511
@@ -214,12 +213,16 @@ SensorVL53L0X       | 1     | MODULE_VL53L0X        | VL53L0X laser time-of-flig
 //#define MODULE_VL53L0X
 
 /***********************************
+ * NodeManager advanced settings
+ */
+
+#define NODEMANAGER_DEBUG
+//#define DISABLE_POWER_MANAGER
+
+/***********************************
  * Load NodeManager Library
  */
 
-// enable NodeManager's debug on serial port
-#define NODEMANAGER_DEBUG
-// include NodeManager's library
 #include "NodeManagerLibrary.h"
 NodeManager node;
 

--- a/NodeManager.ino
+++ b/NodeManager.ino
@@ -220,6 +220,7 @@ SensorVL53L0X       | 1     | USE_VL53L0X        | VL53L0X laser time-of-flight 
 
 //#define DISABLE_POWER_MANAGER
 //#define DISABLE_INTERRUPTS
+#define DISABLE_TRACK_LAST_VALUE
 
 /***********************************
  * Load NodeManager Library

--- a/NodeManagerLibrary.h
+++ b/NodeManagerLibrary.h
@@ -1005,7 +1005,7 @@ class SensorSonoff: public Sensor {
 #ifdef USE_HCSR04
 class SensorHCSR04: public Sensor {
   public:
-    SensorHCSR04(NodeManager& node_manager, int pin);
+    SensorHCSR04(NodeManager& node_manager, int pin, int child_id = -255);
     // [101] Arduino pin tied to trigger pin on the ultrasonic sensor (default: the pin set while registering the sensor)
     void setTriggerPin(int value);
     // [102] Arduino pin tied to echo pin on the ultrasonic sensor (default: the pin set while registering the sensor)
@@ -1013,7 +1013,6 @@ class SensorHCSR04: public Sensor {
     // [103] Maximum distance we want to ping for (in centimeters) (default: 300)
     void setMaxDistance(int value);
     // define what to do at each stage of the sketch
-    void onBefore();
     void onSetup();
     void onLoop(Child* child);
     void onReceive(MyMessage* message);
@@ -1032,9 +1031,8 @@ class SensorHCSR04: public Sensor {
 #ifdef USE_MCP9808
 class SensorMCP9808: public Sensor {
   public:
-    SensorMCP9808(NodeManager& node_manager);
+    SensorMCP9808(NodeManager& node_manager, int child_id = -255);
     // define what to do at each stage of the sketch
-    void onBefore();
     void onSetup();
     void onLoop(Child* child);
     void onReceive(MyMessage* message);
@@ -1049,7 +1047,7 @@ class SensorMCP9808: public Sensor {
  #ifdef USE_MQ
 class SensorMQ: public Sensor {
   public:
-    SensorMQ(NodeManager& node_manager, int pin);
+    SensorMQ(NodeManager& node_manager, int pin, int child_id = -255);
     // [101] define the target gas whose ppm has to be returned. 0: LPG, 1: CO, 2: Smoke (default: 1);
     void setTargetGas(int value);
     // [102] define the load resistance on the board, in kilo ohms (default: 1);
@@ -1073,7 +1071,6 @@ class SensorMQ: public Sensor {
     // set the SmokeCurve array (default: {2.3,0.53,-0.44})
     void setSmokeCurve(float *value);
     // define what to do at each stage of the sketch
-    void onBefore();
     void onSetup();
     void onLoop(Child* child);
     void onReceive(MyMessage* message);
@@ -1109,9 +1106,8 @@ class SensorMQ: public Sensor {
 #ifdef USE_MHZ19
 class SensorMHZ19: public Sensor {
   public:
-    SensorMHZ19(NodeManager& node_manager, int rxpin, int txpin);
+    SensorMHZ19(NodeManager& node_manager, int rxpin, int txpin, int child_id = -255);
     // define what to do at each stage of the sketch
-    void onBefore();
     void onSetup();
     void onLoop(Child* child);
     void onReceive(MyMessage* message);
@@ -1129,9 +1125,8 @@ class SensorMHZ19: public Sensor {
 #ifdef USE_AM2320
 class SensorAM2320: public Sensor {
   public:
-    SensorAM2320(NodeManager& node_manager);
+    SensorAM2320(NodeManager& node_manager, int child_id = -255);
     // define what to do at each stage of the sketch
-    void onBefore();
     void onSetup();
     void onLoop(Child* child);
     void onReceive(MyMessage* message);
@@ -1146,7 +1141,7 @@ class SensorAM2320: public Sensor {
 #ifdef USE_TSL2561
 class SensorTSL2561: public Sensor {
   public:
-    SensorTSL2561(NodeManager& node_manager);
+    SensorTSL2561(NodeManager& node_manager, int child_id = -255);
     // [101] set the gain, possible values are SensorTSL2561::GAIN_0X (0), SensorTSL2561::GAIN_16X (1) (default 16x)
     void setGain(int value);
     // [102] set the timing, possible values are SensorTSL2561::INTEGRATIONTIME_13MS (0), SensorTSL2561::INTEGRATIONTIME_101MS (1), SensorTSL2561::INTEGRATIONTIME_402MS (2) (default: 13ms)
@@ -1156,7 +1151,6 @@ class SensorTSL2561: public Sensor {
     // [104] set the i2c address values are SensorTSL2561::ADDR_FLOAT, SensorTSL2561::ADDR_LOW, SensorTSL2561::ADDR_HIGH
     void setAddress(int value);
     // define what to do at each stage of the sketch
-    void onBefore();
     void onSetup();
     void onLoop(Child* child);
     void onReceive(MyMessage* message);
@@ -1189,11 +1183,10 @@ class SensorTSL2561: public Sensor {
 #ifdef USE_PT100
 class SensorPT100: public Sensor {
   public:
-    SensorPT100(NodeManager& node_manager, int pin);
+    SensorPT100(NodeManager& node_manager, int pin, int child_id = -255);
     // [101] set the voltageRef used to compare with analog measures
     void setVoltageRef(float value);
     // define what to do at each stage of the sketch
-    void onBefore();
     void onSetup();
     void onLoop(Child* child);
     void onReceive(MyMessage* message);
@@ -1209,7 +1202,7 @@ class SensorPT100: public Sensor {
 #ifdef USE_DIMMER
 class SensorDimmer: public Sensor {
   public:
-    SensorDimmer(NodeManager& node_manager, int pin);
+    SensorDimmer(NodeManager& node_manager, int pin, int child_id = -255);
     // [101] set the effect to use for a smooth transition, can be one of SensorDimmer::EASE_LINEAR, SensorDimmer::EASE_INSINE, SensorDimmer::EASE_OUTSINE, SensorDimmer::EASE_INOUTSINE (default: EASE_LINEAR)
     void setEasing(int value);
     // [102] the duration of entire the transition in seconds (default: 1)
@@ -1217,7 +1210,6 @@ class SensorDimmer: public Sensor {
     // [103] the duration of a single step of the transition in milliseconds (default: 100)
     void setStepDuration(int value);
     // define what to do at each stage of the sketch
-    void onBefore();
     void onSetup();
     void onLoop(Child* child);
     void onReceive(MyMessage* message);
@@ -1244,7 +1236,7 @@ class SensorDimmer: public Sensor {
 #ifdef USE_PULSE_METER
 class SensorPulseMeter: public Sensor {
   public:
-    SensorPulseMeter(NodeManager& node_manager, int pin);
+    SensorPulseMeter(NodeManager& node_manager, int pin, int child_id = -255);
     // [102] set how many pulses for each unit (e.g. 1000 pulses for 1 kwh of power, 9 pulses for 1 mm of rain, etc.)
     void setPulseFactor(float value);
     // set initial value - internal pull up (default: HIGH)
@@ -1252,7 +1244,6 @@ class SensorPulseMeter: public Sensor {
     // set the interrupt mode to attach to (default: FALLING)
     void setInterruptMode(int value);
     // define what to do at each stage of the sketch
-    void onBefore();
     void onSetup();
     void onLoop(Child* child);
     void onReceive(MyMessage* message);
@@ -1271,9 +1262,7 @@ class SensorPulseMeter: public Sensor {
 */
 class SensorRainGauge: public SensorPulseMeter {
   public:
-    SensorRainGauge(NodeManager& node_manager, int pin);
-    // define what to do at each stage of the sketch
-    void onBefore();
+    SensorRainGauge(NodeManager& node_manager, int pin, int child_id = -255);
 };
 
 /*
@@ -1281,9 +1270,7 @@ class SensorRainGauge: public SensorPulseMeter {
 */
 class SensorPowerMeter: public SensorPulseMeter {
   public:
-    SensorPowerMeter(NodeManager& node_manager, int pin);
-    // define what to do at each stage of the sketch
-    void onBefore();
+    SensorPowerMeter(NodeManager& node_manager, int pin, int child_id = -255);
   protected:
     void _reportTotal(Child* child);
 };
@@ -1293,9 +1280,7 @@ class SensorPowerMeter: public SensorPulseMeter {
 */
 class SensorWaterMeter: public SensorPulseMeter {
   public:
-    SensorWaterMeter(NodeManager& node_manager, int pin);
-    // define what to do at each stage of the sketch
-    void onBefore();
+    SensorWaterMeter(NodeManager& node_manager, int pin, int child_id = -255);
   protected:
     void _reportTotal(Child* child);
 };
@@ -1307,9 +1292,8 @@ class SensorWaterMeter: public SensorPulseMeter {
 #ifdef USE_PMS
 class SensorPlantowerPMS: public Sensor {
   public:
-    SensorPlantowerPMS(NodeManager& node_manager, int rxpin, int txpin);
+    SensorPlantowerPMS(NodeManager& node_manager, int rxpin, int txpin, int child_id = -255);
     // define what to do at each stage of the sketch
-    void onBefore();
     void onSetup();
     void onLoop(Child* child);
     void onReceive(MyMessage* message);
@@ -1331,9 +1315,8 @@ class SensorPlantowerPMS: public Sensor {
 #ifdef USE_VL53L0X
 class SensorVL53L0X: public Sensor {
   public:
-    SensorVL53L0X(NodeManager& node_manager, int xshut_pin);
+    SensorVL53L0X(NodeManager& node_manager, int xshut_pin, int child_id = -255);
     // define what to do at each stage of the sketch
-    void onBefore();
     void onSetup();
     void onLoop(Child* child);
     void onReceive(MyMessage* message);
@@ -1449,7 +1432,7 @@ class NodeManager {
 #ifndef DISABLE_POWER_MANAGER
     void setPowerManager(PowerManager& powerManager);
 #endif
-    int getAvailableChildId(int child_id);
+    int getAvailableChildId(int child_id = -255);
     List<Sensor*> sensors;
     Child* getChild(int child_id);
     Sensor* getSensorWithChild(int child_id);

--- a/NodeManagerLibrary.h
+++ b/NodeManagerLibrary.h
@@ -327,9 +327,11 @@ class Child {
     int presentation = S_CUSTOM;
     int type = V_CUSTOM;
     const char* description = "";
-    Timer* force_update_timer;
     virtual void sendValue();
+#ifndef DISABLE_TRACK_LAST_VALUE
+    Timer* force_update_timer;
     virtual bool isNewValue();
+#endif
   protected:
     int _samples = 0;
     Sensor* _sensor;
@@ -341,10 +343,14 @@ class ChildInt: public Child {
     void setValueInt(int value);
     int getValueInt();
     void sendValue();
+#ifndef DISABLE_TRACK_LAST_VALUE
     bool isNewValue();
+#endif
   private:
     int _value;
+#ifndef DISABLE_TRACK_LAST_VALUE
     int _last_value;
+#endif
     int _total = 0;
 };
 
@@ -354,10 +360,14 @@ class ChildFloat: public Child {
     void setValueFloat(float value);
     float getValueFloat();
     void sendValue();
+#ifndef DISABLE_TRACK_LAST_VALUE
     bool isNewValue();
+#endif
   private:
     float _value;
+#ifndef DISABLE_TRACK_LAST_VALUE
     float _last_value;
+#endif
     float _total = 0;
 };
 
@@ -367,10 +377,14 @@ class ChildDouble: public Child {
     void setValueDouble(double value);
     double getValueDouble();
     void sendValue();
+#ifndef DISABLE_TRACK_LAST_VALUE
     bool isNewValue();
+#endif
   private:
     double _value;
+#ifndef DISABLE_TRACK_LAST_VALUE
     double _last_value;
+#endif
     double _total = 0;
 };
 
@@ -380,10 +394,14 @@ class ChildString: public Child {
     void setValueString(const char* value);
     const char* getValueString();
     void sendValue();
+#ifndef DISABLE_TRACK_LAST_VALUE
     bool isNewValue();
+#endif
   private:
     const char* _value = "";
+#ifndef DISABLE_TRACK_LAST_VALUE
     const char* _last_value = "";
+#endif
 };
 
 /***************************************
@@ -403,10 +421,12 @@ class Sensor {
     void setSamples(int value);
     // [6] If more then one sample has to be taken, set the interval in milliseconds between measurements (default: 0)
     void setSamplesInterval(int value);
+#ifndef DISABLE_TRACK_LAST_VALUE
     // [7] if true will report the measure only if different than the previous one (default: false)
     void setTrackLastValue(bool value);
     // [9] if track last value is enabled, force to send an update after the configured number of minutes
     void setForceUpdateMinutes(int value);
+#endif
 #ifndef DISABLE_POWER_MANAGER
     // to save battery the sensor can be optionally connected to two pins which will act as vcc and ground and activated on demand
     void setPowerPins(int ground_pin, int vcc_pin, int wait_time = 50);
@@ -461,7 +481,9 @@ class Sensor {
     int _pin = -1;
     int _samples = 1;
     int _samples_interval = 0;
+#ifndef DISABLE_TRACK_LAST_VALUE
     bool _track_last_value = false;
+#endif
 #ifndef DISABLE_INTERRUPTS
     int _interrupt_pin = -1;
 #endif

--- a/NodeManagerLibrary.h
+++ b/NodeManagerLibrary.h
@@ -672,7 +672,6 @@ class SensorACS712: public Sensor {
     // [102] set ACS offset (default: 2500);
     void setOffset(int value);
     // define what to do at each stage of the sketch
-    void onBefore();
     void onSetup();
     void onLoop(Child* child);
     void onReceive(MyMessage* message);

--- a/NodeManagerLibrary.h
+++ b/NodeManagerLibrary.h
@@ -232,7 +232,7 @@ private:
    PowerManager
 */
 
-#ifndef NO_MODULE_POWER_MANAGER
+#ifndef DISABLE_POWER_MANAGER
 class PowerManager {
   public:
     PowerManager(int ground_pin, int vcc_pin, int wait_time = 50);
@@ -407,7 +407,7 @@ class Sensor {
     void setTrackLastValue(bool value);
     // [9] if track last value is enabled, force to send an update after the configured number of minutes
     void setForceUpdateMinutes(int value);
-#ifndef NO_MODULE_POWER_MANAGER
+#ifndef DISABLE_POWER_MANAGER
     // to save battery the sensor can be optionally connected to two pins which will act as vcc and ground and activated on demand
     void setPowerPins(int ground_pin, int vcc_pin, int wait_time = 50);
     // [13] manually turn the power on
@@ -429,7 +429,7 @@ class Sensor {
     int getInterruptPin();
     // listen for interrupts on the given pin so interrupt() will be called when occurring
     void setInterrupt(int pin, int mode, int initial);
-#ifndef NO_MODULE_POWER_MANAGER
+#ifndef DISABLE_POWER_MANAGER
     // set a previously configured PowerManager to the sensor so to powering it up with custom pins
     void setPowerManager(PowerManager& powerManager);
 #endif
@@ -459,7 +459,7 @@ class Sensor {
     int _samples_interval = 0;
     bool _track_last_value = false;
     int _interrupt_pin = -1;
-#ifndef NO_MODULE_POWER_MANAGER
+#ifndef DISABLE_POWER_MANAGER
     PowerManager* _powerManager = nullptr;
 #endif
     Timer* _report_timer;
@@ -1405,7 +1405,7 @@ class NodeManager {
     // register a sensor
     void registerSensor(Sensor* sensor);
     // to save battery the sensor can be optionally connected to two pins which will act as vcc and ground and activated on demand
-#ifndef NO_MODULE_POWER_MANAGER
+#ifndef DISABLE_POWER_MANAGER
     void setPowerPins(int ground_pin, int vcc_pin, int wait_time = 50);
     // [24] manually turn the power on
     void powerOn();
@@ -1477,7 +1477,7 @@ class NodeManager {
     void sendMessage(int child_id, int type, float value);
     void sendMessage(int child_id, int type, double value);
     void sendMessage(int child_id, int type, const char* value);
-#ifndef NO_MODULE_POWER_MANAGER
+#ifndef DISABLE_POWER_MANAGER
     void setPowerManager(PowerManager& powerManager);
 #endif
     int getAvailableChildId();
@@ -1485,7 +1485,7 @@ class NodeManager {
     Child* getChild(int child_id);
     Sensor* getSensorWithChild(int child_id);
   private:
-#ifndef NO_MODULE_POWER_MANAGER
+#ifndef DISABLE_POWER_MANAGER
     PowerManager* _powerManager = nullptr;
 #endif
     MyMessage _message;

--- a/NodeManagerLibrary.h
+++ b/NodeManagerLibrary.h
@@ -322,7 +322,7 @@ class Request {
 class Child {
   public:
     Child();
-    Child(Sensor* sensor, int child_id, int presentation, int type, const char* description);
+    Child(Sensor* sensor, int child_id, int presentation, int type, const char* description = "");
     int child_id;
     int presentation = S_CUSTOM;
     int type = V_CUSTOM;
@@ -337,7 +337,7 @@ class Child {
 
 class ChildInt: public Child {
   public:
-    ChildInt(Sensor* sensor, int child_id, int presentation, int type, const char* description);
+    ChildInt(Sensor* sensor, int child_id, int presentation, int type, const char* description = "");
     void setValueInt(int value);
     int getValueInt();
     void sendValue();
@@ -350,7 +350,7 @@ class ChildInt: public Child {
 
 class ChildFloat: public Child {
   public:
-    ChildFloat(Sensor* sensor, int child_id, int presentation, int type, const char* description);
+    ChildFloat(Sensor* sensor, int child_id, int presentation, int type, const char* description = "");
     void setValueFloat(float value);
     float getValueFloat();
     void sendValue();
@@ -363,7 +363,7 @@ class ChildFloat: public Child {
 
 class ChildDouble: public Child {
   public:
-    ChildDouble(Sensor* sensor, int child_id, int presentation, int type, const char* description);
+    ChildDouble(Sensor* sensor, int child_id, int presentation, int type, const char* description = "");
     void setValueDouble(double value);
     double getValueDouble();
     void sendValue();
@@ -376,7 +376,7 @@ class ChildDouble: public Child {
 
 class ChildString: public Child {
   public:
-    ChildString(Sensor* sensor, int child_id, int presentation, int type, const char* description);
+    ChildString(Sensor* sensor, int child_id, int presentation, int type, const char* description = "");
     void setValueString(const char* value);
     const char* getValueString();
     void sendValue();
@@ -393,7 +393,7 @@ class ChildString: public Child {
 class Sensor {
   public:
     Sensor();
-    Sensor(NodeManager& node_manager, int pin);
+    Sensor(NodeManager& node_manager, int pin = -1);
     // return the name of the sensor
     const char* getName();
     // [1] where the sensor is attached to (default: not set)
@@ -470,7 +470,7 @@ class Sensor {
 */
 class SensorBattery: public Sensor {
   public:
-    SensorBattery(NodeManager& nodeManager);
+    SensorBattery(NodeManager& nodeManager, int child_id = BATTERY_CHILD_ID);
     // [102] the expected vcc when the batter is fully discharged, used to calculate the percentage (default: 2.7)
     void setMinVoltage(float value);
     // [103] the expected vcc when the batter is fully charged, used to calculate the percentage (default: 3.3)
@@ -482,7 +482,6 @@ class SensorBattery: public Sensor {
     // [106] if setBatteryInternalVcc() is set to false, the volts per bit ratio used to calculate the battery voltage (default: 0.003363075)
     void setBatteryVoltsPerBit(float value);
     // define what to do at each stage of the sketch
-    void onBefore();
     void onSetup();
     void onLoop(Child* child);
     void onReceive(MyMessage* message);
@@ -499,12 +498,10 @@ class SensorBattery: public Sensor {
 */
 class SensorSignal: public Sensor {
   public:
-    SensorSignal(NodeManager& nodeManager);
+    SensorSignal(NodeManager& nodeManager, int child_id = SIGNAL_CHILD_ID);
     // [101] define which signal report to send. Possible values are SR_UPLINK_QUALITY, SR_TX_POWER_LEVEL, SR_TX_POWER_PERCENT, SR_TX_RSSI, SR_RX_RSSI, SR_TX_SNR, SR_RX_SNR (default: SR_RX_RSSI)
     void setSignalCommand(int value);
     // define what to do at each stage of the sketch
-    void onBefore();
-    void onSetup();
     void onLoop(Child* child);
     void onReceive(MyMessage* message);
   protected:
@@ -531,7 +528,7 @@ class SensorConfiguration: public Sensor {
 */
 class SensorAnalogInput: public Sensor {
   public:
-    SensorAnalogInput(NodeManager& node_manager, int pin);
+    SensorAnalogInput(NodeManager& node_manager, int pin, int child_id = -255);
     // [101] the analog reference to use (default: not set, can be either INTERNAL or DEFAULT)
     void setReference(int value);
     // [102] reverse the value or the percentage (e.g. 70% -> 30%) (default: false)
@@ -543,7 +540,6 @@ class SensorAnalogInput: public Sensor {
     // [105] maximum value for calculating the percentage (default: 1024)
     void setRangeMax(int value);
     // define what to do at each stage of the sketch
-    void onBefore();
     void onSetup();
     void onLoop(Child* child);
     void onReceive(MyMessage* message);
@@ -562,9 +558,8 @@ class SensorAnalogInput: public Sensor {
 */
 class SensorLDR: public SensorAnalogInput {
   public:
-    SensorLDR(NodeManager& node_manager, int pin);
+    SensorLDR(NodeManager& node_manager, int pin, int child_id = -255);
     // define what to do at each stage of the sketch
-    void onBefore();
     void onSetup();
 };
 
@@ -573,9 +568,8 @@ class SensorLDR: public SensorAnalogInput {
 */
 class SensorRain: public SensorAnalogInput {
   public:
-    SensorRain(NodeManager& node_manager, int pin);
+    SensorRain(NodeManager& node_manager, int pin, int child_id = -255);
     // define what to do at each stage of the sketch
-    void onBefore();
     void onSetup();
 };
 
@@ -584,9 +578,8 @@ class SensorRain: public SensorAnalogInput {
 */
 class SensorSoilMoisture: public SensorAnalogInput {
   public:
-    SensorSoilMoisture(NodeManager& node_manager, int pin);
+    SensorSoilMoisture(NodeManager& node_manager, int pin, int child_id = -255);
     // define what to do at each stage of the sketch
-    void onBefore();
     void onSetup();
 };
 #endif
@@ -597,7 +590,7 @@ class SensorSoilMoisture: public SensorAnalogInput {
 */
 class SensorThermistor: public Sensor {
   public:
-    SensorThermistor(NodeManager& node_manager, int pin);
+    SensorThermistor(NodeManager& node_manager, int pin, int child_id = -255);
     // [101] resistance at 25 degrees C (default: 10000)
     void setNominalResistor(long value);
     // [102] temperature for nominal resistance (default: 25)
@@ -609,7 +602,6 @@ class SensorThermistor: public Sensor {
     // [105] set a temperature offset
     void setOffset(float value);
     // define what to do at each stage of the sketch
-    void onBefore();
     void onSetup();
     void onLoop(Child* child);
     void onReceive(MyMessage* message);
@@ -629,9 +621,8 @@ class SensorThermistor: public Sensor {
 
 class SensorML8511: public Sensor {
   public:
-    SensorML8511(NodeManager& node_Manager, int pin);
+    SensorML8511(NodeManager& node_Manager, int pin, int child_id = -255);
     // define what to do at each stage of the sketch
-    void onBefore();
     void onSetup();
     void onLoop(Child* child);
     void onReceive(MyMessage* message);
@@ -647,7 +638,7 @@ class SensorML8511: public Sensor {
 
 class SensorACS712: public Sensor {
   public:
-    SensorACS712(NodeManager& node_manager, int pin);
+    SensorACS712(NodeManager& node_manager, int pin, int child_id = -255);
     // [101] set how many mV are equivalent to 1 Amp. The value depends on the module (100 for 20A Module, 66 for 30A Module) (default: 185);
     void setmVPerAmp(int value);
     // [102] set ACS offset (default: 2500);
@@ -669,9 +660,8 @@ class SensorACS712: public Sensor {
 */
 class SensorDigitalInput: public Sensor {
   public:
-    SensorDigitalInput(NodeManager& node_manager, int pin);
+    SensorDigitalInput(NodeManager& node_manager, int pin, int child_id = -255);
     // define what to do at each stage of the sketch
-    void onBefore();
     void onSetup();
     void onLoop(Child* child);
     void onReceive(MyMessage* message);
@@ -684,7 +674,7 @@ class SensorDigitalInput: public Sensor {
 */
 class SensorDigitalOutput: public Sensor {
   public:
-    SensorDigitalOutput(NodeManager& node_manager, int pin);
+    SensorDigitalOutput(NodeManager& node_manager, int pin, int child_id = -255);
     // [103] define which value to set to the output when set to on (default: HIGH)
     void setOnValue(int value);
     // [104] when legacy mode is enabled expect a REQ message to trigger, otherwise the default SET (default: false)
@@ -699,8 +689,6 @@ class SensorDigitalOutput: public Sensor {
     void setStatus(Child* child, int value);
     // get the current state
     int getStatus();
-    // define what to do at each stage of the sketch
-    void onBefore();
     void onSetup();
     void onLoop(Child* child);
     void onReceive(MyMessage* message);
@@ -721,9 +709,7 @@ class SensorDigitalOutput: public Sensor {
 */
 class SensorRelay: public SensorDigitalOutput {
   public:
-    SensorRelay(NodeManager& node_manager, int pin);
-    // define what to do at each stage of the sketch
-    void onBefore();
+    SensorRelay(NodeManager& node_manager, int pin, int child_id = -255);
 };
 
 /*
@@ -731,7 +717,7 @@ class SensorRelay: public SensorDigitalOutput {
 */
 class SensorLatchingRelay: public SensorRelay {
   public:
-    SensorLatchingRelay(NodeManager& node_manager, int pin);
+    SensorLatchingRelay(NodeManager& node_manager, int pin, int child_id = -255);
     // [201] set the duration of the pulse to send in ms to activate the relay (default: 50)
     void setPulseWidth(int value);
     // [202] set the pin which turns the relay off (default: the pin provided while registering the sensor)
@@ -739,7 +725,6 @@ class SensorLatchingRelay: public SensorRelay {
     // [203] set the pin which turns the relay on (default: the pin provided while registering the sensor + 1)
     void setPinOn(int value);
     // define what to do at each stage of the sketch
-    void onBefore();
     void onSetup();
   protected:
     int _pin_on;
@@ -755,9 +740,8 @@ class SensorLatchingRelay: public SensorRelay {
 #ifdef USE_DHT
 class SensorDHT: public Sensor {
   public:
-    SensorDHT(NodeManager& node_manager, int pin);
+    SensorDHT(NodeManager& node_manager, int pin, int child_id = -255);
     // define what to do at each stage of the sketch
-    void onBefore();
     void onSetup();
     void onLoop(Child* child);
     void onReceive(MyMessage* message);
@@ -772,7 +756,7 @@ class SensorDHT: public Sensor {
 */
 class SensorDHT11: public SensorDHT {
   public:
-    SensorDHT11(NodeManager& node_manager, int pin);
+    SensorDHT11(NodeManager& node_manager, int pin, int child_id = -255);
 };
 
 /*
@@ -780,7 +764,7 @@ class SensorDHT11: public SensorDHT {
 */
 class SensorDHT22: public SensorDHT {
   public:
-    SensorDHT22(NodeManager& node_manager, int pin);
+    SensorDHT22(NodeManager& node_manager, int pin, int child_id = -255);
 };
 #endif
 
@@ -790,9 +774,8 @@ class SensorDHT22: public SensorDHT {
 #ifdef USE_SHT21
 class SensorSHT21: public Sensor {
   public:
-    SensorSHT21(NodeManager& node_manager);
+    SensorSHT21(NodeManager& node_manager, int child_id = -255);
     // define what to do at each stage of the sketch
-    void onBefore();
     void onSetup();
     void onLoop(Child* child);
     void onReceive(MyMessage* message);
@@ -805,7 +788,7 @@ class SensorSHT21: public Sensor {
 
 class SensorHTU21D: public SensorSHT21 {
   public:
-    SensorHTU21D(NodeManager& nodeManager);
+    SensorHTU21D(NodeManager& nodeManager, int child_id = -255);
 };
 #endif
 
@@ -815,7 +798,7 @@ class SensorHTU21D: public SensorSHT21 {
 #ifdef USE_SWITCH
 class SensorSwitch: public Sensor {
   public:
-    SensorSwitch(NodeManager& node_manager, int pin);
+    SensorSwitch(NodeManager& node_manager, int pin, int child_id = -255);
     // [101] set the interrupt mode. Can be CHANGE, RISING, FALLING (default: CHANGE)
     void setMode(int value);
     // [102] milliseconds to wait before reading the input (default: 0)
@@ -825,7 +808,6 @@ class SensorSwitch: public Sensor {
     // [104] Set initial value on the interrupt pin (default: HIGH)
     void setInitial(int value);
     // define what to do at each stage of the sketch
-    void onBefore();
     void onSetup();
     void onLoop(Child* child);
     void onReceive(MyMessage* message);
@@ -842,8 +824,7 @@ class SensorSwitch: public Sensor {
  */
 class SensorDoor: public SensorSwitch {
   public:
-    SensorDoor(NodeManager& node_manager, int pin);
-    void onBefore();
+    SensorDoor(NodeManager& node_manager, int pin, int child_id = -255);
 };
 
 /*
@@ -851,8 +832,7 @@ class SensorDoor: public SensorSwitch {
  */
 class SensorMotion: public SensorSwitch {
   public:
-    SensorMotion(NodeManager& node_manager, int pin);
-    void onBefore();
+    SensorMotion(NodeManager& node_manager, int pin, int child_id = -255);
     void onSetup();
 };
 #endif
@@ -862,7 +842,7 @@ class SensorMotion: public SensorSwitch {
 #ifdef USE_DS18B20
 class SensorDs18b20: public Sensor {
   public:
-    SensorDs18b20(NodeManager& node_manager, int pin);
+    SensorDs18b20(NodeManager& node_manager, int pin, int child_id = -255);
     // returns the sensor's resolution in bits
     int getResolution();
     // [101] set the sensor's resolution in bits
@@ -870,8 +850,6 @@ class SensorDs18b20: public Sensor {
     // [102] sleep while DS18B20 calculates temperature (default: false)
     void setSleepDuringConversion(bool value);
     // define what to do at each stage of the sketch
-    void onBefore();
-    void onSetup();
     void onLoop(Child* child);
     void onReceive(MyMessage* message);
   protected:
@@ -886,11 +864,10 @@ class SensorDs18b20: public Sensor {
 #ifdef USE_BH1750
 class SensorBH1750: public Sensor {
   public:
-    SensorBH1750(NodeManager& node_manager);
+    SensorBH1750(NodeManager& node_manager, int child_id = -255);
     // [101] set sensor reading mode, e.g. BH1750_ONE_TIME_HIGH_RES_MODE
     void setMode(uint8_t mode);
     // define what to do at each stage of the sketch
-    void onBefore();
     void onSetup();
     void onLoop(Child* child);
     void onReceive(MyMessage* message);
@@ -905,9 +882,8 @@ class SensorBH1750: public Sensor {
 #ifdef USE_MLX90614
 class SensorMLX90614: public Sensor {
   public:
-    SensorMLX90614(NodeManager& node_manager);
+    SensorMLX90614(NodeManager& node_manager, int child_id = -255);
     // define what to do at each stage of the sketch
-    void onBefore();
     void onSetup();
     void onLoop(Child* child);
     void onReceive(MyMessage* message);
@@ -925,13 +901,10 @@ class SensorMLX90614: public Sensor {
 #if defined(USE_BME280) || defined(USE_BMP085) || defined(USE_BMP280)
 class SensorBosch: public Sensor {
   public:
-    SensorBosch(NodeManager& node_manager);
+    SensorBosch(NodeManager& node_manager, int child_id = -255);
     // [101] define how many pressure samples to keep track of for calculating the forecast (default: 5)
     void setForecastSamplesCount(int value);
     // define what to do at each stage of the sketch
-    void onBefore();
-    void onSetup();
-    void onLoop(Child* child);
     void onReceive(MyMessage* message);
     static uint8_t GetI2CAddress(uint8_t chip_id);
   protected:
@@ -954,9 +927,8 @@ class SensorBosch: public Sensor {
 #ifdef USE_BME280
 class SensorBME280: public SensorBosch {
   public:
-    SensorBME280(NodeManager& node_manager);
+    SensorBME280(NodeManager& node_manager, int child_id = -255);
     // define what to do at each stage of the sketch
-    void onBefore();
     void onSetup();
     void onLoop(Child* child);
   protected:
@@ -970,9 +942,8 @@ class SensorBME280: public SensorBosch {
 #ifdef USE_BMP085
 class SensorBMP085: public SensorBosch {
   public:
-    SensorBMP085(NodeManager& node_manager);
+    SensorBMP085(NodeManager& node_manager, int child_id = -255);
     // define what to do at each stage of the sketch
-    void onBefore();
     void onSetup();
     void onLoop(Child* child);
   protected:
@@ -986,9 +957,8 @@ class SensorBMP085: public SensorBosch {
 #ifdef USE_BMP280
 class SensorBMP280: public SensorBosch {
   public:
-    SensorBMP280(NodeManager& node_manager);
+    SensorBMP280(NodeManager& node_manager, int child_id = -255);
     // define what to do at each stage of the sketch
-    void onBefore();
     void onSetup();
     void onLoop(Child* child);
   protected:
@@ -1002,7 +972,7 @@ class SensorBMP280: public SensorBosch {
 #ifdef USE_SONOFF
 class SensorSonoff: public Sensor {
   public:
-    SensorSonoff(NodeManager& node_manager);
+    SensorSonoff(NodeManager& node_manager, int child_id = -255);
     // [101] set the button's pin (default: 0)
     void setButtonPin(int value);
     // [102] set the relay's pin (default: 12)
@@ -1010,7 +980,6 @@ class SensorSonoff: public Sensor {
     // [103] set the led's pin (default: 13)
     void setLedPin(int value);
     // define what to do at each stage of the sketch
-    void onBefore();
     void onSetup();
     void onLoop(Child* child);
     void onReceive(MyMessage* message);
@@ -1480,7 +1449,7 @@ class NodeManager {
 #ifndef DISABLE_POWER_MANAGER
     void setPowerManager(PowerManager& powerManager);
 #endif
-    int getAvailableChildId();
+    int getAvailableChildId(int child_id);
     List<Sensor*> sensors;
     Child* getChild(int child_id);
     Sensor* getSensorWithChild(int child_id);

--- a/NodeManagerLibrary.h
+++ b/NodeManagerLibrary.h
@@ -152,6 +152,10 @@
   #include <Wire.h>
   #include <VL53L0X.h>
 #endif
+#ifdef USE_SSD1306
+  #include <SSD1306Ascii.h>
+  #include <SSD1306AsciiAvrI2c.h>
+#endif
 
 /*******************************************************************
    Classes
@@ -328,6 +332,7 @@ class Child {
     int type = V_CUSTOM;
     const char* description = "";
     virtual void sendValue();
+    virtual void printOn(Print& p);
 #ifndef DISABLE_TRACK_LAST_VALUE
     Timer* force_update_timer;
     virtual bool isNewValue();
@@ -343,6 +348,7 @@ class ChildInt: public Child {
     void setValueInt(int value);
     int getValueInt();
     void sendValue();
+    void printOn(Print& p);
 #ifndef DISABLE_TRACK_LAST_VALUE
     bool isNewValue();
 #endif
@@ -360,6 +366,7 @@ class ChildFloat: public Child {
     void setValueFloat(float value);
     float getValueFloat();
     void sendValue();
+    void printOn(Print& p);
 #ifndef DISABLE_TRACK_LAST_VALUE
     bool isNewValue();
 #endif
@@ -377,6 +384,7 @@ class ChildDouble: public Child {
     void setValueDouble(double value);
     double getValueDouble();
     void sendValue();
+    void printOn(Print& p);
 #ifndef DISABLE_TRACK_LAST_VALUE
     bool isNewValue();
 #endif
@@ -394,6 +402,7 @@ class ChildString: public Child {
     void setValueString(const char* value);
     const char* getValueString();
     void sendValue();
+    void printOn(Print& p);
 #ifndef DISABLE_TRACK_LAST_VALUE
     bool isNewValue();
 #endif
@@ -1351,7 +1360,46 @@ class SensorVL53L0X: public Sensor {
     int _getDistance();
     VL53L0X *_lox;
 };
+#endif
 
+/*
+ * SSD1306 OLED display
+ */
+#ifdef USE_SSD1306
+class DisplaySSD1306: public Sensor {
+  public:
+    DisplaySSD1306(NodeManager& node_manager, int child_id = -255);
+    // set device
+    void setDev(const DevType* dev);
+    // set i2c address
+    void setI2CAddress(uint8_t i2caddress);
+    // set text font (default: &Adafruit5x7)
+    void setFont(const uint8_t* font);
+    // [102] set the contrast of the display (0-255)
+    void setContrast(uint8_t value);
+    // [103] set the displayed text
+    void setText(const char* value);
+    // [104] Rotate the display 180 degree (use rotate=false to revert)
+    void rotateDisplay(bool rotate = true);
+    // [105] Text font size (possible are 1 and 2; default is 1)
+    void setFontSize(int fontsize);
+    // [106] Text caption font size (possible are 1 and 2; default is 2)
+    void setHeaderFontSize(int fontsize);
+    // [107] Invert display (black text on color background; use invert=false to revert)
+    void invertDisplay(bool invert = true);
+    // define what to do at each stage of the sketch
+    void onSetup();
+    void onLoop(Child* child);
+    void onReceive(MyMessage* message);
+    void updateDisplay();
+  protected:
+    virtual void _display(const char*displaystr = 0);
+    SSD1306AsciiAvrI2c *_oled;
+    const DevType* _dev = &Adafruit128x64;
+    uint8_t _i2caddress = 0x3c;
+    int _fontsize = 1;
+    int _caption_fontsize = 2;
+};
 #endif
 
 /***************************************

--- a/NodeManagerLibrary.h
+++ b/NodeManagerLibrary.h
@@ -156,6 +156,10 @@
   #include <SSD1306Ascii.h>
   #include <SSD1306AsciiAvrI2c.h>
 #endif
+#ifdef USE_SHT31
+  #include <Wire.h>
+  #include "Adafruit_SHT31.h"
+#endif
 
 /*******************************************************************
    Classes
@@ -1399,6 +1403,22 @@ class DisplaySSD1306: public Sensor {
     uint8_t _i2caddress = 0x3c;
     int _fontsize = 1;
     int _caption_fontsize = 2;
+};
+#endif
+
+/*
+   SensorSHT31: temperature and humidity sensor
+*/
+#ifdef USE_SHT31
+class SensorSHT31: public Sensor {
+  public:
+    SensorSHT31(NodeManager& node_manager, int child_id = -255);
+    // define what to do at each stage of the sketch
+    void onSetup();
+    void onLoop(Child* child);
+    void onReceive(MyMessage* message);
+  protected:
+    Adafruit_SHT31* _sht31;
 };
 #endif
 

--- a/NodeManagerLibrary.h
+++ b/NodeManagerLibrary.h
@@ -1364,6 +1364,7 @@ class NodeManager {
     // [10] send the same message multiple times (default: 1)
     void setRetries(int value);
     int getRetries();
+#ifndef DISABLE_SLEEP
     // [3] set the duration (in seconds) of a sleep cycle
     void setSleepSeconds(int value);
     long getSleepSeconds();
@@ -1373,6 +1374,7 @@ class NodeManager {
     void setSleepHours(int value);
     // [29] set the duration (in days) of a sleep cycle
     void setSleepDays(int value);
+#endif
 #ifndef DISABLE_INTERRUPTS
     // [19] if enabled, when waking up from the interrupt, the board stops sleeping. Disable it when attaching e.g. a motion sensor (default: true)
     void setSleepInterruptPin(int value);

--- a/NodeManagerLibrary.h
+++ b/NodeManagerLibrary.h
@@ -83,72 +83,72 @@
 #include <MySensors.h>
 
 // include third party libraries
-#ifdef MODULE_DHT
+#ifdef USE_DHT
   #include <DHT.h>
 #endif
-#ifdef MODULE_SHT21
+#ifdef USE_SHT21
   #include <Wire.h>
   #include <Sodaq_SHT2x.h>
 #endif
-#ifdef MODULE_DS18B20
+#ifdef USE_DS18B20
   #include <OneWire.h>
   #include <DallasTemperature.h>
 #endif
-#ifdef MODULE_BH1750
+#ifdef USE_BH1750
   #include <BH1750.h>
   #include <Wire.h>
 #endif
-#ifdef MODULE_MLX90614
+#ifdef USE_MLX90614
   #include <Wire.h>
   #include <Adafruit_MLX90614.h>
 #endif
-#ifdef MODULE_BME280
+#ifdef USE_BME280
   #include <Wire.h>
   #include <SPI.h>
   #include <Adafruit_Sensor.h>
   #include <Adafruit_BME280.h>
 #endif
-#ifdef MODULE_SONOFF
+#ifdef USE_SONOFF
   #include <Bounce2.h>
 #endif
-#ifdef MODULE_BMP085
+#ifdef USE_BMP085
   #include <Wire.h>
   #include <Adafruit_BMP085.h>
 #endif
-#ifdef MODULE_HCSR04
+#ifdef USE_HCSR04
   #include <NewPing.h>
 #endif
-#ifdef MODULE_MCP9808
+#ifdef USE_MCP9808
   #include <Wire.h>
   #include "Adafruit_MCP9808.h"
 #endif
-#ifdef MODULE_MHZ19
+#ifdef USE_MHZ19
   #include <SoftwareSerial.h>
 #endif
-#ifdef MODULE_AM2320
+#ifdef USE_AM2320
   #include <Wire.h>
   #include <AM2320.h>
 #endif
-#ifdef MODULE_TSL2561
+#ifdef USE_TSL2561
   #include <TSL2561.h>
   #include <Wire.h>
 #endif
-#ifdef MODULE_PT100
+#ifdef USE_PT100
   #include <DFRobotHighTemperatureSensor.h>
 #endif
-#ifdef MODULE_BMP280
+#ifdef USE_BMP280
   #include <Wire.h>
   #include <Adafruit_Sensor.h>
   #include <Adafruit_BMP280.h>
 #endif
-#ifdef MODULE_DIMMER
+#ifdef USE_DIMMER
   #include <math.h>
 #endif
-#ifdef MODULE_PMS
+#ifdef USE_PMS
   #include <PMS.h>
   #include <SoftwareSerial.h> 
 #endif
-#ifdef MODULE_VL53L0X
+#ifdef USE_VL53L0X
   #include <Wire.h>
   #include <VL53L0X.h>
 #endif
@@ -525,7 +525,7 @@ class SensorConfiguration: public Sensor {
   protected:
 };
 
-#ifdef MODULE_ANALOG_INPUT
+#ifdef USE_ANALOG_INPUT
 /*
    SensorAnalogInput: read the analog input of a configured pin
 */
@@ -591,7 +591,7 @@ class SensorSoilMoisture: public SensorAnalogInput {
 };
 #endif
 
-#ifdef MODULE_THERMISTOR
+#ifdef USE_THERMISTOR
 /*
    SensorThermistor: read the temperature from a thermistor
 */
@@ -622,7 +622,7 @@ class SensorThermistor: public Sensor {
 };
 #endif
 
-#ifdef MODULE_ML8511
+#ifdef USE_ML8511
 /*
     SensorML8511
 */
@@ -640,7 +640,7 @@ class SensorML8511: public Sensor {
 };
 #endif
 
-#ifdef MODULE_ACS712
+#ifdef USE_ACS712
 /*
     SensorACS712
 */
@@ -663,7 +663,7 @@ class SensorACS712: public Sensor {
 };
 #endif
 
-#ifdef MODULE_DIGITAL_INPUT
+#ifdef USE_DIGITAL_INPUT
 /*
    SensorDigitalInput: read the digital input of the configured pin
 */
@@ -678,7 +678,7 @@ class SensorDigitalInput: public Sensor {
 };
 #endif
 
-#ifdef MODULE_DIGITAL_OUTPUT
+#ifdef USE_DIGITAL_OUTPUT
 /*
    SensorDigitalOutput: control a digital output of the configured pin
 */
@@ -752,7 +752,7 @@ class SensorLatchingRelay: public SensorRelay {
 /*
    SensorDHT
 */
-#ifdef MODULE_DHT
+#ifdef USE_DHT
 class SensorDHT: public Sensor {
   public:
     SensorDHT(NodeManager& node_manager, int pin);
@@ -787,7 +787,7 @@ class SensorDHT22: public SensorDHT {
 /*
    SensorSHT21: temperature and humidity sensor
 */
-#ifdef MODULE_SHT21
+#ifdef USE_SHT21
 class SensorSHT21: public Sensor {
   public:
     SensorSHT21(NodeManager& node_manager);
@@ -812,7 +812,7 @@ class SensorHTU21D: public SensorSHT21 {
 /*
  * SensorSwitch
  */
-#ifdef MODULE_SWITCH
+#ifdef USE_SWITCH
 class SensorSwitch: public Sensor {
   public:
     SensorSwitch(NodeManager& node_manager, int pin);
@@ -859,7 +859,7 @@ class SensorMotion: public SensorSwitch {
 /*
    SensorDs18b20
 */
-#ifdef MODULE_DS18B20
+#ifdef USE_DS18B20
 class SensorDs18b20: public Sensor {
   public:
     SensorDs18b20(NodeManager& node_manager, int pin);
@@ -883,7 +883,7 @@ class SensorDs18b20: public Sensor {
 /*
    SensorBH1750
 */
-#ifdef MODULE_BH1750
+#ifdef USE_BH1750
 class SensorBH1750: public Sensor {
   public:
     SensorBH1750(NodeManager& node_manager);
@@ -902,7 +902,7 @@ class SensorBH1750: public Sensor {
 /*
    SensorMLX90614
 */
-#ifdef MODULE_MLX90614
+#ifdef USE_MLX90614
 class SensorMLX90614: public Sensor {
   public:
     SensorMLX90614(NodeManager& node_manager);
@@ -922,7 +922,7 @@ class SensorMLX90614: public Sensor {
  * SensorBosch
 */
 
-#if defined(MODULE_BME280) || defined(MODULE_BMP085) || defined(MODULE_BMP280)
+#if defined(USE_BME280) || defined(USE_BMP085) || defined(USE_BMP280)
 class SensorBosch: public Sensor {
   public:
     SensorBosch(NodeManager& node_manager);
@@ -951,7 +951,7 @@ class SensorBosch: public Sensor {
 /*
    SensorBME280
 */
-#ifdef MODULE_BME280
+#ifdef USE_BME280
 class SensorBME280: public SensorBosch {
   public:
     SensorBME280(NodeManager& node_manager);
@@ -967,7 +967,7 @@ class SensorBME280: public SensorBosch {
 /*
    SensorBMP085
 */
-#ifdef MODULE_BMP085
+#ifdef USE_BMP085
 class SensorBMP085: public SensorBosch {
   public:
     SensorBMP085(NodeManager& node_manager);
@@ -983,7 +983,7 @@ class SensorBMP085: public SensorBosch {
 /*
    SensorBMP280
 */
-#ifdef MODULE_BMP280
+#ifdef USE_BMP280
 class SensorBMP280: public SensorBosch {
   public:
     SensorBMP280(NodeManager& node_manager);
@@ -999,7 +999,7 @@ class SensorBMP280: public SensorBosch {
 /*
    SensorSonoff
 */
-#ifdef MODULE_SONOFF
+#ifdef USE_SONOFF
 class SensorSonoff: public Sensor {
   public:
     SensorSonoff(NodeManager& node_manager);
@@ -1033,7 +1033,7 @@ class SensorSonoff: public Sensor {
 /*
    SensorHCSR04
 */
-#ifdef MODULE_HCSR04
+#ifdef USE_HCSR04
 class SensorHCSR04: public Sensor {
   public:
     SensorHCSR04(NodeManager& node_manager, int pin);
@@ -1060,7 +1060,7 @@ class SensorHCSR04: public Sensor {
 /*
    SensorMCP9808
 */
-#ifdef MODULE_MCP9808
+#ifdef USE_MCP9808
 class SensorMCP9808: public Sensor {
   public:
     SensorMCP9808(NodeManager& node_manager);
@@ -1077,7 +1077,7 @@ class SensorMCP9808: public Sensor {
 /*
     SensorMQ
  */
- #ifdef MODULE_MQ
+ #ifdef USE_MQ
 class SensorMQ: public Sensor {
   public:
     SensorMQ(NodeManager& node_manager, int pin);
@@ -1137,7 +1137,7 @@ class SensorMQ: public Sensor {
 /*
    SensorMHZ19
 */
-#ifdef MODULE_MHZ19
+#ifdef USE_MHZ19
 class SensorMHZ19: public Sensor {
   public:
     SensorMHZ19(NodeManager& node_manager, int rxpin, int txpin);
@@ -1157,7 +1157,7 @@ class SensorMHZ19: public Sensor {
 /*
    SensorAM2320
 */
-#ifdef MODULE_AM2320
+#ifdef USE_AM2320
 class SensorAM2320: public Sensor {
   public:
     SensorAM2320(NodeManager& node_manager);
@@ -1174,7 +1174,7 @@ class SensorAM2320: public Sensor {
 /*
    SensorTSL2561
 */
-#ifdef MODULE_TSL2561
+#ifdef USE_TSL2561
 class SensorTSL2561: public Sensor {
   public:
     SensorTSL2561(NodeManager& node_manager);
@@ -1217,7 +1217,7 @@ class SensorTSL2561: public Sensor {
 /*
     SensorPT100
 */
-#ifdef MODULE_PT100
+#ifdef USE_PT100
 class SensorPT100: public Sensor {
   public:
     SensorPT100(NodeManager& node_manager, int pin);
@@ -1237,7 +1237,7 @@ class SensorPT100: public Sensor {
 /*
     SensorPT100
 */
-#ifdef MODULE_DIMMER
+#ifdef USE_DIMMER
 class SensorDimmer: public Sensor {
   public:
     SensorDimmer(NodeManager& node_manager, int pin);
@@ -1272,7 +1272,7 @@ class SensorDimmer: public Sensor {
 /*
     SensorPulseMeter
 */
-#ifdef MODULE_PULSE_METER
+#ifdef USE_PULSE_METER
 class SensorPulseMeter: public Sensor {
   public:
     SensorPulseMeter(NodeManager& node_manager, int pin);
@@ -1335,7 +1335,7 @@ class SensorWaterMeter: public SensorPulseMeter {
 /*
    SensorPlantowerPMS
 */
-#ifdef MODULE_PMS
+#ifdef USE_PMS
 class SensorPlantowerPMS: public Sensor {
   public:
     SensorPlantowerPMS(NodeManager& node_manager, int rxpin, int txpin);
@@ -1359,7 +1359,7 @@ class SensorPlantowerPMS: public Sensor {
 /*
  * VL53L0X Laser distance sensor
  */
-#ifdef MODULE_VL53L0X
+#ifdef USE_VL53L0X
 class SensorVL53L0X: public Sensor {
   public:
     SensorVL53L0X(NodeManager& node_manager, int xshut_pin);

--- a/NodeManagerLibrary.h
+++ b/NodeManagerLibrary.h
@@ -1412,14 +1412,18 @@ class NodeManager {
     void hello();
     // [6] reboot the board
     void reboot();
-    // [7] clear the EEPROM
-    void clearEeprom();
     // [9] wake up the board
     void wakeup();
+#ifndef DISABLE_EEPROM
+    // [7] clear the EEPROM
+    void clearEeprom();
     // return the value stored at the requested index from the EEPROM
     int loadFromMemory(int index);
     // [27] save the given index of the EEPROM the provided value
     void saveToMemory(int index, int value);
+    // [40] if set save the sleep settings in memory, also when changed remotely (default: false)
+    void setSaveSleepSettings(bool value);
+#endif
     // return vcc in V
     float getVcc();
 #ifndef DISABLE_INTERRUPTS
@@ -1444,8 +1448,6 @@ class NodeManager {
     void setRebootPin(int value);
     // [32] turn the ADC off so to save 0.2 mA
     void setADCOff();
-    // [30] if set save the sleep settings in memory, also when changed remotely (default: false)
-    void setSaveSleepSettings(bool value);
     // hook into the main sketch functions
     void before();
     void presentation();
@@ -1500,9 +1502,11 @@ class NodeManager {
     int _report_interval_seconds = 10*60;
     bool _sleep_or_wait = true;
     int _reboot_pin = -1;
+#ifndef DISABLE_EEPROM
     bool _save_sleep_settings = false;
     void _loadSleepSettings();
     void _saveSleepSettings();
+#endif
 };
 
 #endif

--- a/NodeManagerLibrary.h
+++ b/NodeManagerLibrary.h
@@ -425,10 +425,12 @@ class Sensor {
     void setReportIntervalDays(int value);
     // return true if the report interval has been already configured
     bool isReportIntervalConfigured();
+#ifndef DISABLE_INTERRUPTS
     // return the pin the interrupt is attached to
     int getInterruptPin();
     // listen for interrupts on the given pin so interrupt() will be called when occurring
     void setInterrupt(int pin, int mode, int initial);
+#endif
 #ifndef DISABLE_POWER_MANAGER
     // set a previously configured PowerManager to the sensor so to powering it up with custom pins
     void setPowerManager(PowerManager& powerManager);
@@ -440,7 +442,9 @@ class Sensor {
     void presentation();
     void setup();
     void loop(MyMessage* message);
+#ifndef DISABLE_INTERRUPTS
     void interrupt();
+#endif
     void receive(MyMessage &message);
     // abstract functions, subclasses need to implement
     virtual void onBefore();
@@ -458,7 +462,9 @@ class Sensor {
     int _samples = 1;
     int _samples_interval = 0;
     bool _track_last_value = false;
+#ifndef DISABLE_INTERRUPTS
     int _interrupt_pin = -1;
+#endif
 #ifndef DISABLE_POWER_MANAGER
     PowerManager* _powerManager = nullptr;
 #endif
@@ -1345,12 +1351,14 @@ class NodeManager {
     void setSleepHours(int value);
     // [29] set the duration (in days) of a sleep cycle
     void setSleepDays(int value);
+#ifndef DISABLE_INTERRUPTS
     // [19] if enabled, when waking up from the interrupt, the board stops sleeping. Disable it when attaching e.g. a motion sensor (default: true)
     void setSleepInterruptPin(int value);
     // configure the interrupt pin and mode. Mode can be CHANGE, RISING, FALLING (default: MODE_NOT_DEFINED)
     void setInterrupt(int pin, int mode, int initial = -1);
     // [28] ignore two consecutive interrupts if happening within this timeframe in milliseconds (default: 100)
     void setInterruptMinDelta(long value);
+#endif
     // [20] optionally sleep interval in milliseconds before sending each message to the radio network (default: 0)
     void setSleepBetweenSend(int value);
     int getSleepBetweenSend();
@@ -1392,10 +1400,12 @@ class NodeManager {
     void saveToMemory(int index, int value);
     // return vcc in V
     float getVcc();
+#ifndef DISABLE_INTERRUPTS
     // setup the configured interrupt pins
     void setupInterrupts();
     // return the pin from which the last interrupt came
     int getLastInterruptPin();
+#endif
     // [36] set the default interval in minutes all the sensors will report their measures. If the same function is called on a specific sensor, this will not change the previously set value. or sleeping sensors, the elapsed time can be evaluated only upon wake up (default: 10 minutes)
     void setReportIntervalSeconds(int value);
     // [37] set the default interval in minutes all the sensors will report their measures. If the same function is called on a specific sensor, this will not change the previously set value. or sleeping sensors, the elapsed time can be evaluated only upon wake up (default: 10 minutes)
@@ -1421,9 +1431,11 @@ class NodeManager {
     void loop();
     void receive(MyMessage & msg);
     void receiveTime(unsigned long ts);
+#ifndef DISABLE_INTERRUPTS
     // handle interrupts
     static void _onInterrupt_1();
     static void _onInterrupt_2();
+#endif
     // send a message by providing the source child, type of the message and value
 	  void sendMessage(int child_id, int type, int value);
     void sendMessage(int child_id, int type, float value);
@@ -1447,6 +1459,7 @@ class NodeManager {
     int _sleep_interrupt_pin = -1;
     int _sleep_between_send = 0;
     int _retries = 1;
+#ifndef DISABLE_INTERRUPTS
     int _interrupt_1_mode = MODE_NOT_DEFINED;
     int _interrupt_2_mode = MODE_NOT_DEFINED;
     int _interrupt_1_initial = -1;
@@ -1455,6 +1468,7 @@ class NodeManager {
     static long _interrupt_min_delta;
     static long _last_interrupt_1;
     static long _last_interrupt_2;
+#endif
     long _timestamp = -1;
     bool _ack = false;
     void _sleep();

--- a/NodeManagerLibrary.ino
+++ b/NodeManagerLibrary.ino
@@ -2114,10 +2114,12 @@ void SensorSonoff::_blink() {
 */
 #ifdef USE_HCSR04
 // contructor
-SensorHCSR04::SensorHCSR04(NodeManager& node_manager, int pin): Sensor(node_manager, pin) {
+SensorHCSR04::SensorHCSR04(NodeManager& node_manager, int pin, int child_id): Sensor(node_manager, pin) {
   _name = "HCSR04";
   _trigger_pin = pin;
   _echo_pin = pin;
+  children.allocateBlocks(1);
+  new ChildInt(this,_node->getAvailableChildId(child_id),S_DISTANCE,V_DISTANCE,_name);
 }
 
 // setter/getter
@@ -2129,12 +2131,6 @@ void SensorHCSR04::setEchoPin(int value) {
 }
 void SensorHCSR04::setMaxDistance(int value) {
   _max_distance = value;
-}
-
-// what to do during before
-void SensorHCSR04::onBefore() {
-  // register the child
-  new ChildInt(this,_node->getAvailableChildId(),S_DISTANCE,V_DISTANCE);
 }
 
 // what to do during setup
@@ -2169,13 +2165,10 @@ void SensorHCSR04::onReceive(MyMessage* message) {
 */
 #ifdef USE_MCP9808
 // contructor
-SensorMCP9808::SensorMCP9808(NodeManager& node_manager): Sensor(node_manager) {
+SensorMCP9808::SensorMCP9808(NodeManager& node_manager, int child_id): Sensor(node_manager) {
   _name = "MCP9808";
-}
-
-// what to do during before
-void SensorMCP9808::onBefore() {
-  new ChildFloat(this,_node->getAvailableChildId(),S_TEMP,V_TEMP);
+  children.allocateBlocks(1);
+  new ChildFloat(this,_node->getAvailableChildId(child_id),S_TEMP,V_TEMP,_name);
 }
 
 // what to do during setup
@@ -2216,11 +2209,13 @@ float SensorMQ::_default_LPGCurve[3] = {2.3,0.21,-0.47};
 float SensorMQ::_default_COCurve[3] = {2.3,0.72,-0.34};
 float SensorMQ::_default_SmokeCurve[3] = {2.3,0.53,-0.44};
 
-SensorMQ::SensorMQ(NodeManager& node_manager, int pin): Sensor(node_manager, pin) {
+SensorMQ::SensorMQ(NodeManager& node_manager, int pin, int child_id): Sensor(node_manager, pin) {
   _name = "MQ";
   _LPGCurve = SensorMQ::_default_LPGCurve;
   _COCurve = SensorMQ::_default_COCurve;
   _SmokeCurve = SensorMQ::_default_SmokeCurve;
+  children.allocateBlocks(1);
+  new ChildInt(this,_node->getAvailableChildId(child_id),S_AIR_QUALITY,V_LEVEL,_name);
 }
 
 //setter/getter
@@ -2258,16 +2253,10 @@ void SensorMQ::setSmokeCurve(float *value) {
   _SmokeCurve = value;
 }
 
-// what to do during before
-void SensorMQ::onBefore() {
-  // prepare the pin for input
-  pinMode(_pin, INPUT);
-  // register the child
-  new ChildInt(this,_node->getAvailableChildId(),S_AIR_QUALITY,V_LEVEL);
-}
-
 // what to do during setup
 void SensorMQ::onSetup() {
+  // prepare the pin for input
+  pinMode(_pin, INPUT);
   _ro = _MQCalibration();
 }
 
@@ -2367,16 +2356,12 @@ int SensorMQ::_MQGetPercentage(float rs_ro_ratio, float *pcurve) {
 */
 #ifdef USE_MHZ19
 // contructor
-SensorMHZ19::SensorMHZ19(NodeManager& node_manager, int rxpin, int txpin): Sensor(node_manager, rxpin) {
+SensorMHZ19::SensorMHZ19(NodeManager& node_manager, int rxpin, int txpin, int child_id): Sensor(node_manager, rxpin) {
   _name = "MHZ19";
   _rx_pin = rxpin;
   _tx_pin = txpin;
-}
-
-// what to do during before
-void SensorMHZ19::onBefore() {
-  // register the child
-  new ChildInt(this,_node->getAvailableChildId(),S_AIR_QUALITY,V_LEVEL);
+  children.allocateBlocks(1);
+  new ChildInt(this,_node->getAvailableChildId(child_id),S_AIR_QUALITY,V_LEVEL,_name);
 }
 
 // what to do during setup
@@ -2448,15 +2433,11 @@ int SensorMHZ19::_readCO2() {
 */
 #ifdef USE_AM2320
 // constructor
-SensorAM2320::SensorAM2320(NodeManager& node_manager): Sensor(node_manager) {
+SensorAM2320::SensorAM2320(NodeManager& node_manager, int child_id): Sensor(node_manager) {
   _name = "AM2320";
-}
-
-// what do to during before
-void SensorAM2320::onBefore() {
-  // register the child
-  new ChildFloat(this,_node->getAvailableChildId(),S_TEMP,V_TEMP);
-  new ChildFloat(this,_node->getAvailableChildId(),S_HUM,V_HUM);
+  children.allocateBlocks(2);
+  new ChildFloat(this,_node->getAvailableChildId(child_id),S_TEMP,V_TEMP,_name);
+  new ChildFloat(this,_node->getAvailableChildId(child_id+1),S_HUM,V_HUM,_name);
 }
 
 // what do to during setup
@@ -2511,8 +2492,10 @@ void SensorAM2320::onReceive(MyMessage* message) {
 */
 #ifdef USE_TSL2561
 // contructor
-SensorTSL2561::SensorTSL2561(NodeManager& node_manager): Sensor(node_manager) {
+SensorTSL2561::SensorTSL2561(NodeManager& node_manager, int child_id): Sensor(node_manager) {
   _name = "TSL2561";
+  children.allocateBlocks(1);
+  new ChildInt(this,_node->getAvailableChildId(child_id),S_LIGHT_LEVEL,V_LEVEL,_name);
 }
 
 // setter/getter
@@ -2527,12 +2510,6 @@ void SensorTSL2561::setSpectrum(int value) {
 }
 void SensorTSL2561::setAddress(int value) {
   _tsl_address = value;
-}
-
-// what do to during before
-void SensorTSL2561::onBefore() {
-  // register the child
-  new ChildInt(this,_node->getAvailableChildId(),S_LIGHT_LEVEL,V_LEVEL);
 }
 
 // what do to during setup
@@ -2635,19 +2612,15 @@ void SensorTSL2561::onReceive(MyMessage* message) {
 */
 #ifdef USE_PT100
 // contructor
-SensorPT100::SensorPT100(NodeManager& node_manager, int pin): Sensor(node_manager, pin) {
+SensorPT100::SensorPT100(NodeManager& node_manager, int pin, int child_id): Sensor(node_manager, pin) {
   _name = "PT100";
+  children.allocateBlocks(1);
+  new ChildFloat(this,_node->getAvailableChildId(child_id),S_TEMP,V_TEMP,_name);
 }
 
 // setter/getter
 void SensorPT100::setVoltageRef(float value) {
    _voltageRef = value;
-}
-
-// what to do during before
-void SensorPT100::onBefore() {
-  // register the child
-  new ChildFloat(this,_node->getAvailableChildId(),S_TEMP,V_TEMP);
 }
 
 // what to do during setup
@@ -2687,8 +2660,10 @@ void SensorPT100::onReceive(MyMessage* message) {
 
 #ifdef USE_DIMMER
 // contructor
-SensorDimmer::SensorDimmer(NodeManager& node_manager, int pin): Sensor(node_manager, pin) {
+SensorDimmer::SensorDimmer(NodeManager& node_manager, int pin, int child_id): Sensor(node_manager, pin) {
   _name = "DIMMER";
+  children.allocateBlocks(1);
+  new ChildInt(this,_node->getAvailableChildId(child_id),S_DIMMER,V_PERCENTAGE,_name);
 }
 
 // setter/getter
@@ -2700,12 +2675,6 @@ void SensorDimmer::setDuration(int value) {
 }
 void SensorDimmer::setStepDuration(int value) {
   _duration = value;
-}
-
-// what to do during before
-void SensorDimmer::onBefore() {
-  // register the child
-  new ChildInt(this,_node->getAvailableChildId(),S_DIMMER,V_PERCENTAGE);
 }
 
 // what to do during setup
@@ -2774,7 +2743,7 @@ float SensorDimmer::_getEasing(float t, float b, float c, float d) {
 */
 #ifdef USE_PULSE_METER
 // contructor
-SensorPulseMeter::SensorPulseMeter(NodeManager& node_manager, int pin): Sensor(node_manager, pin) {
+SensorPulseMeter::SensorPulseMeter(NodeManager& node_manager, int pin, int child_id): Sensor(node_manager, pin) {
   _name = "PULSE";
 }
 
@@ -2787,12 +2756,6 @@ void SensorPulseMeter::setInitialValue(int value) {
 }
 void SensorPulseMeter::setInterruptMode(int value) {
   _interrupt_mode = value;
-}
-
-// what to do during before
-void SensorPulseMeter::onBefore() {
-  // register the child
-  new ChildFloat(this,_node->getAvailableChildId(),S_CUSTOM,V_CUSTOM);
 }
 
 // what to do during setup
@@ -2847,14 +2810,10 @@ void SensorPulseMeter::_reportTotal(Child* child) {
    SensorRainGauge
 */
 // contructor
-SensorRainGauge::SensorRainGauge(NodeManager& node_manager, int pin): SensorPulseMeter(node_manager, pin) {
+SensorRainGauge::SensorRainGauge(NodeManager& node_manager, int pin, int child_id): SensorPulseMeter(node_manager, pin, child_id) {
   _name = "RAIN_GAUGE";
-}
-
-// what to do during before
-void SensorRainGauge::onBefore() {
-  // register the child
-  new ChildFloat(this,_node->getAvailableChildId(),S_RAIN,V_RAIN);
+  children.allocateBlocks(1);
+  new ChildFloat(this,_node->getAvailableChildId(child_id),S_RAIN,V_RAIN,_name);
   setPulseFactor(9.09);
 }
 
@@ -2862,14 +2821,10 @@ void SensorRainGauge::onBefore() {
    SensorPowerMeter
 */
 // contructor
-SensorPowerMeter::SensorPowerMeter(NodeManager& node_manager, int pin): SensorPulseMeter(node_manager, pin) {
+SensorPowerMeter::SensorPowerMeter(NodeManager& node_manager, int pin, int child_id): SensorPulseMeter(node_manager, pin, child_id) {
   _name = "POWER";
-}
-
-// what to do during before
-void SensorPowerMeter::onBefore() {
-  // register the child
-  new ChildDouble(this,_node->getAvailableChildId(),S_POWER,V_KWH);
+  children.allocateBlocks(1);
+  new ChildDouble(this,_node->getAvailableChildId(child_id),S_POWER,V_KWH,_name);
   setPulseFactor(1000);
 }
 
@@ -2882,14 +2837,10 @@ void SensorPowerMeter::_reportTotal(Child* child) {
    SensorWaterMeter
 */
 // contructor
-SensorWaterMeter::SensorWaterMeter(NodeManager& node_manager, int pin): SensorPulseMeter(node_manager, pin) {
+SensorWaterMeter::SensorWaterMeter(NodeManager& node_manager, int pin, int child_id): SensorPulseMeter(node_manager, pin, child_id) {
   _name = "WATER";
-}
-
-// what to do during before
-void SensorWaterMeter::onBefore() {
-  // register the child
-  new ChildDouble(this,_node->getAvailableChildId(),S_WATER,V_VOLUME);
+  children.allocateBlocks(1);
+  new ChildDouble(this,_node->getAvailableChildId(child_id),S_WATER,V_VOLUME,_name);
   setPulseFactor(1000);
 }
 
@@ -2904,20 +2855,15 @@ void SensorWaterMeter::_reportTotal(Child* child) {
 */
 #ifdef USE_PMS
 // contructor
-SensorPlantowerPMS::SensorPlantowerPMS(NodeManager& node_manager, int rxpin, int txpin): Sensor(node_manager, rxpin) {
+SensorPlantowerPMS::SensorPlantowerPMS(NodeManager& node_manager, int rxpin, int txpin, int child_id): Sensor(node_manager, rxpin) {
   _name = "PMS";
   _rx_pin = rxpin;
   _tx_pin = txpin;
-}
-
-// what to do during before
-void SensorPlantowerPMS::onBefore() {
-  // Allocate memory for all children at once (to prevent memory fragmentation)
   children.allocateBlocks(3);
   // register the child
-  new ChildInt(this, _node->getAvailableChildId(), S_DUST, V_LEVEL, "PM1.0");
-  new ChildInt(this, _node->getAvailableChildId(), S_DUST, V_LEVEL, "PM2.5");
-  new ChildInt(this, _node->getAvailableChildId(), S_DUST, V_LEVEL, "PM10.0");
+  new ChildInt(this, _node->getAvailableChildId(child_id), S_DUST, V_LEVEL, "PM1.0");
+  new ChildInt(this, _node->getAvailableChildId(child_id+1), S_DUST, V_LEVEL, "PM2.5");
+  new ChildInt(this, _node->getAvailableChildId(child_id+2), S_DUST, V_LEVEL, "PM10.0");
 }
 
 // what to do during setup
@@ -2980,53 +2926,25 @@ void SensorPlantowerPMS::onReceive(MyMessage* message) {
  */
 #ifdef USE_VL53L0X
 // constructor
-SensorVL53L0X::SensorVL53L0X(NodeManager& node_manager, int xshut_pin): Sensor(node_manager, xshut_pin) {
+SensorVL53L0X::SensorVL53L0X(NodeManager& node_manager, int xshut_pin, int child_id): Sensor(node_manager, xshut_pin) {
   _name = "VL53L0X";
+  children.allocateBlocks(1);
+  new ChildInt(this, _node->getAvailableChildId(child_id), S_DISTANCE, V_DISTANCE,_name);
+}
+
+// what to do during setup
+void SensorVL53L0X::onSetup() {
   if (_pin > 0) {
     pinMode(_pin, OUTPUT); // Put sensor in deep sleep until the loop
     digitalWrite(_pin, LOW);
   }
-}
-
-void SensorVL53L0X::onBefore() {
-  // register the child
-  new ChildInt(this, _node->getAvailableChildId(), S_DISTANCE, V_DISTANCE, "Dist");
   _lox = new VL53L0X();
-}
-
-void SensorVL53L0X::onSetup() {
   if (_lox) {
     Wire.begin();
   }
 }
 
-int SensorVL53L0X::_getDistance() {
-  int distance = -1;
-
-  if (_lox) {
-    // The XSHUT pin puts the sensor into deep sleep when pulled to LOW;
-    // To wake up, do NOT write HIGH (=3.3V or 5V) to the pin, as the sensor
-    // uses only 2.8V and is not 5V-tolerant. Instead, set the pin to INPUT.
-    if (_pin >= 0) {
-      pinMode(_pin, INPUT);
-      sleep(5); // Transition from HW standby to SW standby might take up to 1.5 ms => use 5ms to be on the safe side
-    }
-    _lox->init();
-    _lox->setTimeout(500);
-    distance = _lox->readRangeSingleMillimeters();
-    if (_pin >= 0) {
-      digitalWrite(_pin, LOW);
-      pinMode(_pin, OUTPUT);
-    }
-  }
-
-//  if (measure.RangeStatus == 0) {  // only 0  data
-  if (_lox->timeoutOccurred()) {
-    distance = -1;
-  }
-  return distance;
-}
-
+// what to do during loop
 void SensorVL53L0X::onLoop(Child *child) {
   int val = _getDistance();
   ((ChildInt*)child)->setValueInt(val);
@@ -3049,6 +2967,32 @@ void SensorVL53L0X::onReceive(MyMessage* message) {
   Child* child = getChild(message->sensor);
   if (child == nullptr) return;
   if (message->getCommand() == C_REQ && message->type == child->type) onLoop(child);
+}
+
+// measure the distance
+int SensorVL53L0X::_getDistance() {
+  int distance = -1;
+  if (_lox) {
+    // The XSHUT pin puts the sensor into deep sleep when pulled to LOW;
+    // To wake up, do NOT write HIGH (=3.3V or 5V) to the pin, as the sensor
+    // uses only 2.8V and is not 5V-tolerant. Instead, set the pin to INPUT.
+    if (_pin >= 0) {
+      pinMode(_pin, INPUT);
+      sleep(5); // Transition from HW standby to SW standby might take up to 1.5 ms => use 5ms to be on the safe side
+    }
+    _lox->init();
+    _lox->setTimeout(500);
+    distance = _lox->readRangeSingleMillimeters();
+    if (_pin >= 0) {
+      digitalWrite(_pin, LOW);
+      pinMode(_pin, OUTPUT);
+    }
+  }
+  //  if (measure.RangeStatus == 0) {  // only 0  data
+  if (_lox->timeoutOccurred()) {
+    distance = -1;
+  }
+  return distance;
 }
 #endif
 

--- a/NodeManagerLibrary.ino
+++ b/NodeManagerLibrary.ino
@@ -477,7 +477,9 @@ void Sensor::presentation() {
       Serial.print(F("PRES I="));
       Serial.print(child->child_id);
       Serial.print(F(" T="));
-      Serial.println(child->presentation);
+      Serial.print(child->presentation);
+      Serial.print(F(" D="));
+      Serial.println(child->description);
     #endif
     present(child->child_id, child->presentation,child->description,_node->getAck());
   }
@@ -1396,13 +1398,14 @@ SensorDHT22::SensorDHT22(NodeManager& node_manager, int pin): SensorDHT(node_man
 // contructor
 SensorSHT21::SensorSHT21(NodeManager& node_manager): Sensor(node_manager) {
   _name = "SHT21";
+  // register the child
+  new ChildFloat(this,_node->getAvailableChildId(),S_TEMP,V_TEMP,_name);
+  new ChildFloat(this,_node->getAvailableChildId(),S_HUM,V_HUM,_name);
 }
 
 // what to do during before
 void SensorSHT21::onBefore() {
-  // register the child
-  new ChildFloat(this,_node->getAvailableChildId(),S_TEMP,V_TEMP);
-  new ChildFloat(this,_node->getAvailableChildId(),S_HUM,V_HUM);
+
 }
 
 // what to do during setup
@@ -3600,12 +3603,15 @@ void NodeManager::before() {
     // call each sensor's before()
     sensor->before();
   }
+  #ifdef NODEMANAGER_DEBUG
+    Serial.print(F("RADIO..."));
+  #endif
 }
 
 // present NodeManager and its sensors
 void NodeManager::presentation() {
   #ifdef NODEMANAGER_DEBUG
-    Serial.println(F("RADIO OK"));
+    Serial.println(F("OK"));
   #endif
   // Send the sketch version information to the gateway and Controller
   if (_sleep_between_send > 0) sleep(_sleep_between_send);

--- a/NodeManagerLibrary.ino
+++ b/NodeManagerLibrary.ino
@@ -6,7 +6,7 @@
    PowerManager
 */
 
-#ifndef NO_MODULE_POWER_MANAGER
+#ifndef DISABLE_POWER_MANAGER
 PowerManager::PowerManager(int ground_pin, int vcc_pin, int wait_time) {
   setPowerPins(ground_pin, vcc_pin, wait_time);
 }
@@ -414,7 +414,7 @@ void Sensor::setForceUpdateMinutes(int value) {
     child->force_update_timer->start(value,MINUTES);
   }
 }
-#ifndef NO_MODULE_POWER_MANAGER
+#ifndef DISABLE_POWER_MANAGER
 void Sensor::setPowerPins(int ground_pin, int vcc_pin, int wait_time) {
   if (_powerManager == nullptr) return;
   _powerManager->setPowerPins(ground_pin, vcc_pin, wait_time);
@@ -481,7 +481,7 @@ void Sensor::presentation() {
       Serial.print(F(" D="));
       Serial.println(child->description);
     #endif
-    present(child->child_id, child->presentation,child->description,_node->getAck());
+    present(child->child_id, child->presentation, child->description, _node->getAck());
   }
 
 }
@@ -522,7 +522,7 @@ void Sensor::loop(MyMessage* message) {
     }
   }
   // turn the sensor on
-#ifndef NO_MODULE_POWER_MANAGER
+#ifndef DISABLE_POWER_MANAGER
   powerOn();
 #endif
   // iterates over all the children
@@ -550,7 +550,7 @@ void Sensor::loop(MyMessage* message) {
         child->sendValue();
   }
   // turn the sensor off
-#ifndef NO_MODULE_POWER_MANAGER
+#ifndef DISABLE_POWER_MANAGER
   powerOff();
 #endif
   // if called from loop(), restart the report timer if over
@@ -578,7 +578,7 @@ Child* Sensor::getChild(int child_id) {
   return nullptr;
 }
 
-#ifndef NO_MODULE_POWER_MANAGER
+#ifndef DISABLE_POWER_MANAGER
 void Sensor::setPowerManager(PowerManager& powerManager) {
   _powerManager = &powerManager;
 }
@@ -3196,7 +3196,7 @@ void SensorConfiguration::onReceive(MyMessage* message) {
       case 20: _node->setSleepBetweenSend(request.getValueInt()); break;
       case 21: _node->setAck(request.getValueInt()); break;
       case 22: _node->setIsMetric(request.getValueInt()); break;
-#ifndef NO_MODULE_POWER_MANAGER
+#ifndef DISABLE_POWER_MANAGER
       case 24: _node->powerOn(); break;
       case 25: _node->powerOff(); break;
 #endif
@@ -3224,7 +3224,7 @@ void SensorConfiguration::onReceive(MyMessage* message) {
         case 6: sensor->setSamplesInterval(request.getValueInt()); break;
         case 7: sensor->setTrackLastValue(request.getValueInt()); break;
         case 9: sensor->setForceUpdateMinutes(request.getValueInt()); break;
-#ifndef NO_MODULE_POWER_MANAGER
+#ifndef DISABLE_POWER_MANAGER
         case 13: sensor->powerOn(); break;
         case 14: sensor->powerOff(); break;
 #endif
@@ -3501,7 +3501,7 @@ void NodeManager::setInterrupt(int pin, int mode, int initial) {
 void NodeManager::setInterruptMinDelta(long value) {
   _interrupt_min_delta = value;
 }
-#ifndef NO_MODULE_POWER_MANAGER
+#ifndef DISABLE_POWER_MANAGER
 void NodeManager::setPowerPins(int ground_pin, int vcc_pin, int wait_time) {
   if (_powerManager == nullptr) return;
   _powerManager->setPowerPins(ground_pin, vcc_pin, wait_time);
@@ -3653,7 +3653,7 @@ void NodeManager::setup() {
 // run the main function for all the register sensors
 void NodeManager::loop() {
   // turn on the pin powering all the sensors
-#ifndef NO_MODULE_POWER_MANAGER
+#ifndef DISABLE_POWER_MANAGER
   powerOn();
 #endif
   // run loop for all the registered sensors
@@ -3674,7 +3674,7 @@ void NodeManager::loop() {
     }
   }
   // turn off the pin powering all the sensors
-#ifndef NO_MODULE_POWER_MANAGER
+#ifndef DISABLE_POWER_MANAGER
   powerOff();
 #endif
   // continue/start sleeping as requested
@@ -3699,13 +3699,13 @@ void NodeManager::receive(MyMessage &message) {
   Sensor* sensor = getSensorWithChild(message.sensor);
   if (sensor != nullptr) {
     // turn on the pin powering all the sensors
-#ifndef NO_MODULE_POWER_MANAGER
+#ifndef DISABLE_POWER_MANAGER
     powerOn();
 #endif
     // call the sensor's receive()
     sensor->receive(message);
     // turn off the pin powering all the sensors
-#ifndef NO_MODULE_POWER_MANAGER
+#ifndef DISABLE_POWER_MANAGER
     powerOff();
 #endif
   }
@@ -3982,7 +3982,7 @@ void NodeManager::_sendMessage(int child_id, int type) {
   }
 }
 
-#ifndef NO_MODULE_POWER_MANAGER
+#ifndef DISABLE_POWER_MANAGER
 void NodeManager::setPowerManager(PowerManager& powerManager) {
   _powerManager = &powerManager;
 }
@@ -4048,18 +4048,6 @@ void NodeManager::_sleep() {
   #ifdef NODEMANAGER_DEBUG
     Serial.println(F("AWAKE"));
   #endif
-}
-
-// present the service
-void NodeManager::_present(int child_id, int type) {
-  #ifdef NODEMANAGER_DEBUG
-    Serial.print(F("PRES I="));
-    Serial.print(child_id);
-    Serial.print(F(", T="));
-    Serial.println(type);
-  #endif
-  if (_sleep_between_send > 0) sleep(_sleep_between_send);
-  present(child_id,type,"",_ack);
 }
 
 // load the configuration stored in the eeprom

--- a/NodeManagerLibrary.ino
+++ b/NodeManagerLibrary.ino
@@ -707,7 +707,7 @@ void SensorSignal::onReceive(MyMessage* message) {
 }
 #endif
 
-#ifdef MODULE_ANALOG_INPUT
+#ifdef USE_ANALOG_INPUT
 /*
    SensorAnalogInput
 */
@@ -865,7 +865,7 @@ void SensorSoilMoisture::onSetup() {
 }
 #endif
 
-#ifdef MODULE_THERMISTOR
+#ifdef USE_THERMISTOR
 /*
    SensorThermistor
 */
@@ -939,7 +939,7 @@ void SensorThermistor::onReceive(MyMessage* message) {
 }
 #endif
 
-#ifdef MODULE_ML8511
+#ifdef USE_ML8511
 /*
    SensorML8511
 */
@@ -995,7 +995,7 @@ float SensorML8511::_mapfloat(float x, float in_min, float in_max, float out_min
 }
 #endif
 
-#ifdef MODULE_ACS712
+#ifdef USE_ACS712
 /*
    SensorACS712
 */
@@ -1050,7 +1050,7 @@ void SensorACS712::onReceive(MyMessage* message) {
 
 #endif
 
-#ifdef MODULE_DIGITAL_INPUT
+#ifdef USE_DIGITAL_INPUT
 /*
    SensorDigitalInput
 */
@@ -1098,7 +1098,7 @@ void SensorDigitalInput::onReceive(MyMessage* message) {
 #endif
 
 
-#ifdef MODULE_DIGITAL_OUTPUT
+#ifdef USE_DIGITAL_OUTPUT
 /*
    SensorDigitalOutput
 */
@@ -1302,7 +1302,7 @@ void SensorLatchingRelay::_setStatus(Child* child, int value) {
 
 #endif
 
-#ifdef MODULE_DHT
+#ifdef USE_DHT
 /*
    SensorDHT
 */
@@ -1394,7 +1394,7 @@ SensorDHT22::SensorDHT22(NodeManager& node_manager, int pin): SensorDHT(node_man
 /*
    SensorSHT21
 */
-#ifdef MODULE_SHT21
+#ifdef USE_SHT21
 // contructor
 SensorSHT21::SensorSHT21(NodeManager& node_manager): Sensor(node_manager) {
   _name = "SHT21";
@@ -1465,7 +1465,7 @@ SensorHTU21D::SensorHTU21D(NodeManager& nodeManager): SensorSHT21(nodeManager) {
 }
 #endif 
 
-#ifdef MODULE_SWITCH
+#ifdef USE_SWITCH
 /*
  * SensorSwitch
  */
@@ -1576,7 +1576,7 @@ void SensorMotion::onSetup() {
 /*
    SensorDs18b20
 */
-#ifdef MODULE_DS18B20
+#ifdef USE_DS18B20
 // contructor
 SensorDs18b20::SensorDs18b20(NodeManager& node_manager, int pin): Sensor(node_manager, pin) {
   _name = "DS18B20";
@@ -1657,7 +1657,7 @@ void SensorDs18b20::setSleepDuringConversion(bool value) {
 /*
    SensorBH1750
 */
-#ifdef MODULE_BH1750
+#ifdef USE_BH1750
 // contructor
 SensorBH1750::SensorBH1750(NodeManager& node_manager): Sensor(node_manager) {
   _name = "BH1750";
@@ -1703,7 +1703,7 @@ void SensorBH1750::onReceive(MyMessage* message) {
 /*
    SensorMLX90614
 */
-#ifdef MODULE_MLX90614
+#ifdef USE_MLX90614
 // contructor
 SensorMLX90614::SensorMLX90614(NodeManager& node_manager): Sensor(node_manager) {
   _name = "MLX90614";
@@ -1751,7 +1751,7 @@ void SensorMLX90614::onReceive(MyMessage* message) {
 /*
    SensorBosch
 */
-#if defined(MODULE_BME280) || defined(MODULE_BMP085) || defined(MODULE_BMP280)
+#if defined(USE_BME280) || defined(USE_BMP085) || defined(USE_BMP280)
 // contructor
 SensorBosch::SensorBosch(NodeManager& node_manager): Sensor(node_manager) {
   _name = "BOSH";
@@ -1894,7 +1894,7 @@ uint8_t SensorBosch::GetI2CAddress(uint8_t chip_id) {
 /*
  * SensorBME280
  */
-#ifdef MODULE_BME280
+#ifdef USE_BME280
 SensorBME280::SensorBME280(NodeManager& node_manager): SensorBosch(node_manager) {
   _name = "BME280";
 }
@@ -1974,7 +1974,7 @@ void SensorBME280::onLoop(Child* child) {
 /*
    SensorBMP085
 */
-#ifdef MODULE_BMP085
+#ifdef USE_BMP085
 // contructor
 SensorBMP085::SensorBMP085(NodeManager& node_manager): SensorBosch(node_manager) {
   _name = "BMP085";
@@ -2041,7 +2041,7 @@ void SensorBMP085::onLoop(Child* child) {
 /*
  * SensorBMP280
  */
-#ifdef MODULE_BMP280
+#ifdef USE_BMP280
 SensorBMP280::SensorBMP280(NodeManager& node_manager): SensorBosch(node_manager) {
   _name = "BMP280";
 }
@@ -2106,7 +2106,7 @@ void SensorBMP280::onLoop(Child* child) {
 /*
    SensorSonoff
 */
-#ifdef MODULE_SONOFF
+#ifdef USE_SONOFF
 // contructor
 SensorSonoff::SensorSonoff(NodeManager& node_manager): Sensor(node_manager) {
   _name = "SONOFF";
@@ -2207,7 +2207,7 @@ void SensorSonoff::_blink() {
 /*
    SensorHCSR04
 */
-#ifdef MODULE_HCSR04
+#ifdef USE_HCSR04
 // contructor
 SensorHCSR04::SensorHCSR04(NodeManager& node_manager, int pin): Sensor(node_manager, pin) {
   _name = "HCSR04";
@@ -2262,7 +2262,7 @@ void SensorHCSR04::onReceive(MyMessage* message) {
 /*
    SensorMCP9808
 */
-#ifdef MODULE_MCP9808
+#ifdef USE_MCP9808
 // contructor
 SensorMCP9808::SensorMCP9808(NodeManager& node_manager): Sensor(node_manager) {
   _name = "MCP9808";
@@ -2305,7 +2305,7 @@ void SensorMCP9808::onReceive(MyMessage* message) {
 /*
  * SensorMQ
  */
-#ifdef MODULE_MQ
+#ifdef USE_MQ
 
 float SensorMQ::_default_LPGCurve[3] = {2.3,0.21,-0.47};
 float SensorMQ::_default_COCurve[3] = {2.3,0.72,-0.34};
@@ -2460,7 +2460,7 @@ int SensorMQ::_MQGetPercentage(float rs_ro_ratio, float *pcurve) {
 /*
    SensorMHZ19
 */
-#ifdef MODULE_MHZ19
+#ifdef USE_MHZ19
 // contructor
 SensorMHZ19::SensorMHZ19(NodeManager& node_manager, int rxpin, int txpin): Sensor(node_manager, rxpin) {
   _name = "MHZ19";
@@ -2541,7 +2541,7 @@ int SensorMHZ19::_readCO2() {
 /*
    SensorAM2320
 */
-#ifdef MODULE_AM2320
+#ifdef USE_AM2320
 // constructor
 SensorAM2320::SensorAM2320(NodeManager& node_manager): Sensor(node_manager) {
   _name = "AM2320";
@@ -2604,7 +2604,7 @@ void SensorAM2320::onReceive(MyMessage* message) {
 /*
    SensorTSL2561
 */
-#ifdef MODULE_TSL2561
+#ifdef USE_TSL2561
 // contructor
 SensorTSL2561::SensorTSL2561(NodeManager& node_manager): Sensor(node_manager) {
   _name = "TSL2561";
@@ -2728,7 +2728,7 @@ void SensorTSL2561::onReceive(MyMessage* message) {
 /*
    SensorPT100
 */
-#ifdef MODULE_PT100
+#ifdef USE_PT100
 // contructor
 SensorPT100::SensorPT100(NodeManager& node_manager, int pin): Sensor(node_manager, pin) {
   _name = "PT100";
@@ -2780,7 +2780,7 @@ void SensorPT100::onReceive(MyMessage* message) {
    SensorDimmer
 */
 
-#ifdef MODULE_DIMMER
+#ifdef USE_DIMMER
 // contructor
 SensorDimmer::SensorDimmer(NodeManager& node_manager, int pin): Sensor(node_manager, pin) {
   _name = "DIMMER";
@@ -2867,7 +2867,7 @@ float SensorDimmer::_getEasing(float t, float b, float c, float d) {
 /*
    SensorPulseMeter
 */
-#ifdef MODULE_PULSE_METER
+#ifdef USE_PULSE_METER
 // contructor
 SensorPulseMeter::SensorPulseMeter(NodeManager& node_manager, int pin): Sensor(node_manager, pin) {
   _name = "PULSE";
@@ -2997,7 +2997,7 @@ void SensorWaterMeter::_reportTotal(Child* child) {
 /*
    SensorPlantowerPMS
 */
-#ifdef MODULE_PMS
+#ifdef USE_PMS
 // contructor
 SensorPlantowerPMS::SensorPlantowerPMS(NodeManager& node_manager, int rxpin, int txpin): Sensor(node_manager, rxpin) {
   _name = "PMS";
@@ -3073,7 +3073,7 @@ void SensorPlantowerPMS::onReceive(MyMessage* message) {
 /*
  * VL53L0X Laser distance sensor
  */
-#ifdef MODULE_VL53L0X
+#ifdef USE_VL53L0X
 // constructor
 SensorVL53L0X::SensorVL53L0X(NodeManager& node_manager, int xshut_pin): Sensor(node_manager, xshut_pin) {
   _name = "VL53L0X";
@@ -3256,7 +3256,7 @@ void SensorConfiguration::onReceive(MyMessage* message) {
         }
       }
       #endif
-      #ifdef MODULE_ANALOG_INPUT
+      #ifdef USE_ANALOG_INPUT
       if (strcmp(sensor->getName(),"ANALOG_I") == 0 || strcmp(sensor->getName(),"LDR") == 0 || strcmp(sensor->getName(),"RAIN") == 0 || strcmp(sensor->getName(),"SOIL") == 0) {
         SensorAnalogInput* custom_sensor = (SensorAnalogInput*)sensor;
         switch(function) {
@@ -3269,7 +3269,7 @@ void SensorConfiguration::onReceive(MyMessage* message) {
         }
       }
       #endif
-      #ifdef MODULE_THERMISTOR
+      #ifdef USE_THERMISTOR
       if (strcmp(sensor->getName(),"THERMISTOR") == 0) {
         SensorThermistor* custom_sensor = (SensorThermistor*)sensor;
         switch(function) {
@@ -3282,7 +3282,7 @@ void SensorConfiguration::onReceive(MyMessage* message) {
         }
       }
       #endif
-      #ifdef MODULE_ACS712
+      #ifdef USE_ACS712
       if (strcmp(sensor->getName(),"ACS712") == 0) {
         SensorACS712* custom_sensor = (SensorACS712*)sensor;
         switch(function) {
@@ -3292,7 +3292,7 @@ void SensorConfiguration::onReceive(MyMessage* message) {
         }
       }
       #endif
-      #ifdef MODULE_DIGITAL_OUTPUT
+      #ifdef USE_DIGITAL_OUTPUT
       if (strcmp(sensor->getName(),"DIGITAL_O") == 0 || strcmp(sensor->getName(),"RELAY") == 0 || strcmp(sensor->getName(),"LATCHING") == 0) {
         SensorDigitalOutput* custom_sensor = (SensorDigitalOutput*)sensor;
         switch(function) {
@@ -3314,7 +3314,7 @@ void SensorConfiguration::onReceive(MyMessage* message) {
         }
       }
       #endif
-      #ifdef MODULE_SWITCH
+      #ifdef USE_SWITCH
       if (strcmp(sensor->getName(),"SWITCH") == 0 || strcmp(sensor->getName(),"DOOR") == 0 || strcmp(sensor->getName(),"MOTION") == 0) {
         SensorSwitch* custom_sensor = (SensorSwitch*)sensor;
         switch(function) {
@@ -3326,7 +3326,7 @@ void SensorConfiguration::onReceive(MyMessage* message) {
         }
       }
       #endif
-      #ifdef MODULE_DS18B20
+      #ifdef USE_DS18B20
       if (strcmp(sensor->getName(),"DS18B20") == 0) {
         SensorDs18b20* custom_sensor = (SensorDs18b20*)sensor;
         switch(function) {
@@ -3336,7 +3336,7 @@ void SensorConfiguration::onReceive(MyMessage* message) {
         }
       }
       #endif
-      #ifdef MODULE_BH1750
+      #ifdef USE_BH1750
       if (strcmp(sensor->getName(),"BH1750") == 0) {
         SensorBH1750* custom_sensor = (SensorBH1750*)sensor;
         switch(function) {
@@ -3345,7 +3345,7 @@ void SensorConfiguration::onReceive(MyMessage* message) {
         }
       }
       #endif
-      #if defined(MODULE_BME280) || defined(MODULE_BMP085) || defined(MODULE_BMP280)
+      #if defined(USE_BME280) || defined(USE_BMP085) || defined(USE_BMP280)
       if (strcmp(sensor->getName(),"BMP085") == 0 || strcmp(sensor->getName(),"BME280") == 0 || strcmp(sensor->getName(),"BMP280") == 0) {
         SensorBosch* custom_sensor = (SensorBosch*)sensor;
         switch(function) {
@@ -3354,7 +3354,7 @@ void SensorConfiguration::onReceive(MyMessage* message) {
         }
       }
       #endif
-      #ifdef MODULE_SONOFF
+      #ifdef USE_SONOFF
       if (strcmp(sensor->getName(),"SONOFF") == 0) {
         SensorSonoff* custom_sensor = (SensorSonoff*)sensor;
         switch(function) {
@@ -3365,7 +3365,7 @@ void SensorConfiguration::onReceive(MyMessage* message) {
         }
       }
       #endif
-      #ifdef MODULE_HCSR04
+      #ifdef USE_HCSR04
       if (strcmp(sensor->getName(),"HCSR04") == 0) {
         SensorHCSR04* custom_sensor = (SensorHCSR04*)sensor;
         switch(function) {
@@ -3376,7 +3376,7 @@ void SensorConfiguration::onReceive(MyMessage* message) {
         }
       }
       #endif
-      #ifdef MODULE_MQ
+      #ifdef USE_MQ
       if (strcmp(sensor->getName(),"MQ") == 0) {
         SensorMQ* custom_sensor = (SensorMQ*)sensor;
         switch(function) {
@@ -3392,7 +3392,7 @@ void SensorConfiguration::onReceive(MyMessage* message) {
         }
       }
       #endif
-      #ifdef MODULE_TSL2561
+      #ifdef USE_TSL2561
       if (strcmp(sensor->getName(),"TSL2561") == 0) {
         SensorTSL2561* custom_sensor = (SensorTSL2561*)sensor;
         switch(function) {
@@ -3404,7 +3404,7 @@ void SensorConfiguration::onReceive(MyMessage* message) {
         }
       }
       #endif
-      #ifdef MODULE_PT100
+      #ifdef USE_PT100
       if (strcmp(sensor->getName(),"PT100") == 0) {
         SensorPT100* custom_sensor = (SensorPT100*)sensor;
         switch(function) {
@@ -3413,7 +3413,7 @@ void SensorConfiguration::onReceive(MyMessage* message) {
         }
       }
       #endif
-      #ifdef MODULE_DIMMER
+      #ifdef USE_DIMMER
       if (strcmp(sensor->getName(),"DIMMER") == 0) {
         SensorDimmer* custom_sensor = (SensorDimmer*)sensor;
         switch(function) {
@@ -3424,7 +3424,7 @@ void SensorConfiguration::onReceive(MyMessage* message) {
         }
       }
       #endif
-      #ifdef MODULE_PULSE_METER
+      #ifdef USE_PULSE_METER
       if (strcmp(sensor->getName(),"RAIN_GAUGE") == 0 || strcmp(sensor->getName(),"POWER") == 0 || strcmp(sensor->getName(),"WATER") == 0) {
         SensorPulseMeter* custom_sensor = (SensorPulseMeter*)sensor;
         switch(function) {

--- a/README.md
+++ b/README.md
@@ -33,49 +33,49 @@ To use a buil-in sensor:
 Once created, the sensor will automatically present one or more child to the gateway and controller.
 A list of buil-in sensors, module to enable, required dependencies and the number of child automatically created is presented below:
 
-Sensor Name         |#Child | Module to enable      | Description                                                                                       | Dependencies
---------------------|-------|-----------------------|---------------------------------------------------------------------------------------------------|----------------------------------------------------------
-SensorBattery       | 1     | -                     | Built-in sensor for automatic battery reporting                                                   | - 
-SensorSignal        | 1     | -                     | Built-in sensor for automatic signal level reporting                                              | -
-SensorConfiguration | 1     | -                     | Built-in sensor for OTA remote configuration of any registered sensor                             | -
-SensorAnalogInput   | 1     | MODULE_ANALOG_INPUT   | Generic analog sensor, return a pin's analog value or its percentage                              | -
-SensorLDR           | 1     | MODULE_ANALOG_INPUT   | LDR sensor, return the light level of an attached light resistor in percentage                    | -
-SensorRain          | 1     | MODULE_ANALOG_INPUT   | Rain sensor, return the percentage of rain from an attached analog sensor                         | -
-SensorSoilMoisture  | 1     | MODULE_ANALOG_INPUT   | Soil moisture sensor, return the percentage of moisture from an attached analog sensor            | -
-SensorThermistor    | 1     | MODULE_THERMISTOR     | Thermistor sensor, return the temperature based on the attached thermistor                        | -
-SensorML8511        | 1     | MODULE_ML8511         | ML8511 sensor, return UV intensity                                                                | -
-SensorACS712        | 1     | MODULE_ACS712         | ACS712 sensor, measure the current going through the attached module                              | -
-SensorDigitalInput  | 1     | MODULE_DIGITAL_INPUT  | Generic digital sensor, return a pin's digital value                                              | -
-SensorDigitalOutput | 1     | MODULE_DIGITAL_OUTPUT | Generic digital output sensor, allows setting the digital output of a pin to the requested value  | -
-SensorRelay         | 1     | MODULE_DIGITAL_OUTPUT | Relay sensor, allows activating the relay                                                         | -
-SensorLatchingRelay | 1     | MODULE_DIGITAL_OUTPUT | Latching Relay sensor, allows activating the relay with a pulse                                   | -
-SensorDHT11         | 2     | MODULE_DHT            | DHT11 sensor, return temperature/humidity based on the attached DHT sensor                        | https://github.com/mysensors/MySensorsArduinoExamples/tree/master/libraries/DHT
-SensorDHT22         | 2     | MODULE_DHT            | DHT22 sensor, return temperature/humidity based on the attached DHT sensor                        | https://github.com/mysensors/MySensorsArduinoExamples/tree/master/libraries/DHT
-SensorSHT21         | 2     | MODULE_SHT21          | SHT21 sensor, return temperature/humidity based on the attached SHT21 sensor                      | https://github.com/SodaqMoja/Sodaq_SHT2x
-SensorHTU21D        | 2     | MODULE_SHT21          | HTU21D sensor, return temperature/humidity based on the attached HTU21D sensor                    | https://github.com/SodaqMoja/Sodaq_SHT2x
-SensorSwitch        | 1     | MODULE_SWITCH         | Generic switch, wake up the board when a pin changes status                                       | -
-SensorDoor          | 1     | MODULE_SWITCH         | Door sensor, wake up the board and report when an attached magnetic sensor has been opened/closed | -
-SensorMotion        | 1     | MODULE_SWITCH         | Motion sensor, wake up the board and report when an attached PIR has triggered                    | -
-SensorDs18b20       | 1+    |  MODULE_DS18B20       | DS18B20 sensor, return the temperature based on the attached sensor                               | https://github.com/milesburton/Arduino-Temperature-Control-Library
-SensorBH1750        | 1     | MODULE_BH1750         | BH1750 sensor, return light level in lux                                                          | https://github.com/claws/BH1750
-SensorMLX90614      | 2     | MODULE_MLX90614       | MLX90614 contactless temperature sensor, return ambient and object temperature                    | https://github.com/adafruit/Adafruit-MLX90614-Library
-SensorBME280        | 4     | MODULE_BME280         | BME280 sensor, return temperature/humidity/pressure based on the attached BME280 sensor           | https://github.com/adafruit/Adafruit_BME280_Library
-SensorBMP085        | 3     | MODULE_BMP085         | BMP085/BMP180 sensor, return temperature and pressure                                             | https://github.com/adafruit/Adafruit-BMP085-Library
-SensorBMP280        | 3     | MODULE_BMP280         | BMP280 sensor, return temperature/pressure based on the attached BMP280 sensor                    | https://github.com/adafruit/Adafruit_BMP280_Library
-SensorSonoff        | 1     | MODULE_SONOFF         | Sonoff wireless smart switch                                                                      | https://github.com/thomasfredericks/Bounce2
-SensorHCSR04        | 1     | MODULE_HCSR04         | HC-SR04 sensor, return the distance between the sensor and an object                              | https://github.com/mysensors/MySensorsArduinoExamples/tree/master/libraries/NewPing
-SensorMCP9808       | 1     | MODULE_MCP9808        | MCP9808 sensor, measure the temperature through the attached module                               | https://github.com/adafruit/Adafruit_MCP9808_Library
-SensorMQ            | 1     | MODULE_MQ             | MQ sensor, return ppm of the target gas                                                           | -
-SensorMHZ19         | 1     | MODULE_MHZ19          | MH-Z19 CO2 sensor via UART (SoftwareSerial, default on pins 6(Rx) and 7(Tx)                       | -
-SensorAM2320        | 2     | MODULE_AM2320         | AM2320 sensors, return temperature/humidity based on the attached AM2320 sensor                   | https://github.com/thakshak/AM2320
-SensorTSL2561       | 1     | MODULE_TSL2561        | TSL2561 sensor, return light in lux                                                               | https://github.com/adafruit/TSL2561-Arduino-Library
-SensorPT100         | 1     | MODULE_PT100          | DFRobot Driver high temperature sensor, return the temperature from the attached PT100 sensor     | -
-SensorDimmer        | 1     | MODULE_DIMMER         | Generic dimmer sensor used to drive a pwm output                                                  | -
-SensorRainGauge     | 1     | MODULE_PULSE_METER    | Rain gauge sensor                                                                                 | -
-SensorPowerMeter    | 1     | MODULE_PULSE_METER    | Power meter pulse sensor                                                                          | -
-SensorWaterMeter    | 1     | MODULE_PULSE_METER    | Water meter pulse sensor                                                                          | -
-SensorPlantowerPMS  | 3     | MODULE_PMS            | Plantower PMS particulate matter sensors (reporting PM<=1.0, PM<=2.5 and PM<=10.0 in µg/m³)       | https://github.com/fu-hsi/pms
-SensorVL53L0X       | 1     | MODULE_VL53L0X        | VL53L0X laser time-of-flight distance sensor via I²C, sleep pin supported (optional)              | https://github.com/pololu/vl53l0x-arduino
+Sensor Name         |#Child | Module to enable   | Description                                                                                       | Dependencies
+--------------------|-------|--------------------|---------------------------------------------------------------------------------------------------|----------------------------------------------------------
+SensorBattery       | 1     | -                  | Built-in sensor for automatic battery reporting                                                   | - 
+SensorSignal        | 1     | -                  | Built-in sensor for automatic signal level reporting                                              | -
+SensorConfiguration | 1     | -                  | Built-in sensor for OTA remote configuration of any registered sensor                             | -
+SensorAnalogInput   | 1     | USE_ANALOG_INPUT   | Generic analog sensor, return a pin's analog value or its percentage                              | -
+SensorLDR           | 1     | USE_ANALOG_INPUT   | LDR sensor, return the light level of an attached light resistor in percentage                    | -
+SensorRain          | 1     | USE_ANALOG_INPUT   | Rain sensor, return the percentage of rain from an attached analog sensor                         | -
+SensorSoilMoisture  | 1     | USE_ANALOG_INPUT   | Soil moisture sensor, return the percentage of moisture from an attached analog sensor            | -
+SensorThermistor    | 1     | USE_THERMISTOR     | Thermistor sensor, return the temperature based on the attached thermistor                        | -
+SensorML8511        | 1     | USE_ML8511         | ML8511 sensor, return UV intensity                                                                | -
+SensorACS712        | 1     | USE_ACS712         | ACS712 sensor, measure the current going through the attached module                              | -
+SensorDigitalInput  | 1     | USE_DIGITAL_INPUT  | Generic digital sensor, return a pin's digital value                                              | -
+SensorDigitalOutput | 1     | USE_DIGITAL_OUTPUT | Generic digital output sensor, allows setting the digital output of a pin to the requested value  | -
+SensorRelay         | 1     | USE_DIGITAL_OUTPUT | Relay sensor, allows activating the relay                                                         | -
+SensorLatchingRelay | 1     | USE_DIGITAL_OUTPUT | Latching Relay sensor, allows activating the relay with a pulse                                   | -
+SensorDHT11         | 2     | USE_DHT            | DHT11 sensor, return temperature/humidity based on the attached DHT sensor                        | https://github.com/mysensors/MySensorsArduinoExamples/tree/master/libraries/DHT
+SensorDHT22         | 2     | USE_DHT            | DHT22 sensor, return temperature/humidity based on the attached DHT sensor                        | https://github.com/mysensors/MySensorsArduinoExamples/tree/master/libraries/DHT
+SensorSHT21         | 2     | USE_SHT21          | SHT21 sensor, return temperature/humidity based on the attached SHT21 sensor                      | https://github.com/SodaqMoja/Sodaq_SHT2x
+SensorHTU21D        | 2     | USE_SHT21          | HTU21D sensor, return temperature/humidity based on the attached HTU21D sensor                    | https://github.com/SodaqMoja/Sodaq_SHT2x
+SensorSwitch        | 1     | USE_SWITCH         | Generic switch, wake up the board when a pin changes status                                       | -
+SensorDoor          | 1     | USE_SWITCH         | Door sensor, wake up the board and report when an attached magnetic sensor has been opened/closed | -
+SensorMotion        | 1     | USE_SWITCH         | Motion sensor, wake up the board and report when an attached PIR has triggered                    | -
+SensorDs18b20       | 1+    | USE_DS18B20        | DS18B20 sensor, return the temperature based on the attached sensor                               | https://github.com/milesburton/Arduino-Temperature-Control-Library
+SensorBH1750        | 1     | USE_BH1750         | BH1750 sensor, return light level in lux                                                          | https://github.com/claws/BH1750
+SensorMLX90614      | 2     | USE_MLX90614       | MLX90614 contactless temperature sensor, return ambient and object temperature                    | https://github.com/adafruit/Adafruit-MLX90614-Library
+SensorBME280        | 4     | USE_BME280         | BME280 sensor, return temperature/humidity/pressure based on the attached BME280 sensor           | https://github.com/adafruit/Adafruit_BME280_Library
+SensorBMP085        | 3     | USE_BMP085         | BMP085/BMP180 sensor, return temperature and pressure                                             | https://github.com/adafruit/Adafruit-BMP085-Library
+SensorBMP280        | 3     | USE_BMP280         | BMP280 sensor, return temperature/pressure based on the attached BMP280 sensor                    | https://github.com/adafruit/Adafruit_BMP280_Library
+SensorSonoff        | 1     | USE_SONOFF         | Sonoff wireless smart switch                                                                      | https://github.com/thomasfredericks/Bounce2
+SensorHCSR04        | 1     | USE_HCSR04         | HC-SR04 sensor, return the distance between the sensor and an object                              | https://github.com/mysensors/MySensorsArduinoExamples/tree/master/libraries/NewPing
+SensorMCP9808       | 1     | USE_MCP9808        | MCP9808 sensor, measure the temperature through the attached module                               | https://github.com/adafruit/Adafruit_MCP9808_Library
+SensorMQ            | 1     | USE_MQ             | MQ sensor, return ppm of the target gas                                                           | -
+SensorMHZ19         | 1     | USE_MHZ19          | MH-Z19 CO2 sensor via UART (SoftwareSerial, default on pins 6(Rx) and 7(Tx)                       | -
+SensorAM2320        | 2     | USE_AM2320         | AM2320 sensors, return temperature/humidity based on the attached AM2320 sensor                   | https://github.com/thakshak/AM2320
+SensorTSL2561       | 1     | USE_TSL2561        | TSL2561 sensor, return light in lux                                                               | https://github.com/adafruit/TSL2561-Arduino-Library
+SensorPT100         | 1     | USE_PT100          | DFRobot Driver high temperature sensor, return the temperature from the attached PT100 sensor     | -
+SensorDimmer        | 1     | USE_DIMMER         | Generic dimmer sensor used to drive a pwm output                                                  | -
+SensorRainGauge     | 1     | USE_PULSE_METER    | Rain gauge sensor                                                                                 | -
+SensorPowerMeter    | 1     | USE_PULSE_METER    | Power meter pulse sensor                                                                          | -
+SensorWaterMeter    | 1     | USE_PULSE_METER    | Water meter pulse sensor                                                                          | -
+SensorPlantowerPMS  | 3     | USE_PMS            | Plantower PMS particulate matter sensors (reporting PM<=1.0, PM<=2.5 and PM<=10.0 in µg/m³)       | https://github.com/fu-hsi/pms
+SensorVL53L0X       | 1     | USE_VL53L0X        | VL53L0X laser time-of-flight distance sensor via I²C, sleep pin supported (optional)              | https://github.com/pololu/vl53l0x-arduino
 
 ## Installation
 
@@ -625,8 +625,8 @@ Even if the sensor is sleeping most of the time, it can be potentially woke up b
  * NodeManager modules
  */
 
-#define MODULE_ANALOG_INPUT
-#define MODULE_THERMISTOR
+#define USE_ANALOG_INPUT
+#define USE_THERMISTOR
 
 /***********************************
  * Load NodeManager Library
@@ -725,7 +725,7 @@ The following sketch can be used to report back to the controller when a motion 
  * NodeManager modules
  */
 
-#define MODULE_SWITCH
+#define USE_SWITCH
 
 /***********************************
  * Load NodeManager Library
@@ -824,7 +824,7 @@ The board will be put to sleep just after startup and will report back to the co
  * NodeManager modules
  */
 
-#define MODULE_DIGITAL_OUTPUT
+#define USE_DIGITAL_OUTPUT
 
 /***********************************
  * Load NodeManager Library

--- a/README.md
+++ b/README.md
@@ -605,7 +605,6 @@ The sensor will be put to sleep after startup and will report both the measures 
 Even if the sensor is sleeping most of the time, it can be potentially woke up by sending a V_CUSTOM message to NodeManager service child id (200 by default) just after having reported its heartbeat. At this point the node will report awake and the user can interact with it by e.g. sending REQ messages to its child IDs, changing the duration of a sleep cycle, etc.
 
 ~~~c
-*/
 
 /**********************************
  * MySensors node configuration
@@ -705,7 +704,6 @@ void receiveTime(unsigned long ts) {
 The following sketch can be used to report back to the controller when a motion sensor attached to the board's pin 3 triggers. In this example, the board will be put to sleep just after startup and will report a heartbeat every hour. NodeManager will take care of configuring an interrupt associated to the provided pin so automatically wake up when a motion is detected and report a V_TRIPPED message back.
 
 ~~~c
-*/
 
 /**********************************
  * MySensors node configuration
@@ -804,7 +802,6 @@ In this example, the board also runs at 1Mhz so it can go down to 1.8V: by setti
 The board will be put to sleep just after startup and will report back to the controller every 5 minutes. It is the controller's responsability to catch when the board reports its heartbeat (using smart sleep behind the scene) and send a command back if needed.
 
 ~~~c
-*/
 
 /**********************************
  * MySensors node configuration

--- a/README.md
+++ b/README.md
@@ -253,7 +253,7 @@ You can interact with each class provided by NodeManager through a set of API fu
     void setRebootPin(int value);
     // [32] turn the ADC off so to save 0.2 mA
     void setADCOff();
-    // [30] if set save the sleep settings in memory, also when changed remotely (default: false)
+    // [40] if set save the sleep settings in memory, also when changed remotely (default: false)
     void setSaveSleepSettings(bool value);
 ~~~
 

--- a/README.md
+++ b/README.md
@@ -111,15 +111,21 @@ The next step is to enable NodeManager's modules required for your sensors. When
 
 ### Add your sensors
 
-Find in the main sketch `Add your sensors below` and add your sensors to NodeManager. To add a sensor, just create an instance of the class, passing it `node` as an argument and an optional pin. 
+Find in the main sketch `Add your sensors below` and add your sensors to NodeManager. To add a sensor, just create an instance of the class, passing it `node` as an argument. 
+Those sensors requiring a pin to operate would take it as a second argument in the constructor. 
+NodeManager automatically creates all the child_ids assigning an incremental counter. If you need to set your own child_id, pass it as the last argument to the constructor
 
 ~~~c
+// Add a thermistor sensor attached to pin A0
 SensorThermistor thermistor(node,A0);
+// Add a LDR sensor attached to pin A0 and assing child_id 5
+SensorLDR ldr(node,A1,5);
+// Add a temperature/humidity sensor SHT21 sensor. No pin required since using i2c
 SensorSHT21 sht21(node);
 ~~~
 
 The sensor will be then registered automatically with NodeManager which will take care of it all along its lifecycle. Please ensure the corresponding module has been previously enabled for a successful compilation of the code.
-NodeManager will assign a child id automatically, present each sensor for you to the controller, query each sensor and report the measure back to the gateway/controller. For actuators (e.g. relays) those can be triggered by sending a `REQ` message with the expected type to their assigned child id.
+NodeManager will present each sensor for you to the controller, query each sensor and report the measure back to the gateway/controller. For actuators (e.g. relays) those can be triggered by sending a `REQ` message with the expected type to their assigned child id.
 
 ### Configuring your sensors
 

--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ SensorPowerMeter    | 1     | USE_PULSE_METER    | Power meter pulse sensor     
 SensorWaterMeter    | 1     | USE_PULSE_METER    | Water meter pulse sensor                                                                          | -
 SensorPlantowerPMS  | 3     | USE_PMS            | Plantower PMS particulate matter sensors (reporting PM<=1.0, PM<=2.5 and PM<=10.0 in µg/m³)       | https://github.com/fu-hsi/pms
 SensorVL53L0X       | 1     | USE_VL53L0X        | VL53L0X laser time-of-flight distance sensor via I²C, sleep pin supported (optional)              | https://github.com/pololu/vl53l0x-arduino
+DisplaySSD1306      | 1     | MODULE_SSD1306     | SSD1306 128x64 OLED display (I²C); By default displays values of all sensors and children         | https://github.com/greiman/SSD1306Ascii.git
 
 ## Installation
 
@@ -504,6 +505,28 @@ Each sensor class exposes additional methods.
     void setInitialValue(int value);
     // set the interrupt mode to attach to (default: FALLING)
     void setInterruptMode(int value);
+~~~
+
+* DisplaySSD1306
+~~~c
+    // set device
+    void setDev(const DevType* dev);
+    // set i2c address
+    void setI2CAddress(uint8_t i2caddress);
+    // set text font (default: &Adafruit5x7)
+    void setFont(const uint8_t* font);
+    // [102] set the contrast of the display (0-255)
+    void setContrast(uint8_t value);
+    // [103] set the displayed text
+    void setText(const char* value);
+    // [104] Rotate the display 180 degree (use rotate=false to revert)
+    void rotateDisplay(bool rotate = true);
+    // [105] Text font size (possible are 1 and 2; default is 1)
+    void setFontSize(int fontsize);
+    // [106] Text caption font size (possible are 1 and 2; default is 2)
+    void setHeaderFontSize(int fontsize);
+    // [107] Invert display (black text on color background; use invert=false to revert)
+    void invertDisplay(bool invert = true);
 ~~~
 
 ### Remote API


### PR DESCRIPTION
This PR implements a number of good advice received after #229 was merged:

* Moved Child creation into the sensor's constructor. For those sensors deriving from another class where the Child is already created, type, presentation and description are modified by the subclasses 
* Added child_id in each constructor so the user can pass a preferred child_id when creating a sensor. If not provided the incremental counter is used instead
* Each sensor set "description" to the sensor's name
* Calling children.allocateBlocks() before creating any Child to avoid heap fragmentation
* Renamed MODULE_* into USE_*
* Renamed NO_MODULE_POWER_MANAGER into DISABLE_POWER_MANAGER
* Added DISABLE_INTERRUPTS (saves 1478 bytes in flash, 18 in SRAM)
* Added DISABLE_TRACK_LAST_VALUE (saves 114 bytes in flash)
* Added DISABLE_EEPROM (saves 117 bytes in flash)
* Added DISABLE_SLEEP (sabes 1054 bytes in flash)

This PR also includes:
* Support for SSD1306-based OLED I²C displays (see #245 for implementation details)
* Support for SHT31 temperature and humidity sensor (fixes #213)