### PR TITLE
Time Aware capability

### DIFF
--- a/NodeManager.ino
+++ b/NodeManager.ino
@@ -195,7 +195,7 @@ SensorSHT31         | 2     | USE_SHT31          | SHT31 sensor, return temperat
  * NodeManager modules
  */
 
-//#define USE_ANALOG_INPUT
+#define USE_ANALOG_INPUT
 //#define USE_THERMISTOR
 //#define USE_ML8511
 //#define USE_ACS712
@@ -259,7 +259,7 @@ NodeManager node;
 //PowerManager power(5,6);
 
 // Attached sensors
-//SensorAnalogInput analog(node,A0);
+SensorAnalogInput analog(node,A0);
 //SensorLDR ldr(node,A0);
 //SensorRain rain(node,A0);
 //SensorSoilMoisture soil(node,A0);
@@ -314,7 +314,7 @@ void before() {
   /*
   * Configure your sensors below
   */
-  //node.setReportIntervalSeconds(20);
+  node.setReportIntervalSeconds(20);
   //node.setReportIntervalMinutes(5);
   //node.setSleepMinutes(5);
   node.setSleepSeconds(10);
@@ -350,39 +350,6 @@ void setup() {
 void loop() {
   // call NodeManager loop routine
   node.loop();
-    tmElements_t tm;
-  RTC.read(tm);
-  Serial.print(tm.Day);
-  Serial.print("-");
-  Serial.print(tm.Month);
-  Serial.print("-");
-  Serial.print(tmYearToCalendar(tm.Year)-2000);
-  Serial.print(" ");
-  Serial.print(tm.Hour);
-  Serial.print(":");
-  Serial.print(tm.Minute);
-  Serial.print(":");
-  Serial.print(tm.Second);
-  Serial.println("");
-  
-   Serial.println(now());
-  Serial.println(millis());
-    // digital clock display of the time
-    Serial.print(hour());
-    Serial.print(' ');
-    Serial.print(minute());
-    Serial.print(' ');
-    Serial.print(second());
-    Serial.print(' ');
-    Serial.print(day());
-    Serial.print(' ');
-    Serial.print(month());
-    Serial.print(' ');
-    Serial.print(year()); 
-    Serial.println(); 
-    Serial.println(); 
-
-    
 }
 
 // receive

--- a/NodeManager.ino
+++ b/NodeManager.ino
@@ -203,7 +203,7 @@ SensorSHT31         | 2     | USE_SHT31          | SHT31 sensor, return temperat
 //#define USE_DIGITAL_OUTPUT
 //#define USE_DHT
 //#define USE_SHT21
-//#define USE_SWITCH
+#define USE_SWITCH
 //#define USE_DS18B20
 //#define USE_BH1750
 //#define USE_MLX90614
@@ -224,7 +224,6 @@ SensorSHT31         | 2     | USE_SHT31          | SHT31 sensor, return temperat
 //#define USE_VL53L0X
 //#define USE_SSD1306
 //#define USE_SHT31
-#define USE_TIME
 
 /***********************************
  * NodeManager advanced settings
@@ -237,6 +236,7 @@ SensorSHT31         | 2     | USE_SHT31          | SHT31 sensor, return temperat
 //#define DISABLE_TRACK_LAST_VALUE
 //#define DISABLE_EEPROM
 //#define DISABLE_SLEEP
+#define ENABLE_TIME
 
 /***********************************
  * Load NodeManager Library
@@ -273,7 +273,7 @@ NodeManager node;
 //SensorHTU21D htu21(node);
 //SensorSwitch sensorSwitch(node,3);
 //SensorDoor door(node,3);
-//SensorMotion motion(node,3);
+SensorMotion motion(node,3);
 //SensorDs18b20 ds18b20(node,6);
 //SensorBH1750 bh1750(node);
 //SensorMLX90614 mlx90614(node);
@@ -314,11 +314,13 @@ void before() {
   //node.setReportIntervalSeconds(10);
   //node.setReportIntervalMinutes(5);
   //node.setSleepMinutes(5);
-  node.setSleepSeconds(10);
+  node.setSleepSeconds(30);
+  //setTime(1516543198);
+/*
   RTC.set(1516543198);
   //setSyncProvider(RTC.get);
   setSyncInterval(0);
-  
+  */
   //node.setPowerManager(power);
   //battery.setReportIntervalMinutes(30);
   //sht21.children.get(1)->child_id = 5;
@@ -345,6 +347,7 @@ void setup() {
 void loop() {
   // call NodeManager loop routine
   node.loop();
+  /*
     tmElements_t tm;
   RTC.read(tm);
   Serial.print(tm.Day);
@@ -376,7 +379,7 @@ void loop() {
     Serial.print(year()); 
     Serial.println(); 
     Serial.println(); 
-
+*/
     
 }
 

--- a/NodeManager.ino
+++ b/NodeManager.ino
@@ -79,6 +79,23 @@ SensorVL53L0X       | 1     | USE_VL53L0X        | VL53L0X laser time-of-flight 
 DisplaySSD1306      | 1     | USE_SSD1306        | SSD1306 128x64 OLED display (I²C); By default displays values of all sensors and children         | https://github.com/greiman/SSD1306Ascii.git
 SensorSHT31         | 2     | USE_SHT31          | SHT31 sensor, return temperature/humidity based on the attached SHT31 sensor                      | https://github.com/adafruit/Adafruit_SHT31
 
+NodeManager provides useful built-in features which can be disabled if you need to save some storage for your code. 
+To enable/disable a buil-in feature:
+* Install the required library if any
+* Enable the corresponding feature by setting it to ON in the main sketch. To disable it, set it to OFF
+
+A list of buil-in features and the required dependencies is presented below:
+
+Feature                     | Default | Description                                                                                      | Dependencies
+----------------------------|---------|--------------------------------------------------------------------------------------------------|----------------------------------------------------------
+FEATURE_POWER_MANAGER       | ON      | allow powering on your sensors only while the node is awake                                      | - 
+FEATURE_INTERRUPTS          | ON      | allow managing interrupt-based sensors like a PIR or a door sensor                               | - 
+FEATURE_TRACK_LAST_VALUE    | ON      | allow reporting a measure only when different from the previous one                              | - 
+FEATURE_EEPROM              | ON      | allow keeping track of some information in the EEPROM                                            | - 
+FEATURE_SLEEP               | ON      | allow managing automatically the complexity behind battery-powered sleeping sensors              | - 
+FEATURE_TIME                | OFF     | allow keeping the current system time in sync with the controller                                | https://github.com/PaulStoffregen/Time
+FEATURE_RTC                 | OFF     | allow keeping the current system time in sync with an attached RTC device (requires FEATURE_TIME)| https://github.com/JChristensen/DS3232RTC
+
 /**********************************
  * MySensors node configuration
  */
@@ -87,7 +104,7 @@ SensorSHT31         | 2     | USE_SHT31          | SHT31 sensor, return temperat
 #define SKETCH_NAME "NodeManager"
 #define SKETCH_VERSION "1.0"
 //#define MY_DEBUG
-#define MY_NODE_ID 99
+//#define MY_NODE_ID 99
 
 // NRF24 radio settings
 #define MY_RADIO_NRF24
@@ -195,7 +212,7 @@ SensorSHT31         | 2     | USE_SHT31          | SHT31 sensor, return temperat
  * NodeManager modules
  */
 
-#define USE_ANALOG_INPUT
+//#define USE_ANALOG_INPUT
 //#define USE_THERMISTOR
 //#define USE_ML8511
 //#define USE_ACS712
@@ -232,14 +249,14 @@ SensorSHT31         | 2     | USE_SHT31          | SHT31 sensor, return temperat
 // NodeManager's debug output on serial console when defined
 #define NODEMANAGER_DEBUG
 
-// Enable/disable NodeManager's features
+// Enable/disable NodeManager's advanced features
 #define FEATURE_POWER_MANAGER ON
 #define FEATURE_INTERRUPTS ON
 #define FEATURE_TRACK_LAST_VALUE ON
 #define FEATURE_EEPROM ON
 #define FEATURE_SLEEP ON
-#define FEATURE_TIME ON
-#define FEATURE_RTC ON
+#define FEATURE_TIME OFF
+#define FEATURE_RTC OFF
 
 /***********************************
  * Load NodeManager Library
@@ -259,7 +276,7 @@ NodeManager node;
 //PowerManager power(5,6);
 
 // Attached sensors
-SensorAnalogInput analog(node,A0);
+//SensorAnalogInput analog(node,A0);
 //SensorLDR ldr(node,A0);
 //SensorRain rain(node,A0);
 //SensorSoilMoisture soil(node,A0);
@@ -314,19 +331,19 @@ void before() {
   /*
   * Configure your sensors below
   */
-  node.setReportIntervalSeconds(20);
-  //node.setReportIntervalMinutes(5);
+
+  // report measures of every attached sensors every 10 minutes
+  //node.setReportIntervalMinutes(10);
+  // set the node to sleep in 5 minutes cycles
   //node.setSleepMinutes(5);
-  node.setSleepSeconds(10);
-  //setTime(1516543198);
-/*
-  RTC.set(1516543198);
-  //setSyncProvider(RTC.get);
-  setSyncInterval(0);
-  */
-  //node.setPowerManager(power);
-  //battery.setReportIntervalMinutes(30);
+  // report battery level every 10 minutes
+  //battery.setReportIntervalMinutes(10);
+  // set an offset to -1 to a thermistor sensor
+  //thermistor.setOffset(-1);
+  // Change the id of a the first child of a sht21 sensor
   //sht21.children.get(1)->child_id = 5;
+  // power all the nodes through dedicated pins
+  //node.setPowerManager(power);
   
   /*
   * Configure your sensors above

--- a/NodeManager.ino
+++ b/NodeManager.ino
@@ -87,7 +87,7 @@ SensorSHT31         | 2     | USE_SHT31          | SHT31 sensor, return temperat
 #define SKETCH_NAME "NodeManager"
 #define SKETCH_VERSION "1.0"
 //#define MY_DEBUG
-//#define MY_NODE_ID 99
+#define MY_NODE_ID 99
 
 // NRF24 radio settings
 #define MY_RADIO_NRF24
@@ -224,6 +224,7 @@ SensorSHT31         | 2     | USE_SHT31          | SHT31 sensor, return temperat
 //#define USE_VL53L0X
 //#define USE_SSD1306
 //#define USE_SHT31
+#define USE_TIME
 
 /***********************************
  * NodeManager advanced settings
@@ -313,6 +314,10 @@ void before() {
   //node.setReportIntervalSeconds(10);
   //node.setReportIntervalMinutes(5);
   //node.setSleepMinutes(5);
+  node.setSleepSeconds(10);
+  RTC.set(1516543198);
+  //setSyncProvider(RTC.get);
+  setSyncInterval(0);
   
   //node.setPowerManager(power);
   //battery.setReportIntervalMinutes(30);
@@ -340,6 +345,39 @@ void setup() {
 void loop() {
   // call NodeManager loop routine
   node.loop();
+    tmElements_t tm;
+  RTC.read(tm);
+  Serial.print(tm.Day);
+  Serial.print("-");
+  Serial.print(tm.Month);
+  Serial.print("-");
+  Serial.print(tmYearToCalendar(tm.Year)-2000);
+  Serial.print(" ");
+  Serial.print(tm.Hour);
+  Serial.print(":");
+  Serial.print(tm.Minute);
+  Serial.print(":");
+  Serial.print(tm.Second);
+  Serial.println("");
+  
+   Serial.println(now());
+  Serial.println(millis());
+    // digital clock display of the time
+    Serial.print(hour());
+    Serial.print(' ');
+    Serial.print(minute());
+    Serial.print(' ');
+    Serial.print(second());
+    Serial.print(' ');
+    Serial.print(day());
+    Serial.print(' ');
+    Serial.print(month());
+    Serial.print(' ');
+    Serial.print(year()); 
+    Serial.println(); 
+    Serial.println(); 
+
+    
 }
 
 // receive

--- a/NodeManager.ino
+++ b/NodeManager.ino
@@ -229,14 +229,17 @@ SensorSHT31         | 2     | USE_SHT31          | SHT31 sensor, return temperat
  * NodeManager advanced settings
  */
 
+// NodeManager's debug output on serial console when defined
 #define NODEMANAGER_DEBUG
 
+// Enable/disable NodeManager's features
 #define FEATURE_POWER_MANAGER ON
 #define FEATURE_INTERRUPTS ON
 #define FEATURE_TRACK_LAST_VALUE ON
 #define FEATURE_EEPROM ON
 #define FEATURE_SLEEP ON
 #define FEATURE_TIME ON
+#define FEATURE_RTC OFF
 
 /***********************************
  * Load NodeManager Library
@@ -389,8 +392,10 @@ void receive(MyMessage &message) {
   node.receive(message);
 }
 
+#if FEATURE_TIME == ON
 // receiveTime
 void receiveTime(unsigned long ts) {
   // call NodeManager receiveTime routine
   node.receiveTime(ts);
 }
+#endif

--- a/NodeManager.ino
+++ b/NodeManager.ino
@@ -203,7 +203,7 @@ SensorSHT31         | 2     | USE_SHT31          | SHT31 sensor, return temperat
 //#define USE_DIGITAL_OUTPUT
 //#define USE_DHT
 //#define USE_SHT21
-#define USE_SWITCH
+//#define USE_SWITCH
 //#define USE_DS18B20
 //#define USE_BH1750
 //#define USE_MLX90614
@@ -273,7 +273,7 @@ NodeManager node;
 //SensorHTU21D htu21(node);
 //SensorSwitch sensorSwitch(node,3);
 //SensorDoor door(node,3);
-SensorMotion motion(node,3);
+//SensorMotion motion(node,3);
 //SensorDs18b20 ds18b20(node,6);
 //SensorBH1750 bh1750(node);
 //SensorMLX90614 mlx90614(node);
@@ -314,7 +314,7 @@ void before() {
   //node.setReportIntervalSeconds(10);
   //node.setReportIntervalMinutes(5);
   //node.setSleepMinutes(5);
-  node.setSleepSeconds(30);
+  //node.setSleepSeconds(30);
   //setTime(1516543198);
 /*
   RTC.set(1516543198);

--- a/NodeManager.ino
+++ b/NodeManager.ino
@@ -239,7 +239,7 @@ SensorSHT31         | 2     | USE_SHT31          | SHT31 sensor, return temperat
 #define FEATURE_EEPROM ON
 #define FEATURE_SLEEP ON
 #define FEATURE_TIME ON
-#define FEATURE_RTC OFF
+#define FEATURE_RTC ON
 
 /***********************************
  * Load NodeManager Library
@@ -314,10 +314,10 @@ void before() {
   /*
   * Configure your sensors below
   */
-  //node.setReportIntervalSeconds(10);
+  //node.setReportIntervalSeconds(20);
   //node.setReportIntervalMinutes(5);
   //node.setSleepMinutes(5);
-  //node.setSleepSeconds(30);
+  node.setSleepSeconds(10);
   //setTime(1516543198);
 /*
   RTC.set(1516543198);
@@ -350,7 +350,6 @@ void setup() {
 void loop() {
   // call NodeManager loop routine
   node.loop();
-  /*
     tmElements_t tm;
   RTC.read(tm);
   Serial.print(tm.Day);
@@ -382,7 +381,7 @@ void loop() {
     Serial.print(year()); 
     Serial.println(); 
     Serial.println(); 
-*/
+
     
 }
 

--- a/NodeManager.ino
+++ b/NodeManager.ino
@@ -231,12 +231,12 @@ SensorSHT31         | 2     | USE_SHT31          | SHT31 sensor, return temperat
 
 #define NODEMANAGER_DEBUG
 
-//#define DISABLE_POWER_MANAGER
-//#define DISABLE_INTERRUPTS
-//#define DISABLE_TRACK_LAST_VALUE
-//#define DISABLE_EEPROM
-//#define DISABLE_SLEEP
-#define ENABLE_TIME
+#define FEATURE_POWER_MANAGER ON
+#define FEATURE_INTERRUPTS ON
+#define FEATURE_TRACK_LAST_VALUE ON
+#define FEATURE_EEPROM ON
+#define FEATURE_SLEEP ON
+#define FEATURE_TIME ON
 
 /***********************************
  * Load NodeManager Library

--- a/NodeManagerLibrary.h
+++ b/NodeManagerLibrary.h
@@ -160,8 +160,10 @@
   #include <Wire.h>
   #include "Adafruit_SHT31.h"
 #endif
-#ifdef USE_TIME
+#ifdef ENABLE_TIME
   #include <DS3232RTC.h>
+  #include <TimeLib.h>
+
 #endif
 /*******************************************************************
    Classes
@@ -1467,8 +1469,6 @@ class NodeManager {
     // [21] set this to true if you want destination node to send ack back to this node (default: false)
     void setAck(bool value);
     bool getAck();
-    // request and return the current timestamp from the controller
-    long getTimestamp();
     // Request the controller's configuration on startup (default: true)
     void setGetControllerConfig(bool value);
     // [22] Manually set isMetric setting
@@ -1518,6 +1518,9 @@ class NodeManager {
     void setRebootPin(int value);
     // [32] turn the ADC off so to save 0.2 mA
     void setADCOff();
+#ifdef ENABLE_TIME
+    void syncTime();
+#endif
     // hook into the main sketch functions
     void before();
     void presentation();
@@ -1563,7 +1566,6 @@ class NodeManager {
     static long _last_interrupt_1;
     static long _last_interrupt_2;
 #endif
-    long _timestamp = -1;
     bool _ack = false;
     void _sleep();
     void _present(int child_id, int type);
@@ -1578,9 +1580,9 @@ class NodeManager {
     void _saveSleepSettings();
 #endif
     void _sleepBetweenSend();
-#ifdef USE_TIME
-    bool _time_received = false;
-    void _requestTime();
+#ifdef ENABLE_TIME
+    bool _time_is_valid = false;
+    long _remainder_sleep_time = -1;
 #endif
 };
 

--- a/NodeManagerLibrary.h
+++ b/NodeManagerLibrary.h
@@ -476,14 +476,18 @@ class Sensor {
 #endif
     // list of configured child
     List<Child*> children;
+#if FEATURE_INTERRUPTS == ON
+    void interrupt();
+#endif
+    Child* getChild(int child_id);
+    // register a child
+    void registerChild(Child* child);
+    NodeManager* _node;
     // define what to do at each stage of the sketch
     void before();
     void presentation();
     void setup();
     void loop(MyMessage* message);
-#if FEATURE_INTERRUPTS == ON
-    void interrupt();
-#endif
     void receive(MyMessage &message);
     // abstract functions, subclasses need to implement
     virtual void onBefore();
@@ -491,10 +495,6 @@ class Sensor {
     virtual void onLoop(Child* child);
     virtual void onReceive(MyMessage* message);
     virtual void onInterrupt();
-    Child* getChild(int child_id);
-    // register a child
-    void registerChild(Child* child);
-    NodeManager* _node;
   protected:
     const char* _name = "";
     int _pin = -1;
@@ -1527,12 +1527,6 @@ class NodeManager {
     long getTime();
     void receiveTime(unsigned long ts);
 #endif
-    // hook into the main sketch functions
-    void before();
-    void presentation();
-    void setup();
-    void loop();
-    void receive(MyMessage & msg);
 #if FEATURE_INTERRUPTS == ON
     // handle interrupts
     static void _onInterrupt_1();
@@ -1550,6 +1544,12 @@ class NodeManager {
     List<Sensor*> sensors;
     Child* getChild(int child_id);
     Sensor* getSensorWithChild(int child_id);
+    // hook into the main sketch functions
+    void before();
+    void presentation();
+    void setup();
+    void loop();
+    void receive(MyMessage & msg);
   private:
 #if FEATURE_POWER_MANAGER == ON
     PowerManager* _powerManager = nullptr;

--- a/NodeManagerLibrary.h
+++ b/NodeManagerLibrary.h
@@ -160,10 +160,9 @@
   #include <Wire.h>
   #include "Adafruit_SHT31.h"
 #endif
-#ifdef ENABLE_TIME
+#if FEATURE_TIME == ON
   #include <DS3232RTC.h>
   #include <TimeLib.h>
-
 #endif
 /*******************************************************************
    Classes
@@ -244,7 +243,7 @@ private:
    PowerManager
 */
 
-#ifndef DISABLE_POWER_MANAGER
+#if FEATURE_POWER_MANAGER == ON
 class PowerManager {
   public:
     PowerManager(int ground_pin, int vcc_pin, int wait_time = 50);
@@ -341,7 +340,7 @@ class Child {
     const char* description = "";
     virtual void sendValue();
     virtual void printOn(Print& p);
-#ifndef DISABLE_TRACK_LAST_VALUE
+#if FEATURE_TRACK_LAST_VALUE == ON
     Timer* force_update_timer;
     virtual bool isNewValue();
 #endif
@@ -357,12 +356,12 @@ class ChildInt: public Child {
     int getValueInt();
     void sendValue();
     void printOn(Print& p);
-#ifndef DISABLE_TRACK_LAST_VALUE
+#if FEATURE_TRACK_LAST_VALUE == ON
     bool isNewValue();
 #endif
   private:
     int _value;
-#ifndef DISABLE_TRACK_LAST_VALUE
+#if FEATURE_TRACK_LAST_VALUE == ON
     int _last_value;
 #endif
     int _total = 0;
@@ -375,12 +374,12 @@ class ChildFloat: public Child {
     float getValueFloat();
     void sendValue();
     void printOn(Print& p);
-#ifndef DISABLE_TRACK_LAST_VALUE
+#if FEATURE_TRACK_LAST_VALUE == ON
     bool isNewValue();
 #endif
   private:
     float _value;
-#ifndef DISABLE_TRACK_LAST_VALUE
+#if FEATURE_TRACK_LAST_VALUE == ON
     float _last_value;
 #endif
     float _total = 0;
@@ -393,12 +392,12 @@ class ChildDouble: public Child {
     double getValueDouble();
     void sendValue();
     void printOn(Print& p);
-#ifndef DISABLE_TRACK_LAST_VALUE
+#if FEATURE_TRACK_LAST_VALUE == ON
     bool isNewValue();
 #endif
   private:
     double _value;
-#ifndef DISABLE_TRACK_LAST_VALUE
+#if FEATURE_TRACK_LAST_VALUE == ON
     double _last_value;
 #endif
     double _total = 0;
@@ -411,12 +410,12 @@ class ChildString: public Child {
     const char* getValueString();
     void sendValue();
     void printOn(Print& p);
-#ifndef DISABLE_TRACK_LAST_VALUE
+#if FEATURE_TRACK_LAST_VALUE == ON
     bool isNewValue();
 #endif
   private:
     const char* _value = "";
-#ifndef DISABLE_TRACK_LAST_VALUE
+#if FEATURE_TRACK_LAST_VALUE == ON
     const char* _last_value = "";
 #endif
 };
@@ -438,13 +437,13 @@ class Sensor {
     void setSamples(int value);
     // [6] If more then one sample has to be taken, set the interval in milliseconds between measurements (default: 0)
     void setSamplesInterval(int value);
-#ifndef DISABLE_TRACK_LAST_VALUE
+#if FEATURE_TRACK_LAST_VALUE == ON
     // [7] if true will report the measure only if different than the previous one (default: false)
     void setTrackLastValue(bool value);
     // [9] if track last value is enabled, force to send an update after the configured number of minutes
     void setForceUpdateMinutes(int value);
 #endif
-#ifndef DISABLE_POWER_MANAGER
+#if FEATURE_POWER_MANAGER == ON
     // to save battery the sensor can be optionally connected to two pins which will act as vcc and ground and activated on demand
     void setPowerPins(int ground_pin, int vcc_pin, int wait_time = 50);
     // [13] manually turn the power on
@@ -462,13 +461,13 @@ class Sensor {
     void setReportIntervalDays(int value);
     // return true if the report interval has been already configured
     bool isReportIntervalConfigured();
-#ifndef DISABLE_INTERRUPTS
+#if FEATURE_INTERRUPTS == ON
     // return the pin the interrupt is attached to
     int getInterruptPin();
     // listen for interrupts on the given pin so interrupt() will be called when occurring
     void setInterrupt(int pin, int mode, int initial);
 #endif
-#ifndef DISABLE_POWER_MANAGER
+#if FEATURE_POWER_MANAGER == ON
     // set a previously configured PowerManager to the sensor so to powering it up with custom pins
     void setPowerManager(PowerManager& powerManager);
 #endif
@@ -479,7 +478,7 @@ class Sensor {
     void presentation();
     void setup();
     void loop(MyMessage* message);
-#ifndef DISABLE_INTERRUPTS
+#if FEATURE_INTERRUPTS == ON
     void interrupt();
 #endif
     void receive(MyMessage &message);
@@ -498,13 +497,13 @@ class Sensor {
     int _pin = -1;
     int _samples = 1;
     int _samples_interval = 0;
-#ifndef DISABLE_TRACK_LAST_VALUE
+#if FEATURE_TRACK_LAST_VALUE == ON
     bool _track_last_value = false;
 #endif
-#ifndef DISABLE_INTERRUPTS
+#if FEATURE_INTERRUPTS == ON
     int _interrupt_pin = -1;
 #endif
-#ifndef DISABLE_POWER_MANAGER
+#if FEATURE_POWER_MANAGER == ON
     PowerManager* _powerManager = nullptr;
 #endif
     Timer* _report_timer;
@@ -1435,7 +1434,7 @@ class NodeManager {
     // [10] send the same message multiple times (default: 1)
     void setRetries(int value);
     int getRetries();
-#ifndef DISABLE_SLEEP
+#if FEATURE_SLEEP == ON
     // [3] set the duration (in seconds) of a sleep cycle
     void setSleepSeconds(int value);
     long getSleepSeconds();
@@ -1446,7 +1445,7 @@ class NodeManager {
     // [29] set the duration (in days) of a sleep cycle
     void setSleepDays(int value);
 #endif
-#ifndef DISABLE_INTERRUPTS
+#if FEATURE_INTERRUPTS == ON
     // [19] if enabled, when waking up from the interrupt, the board stops sleeping. Disable it when attaching e.g. a motion sensor (default: true)
     void setSleepInterruptPin(int value);
     // configure the interrupt pin and mode. Mode can be CHANGE, RISING, FALLING (default: MODE_NOT_DEFINED)
@@ -1459,7 +1458,7 @@ class NodeManager {
     // register a sensor
     void registerSensor(Sensor* sensor);
     // to save battery the sensor can be optionally connected to two pins which will act as vcc and ground and activated on demand
-#ifndef DISABLE_POWER_MANAGER
+#if FEATURE_POWER_MANAGER == ON
     void setPowerPins(int ground_pin, int vcc_pin, int wait_time = 50);
     // [24] manually turn the power on
     void powerOn();
@@ -1484,7 +1483,7 @@ class NodeManager {
     void reboot();
     // [9] wake up the board
     void wakeup();
-#ifndef DISABLE_EEPROM
+#if FEATURE_EEPROM == ON
     // [7] clear the EEPROM
     void clearEeprom();
     // return the value stored at the requested index from the EEPROM
@@ -1496,7 +1495,7 @@ class NodeManager {
 #endif
     // return vcc in V
     float getVcc();
-#ifndef DISABLE_INTERRUPTS
+#if FEATURE_INTERRUPTS == ON
     // setup the configured interrupt pins
     void setupInterrupts();
     // return the pin from which the last interrupt came
@@ -1518,7 +1517,7 @@ class NodeManager {
     void setRebootPin(int value);
     // [32] turn the ADC off so to save 0.2 mA
     void setADCOff();
-#ifdef ENABLE_TIME
+#if FEATURE_TIME == ON
     void syncTime();
 #endif
     // hook into the main sketch functions
@@ -1528,7 +1527,7 @@ class NodeManager {
     void loop();
     void receive(MyMessage & msg);
     void receiveTime(unsigned long ts);
-#ifndef DISABLE_INTERRUPTS
+#if FEATURE_INTERRUPTS == ON
     // handle interrupts
     static void _onInterrupt_1();
     static void _onInterrupt_2();
@@ -1538,7 +1537,7 @@ class NodeManager {
     void sendMessage(int child_id, int type, float value);
     void sendMessage(int child_id, int type, double value);
     void sendMessage(int child_id, int type, const char* value);
-#ifndef DISABLE_POWER_MANAGER
+#if FEATURE_POWER_MANAGER == ON
     void setPowerManager(PowerManager& powerManager);
 #endif
     int getAvailableChildId(int child_id = -255);
@@ -1546,7 +1545,7 @@ class NodeManager {
     Child* getChild(int child_id);
     Sensor* getSensorWithChild(int child_id);
   private:
-#ifndef DISABLE_POWER_MANAGER
+#if FEATURE_POWER_MANAGER == ON
     PowerManager* _powerManager = nullptr;
 #endif
     MyMessage _message;
@@ -1556,7 +1555,7 @@ class NodeManager {
     int _sleep_interrupt_pin = -1;
     int _sleep_between_send = 0;
     int _retries = 1;
-#ifndef DISABLE_INTERRUPTS
+#if FEATURE_INTERRUPTS == ON
     int _interrupt_1_mode = MODE_NOT_DEFINED;
     int _interrupt_2_mode = MODE_NOT_DEFINED;
     int _interrupt_1_initial = -1;
@@ -1574,13 +1573,13 @@ class NodeManager {
     int _report_interval_seconds = 10*60;
     bool _sleep_or_wait = true;
     int _reboot_pin = -1;
-#ifndef DISABLE_EEPROM
+#if FEATURE_EEPROM == ON
     bool _save_sleep_settings = false;
     void _loadSleepSettings();
     void _saveSleepSettings();
 #endif
     void _sleepBetweenSend();
-#ifdef ENABLE_TIME
+#if FEATURE_TIME == ON
     bool _time_is_valid = false;
     long _remainder_sleep_time = -1;
     long _time_last_sync;

--- a/NodeManagerLibrary.h
+++ b/NodeManagerLibrary.h
@@ -1583,6 +1583,7 @@ class NodeManager {
 #ifdef ENABLE_TIME
     bool _time_is_valid = false;
     long _remainder_sleep_time = -1;
+    long _time_last_sync;
 #endif
 };
 

--- a/NodeManagerLibrary.h
+++ b/NodeManagerLibrary.h
@@ -161,8 +161,11 @@
   #include "Adafruit_SHT31.h"
 #endif
 #if FEATURE_TIME == ON
-  #include <DS3232RTC.h>
   #include <TimeLib.h>
+#endif
+#if FEATURE_RTC == ON
+  #define FEATURE_TIME ON
+  #include <DS3232RTC.h>
 #endif
 /*******************************************************************
    Classes
@@ -1526,7 +1529,9 @@ class NodeManager {
     void setup();
     void loop();
     void receive(MyMessage & msg);
+#if FEATURE_TIME == ON
     void receiveTime(unsigned long ts);
+#endif
 #if FEATURE_INTERRUPTS == ON
     // handle interrupts
     static void _onInterrupt_1();

--- a/NodeManagerLibrary.h
+++ b/NodeManagerLibrary.h
@@ -299,10 +299,10 @@ class Timer {
     NodeManager* _node;
     int _target = 0;
     long _elapsed = 0;
-    long _last_millis = 0;
     bool _is_running = false;
     bool _is_configured = false;
     bool _first_run = true;
+    long _last = 0;
 };
 
 /*
@@ -1521,7 +1521,11 @@ class NodeManager {
     // [32] turn the ADC off so to save 0.2 mA
     void setADCOff();
 #if FEATURE_TIME == ON
+    // [41] synchronize the local time with the controller
     void syncTime();
+    // [42] returns the current system time
+    long getTime();
+    void receiveTime(unsigned long ts);
 #endif
     // hook into the main sketch functions
     void before();
@@ -1529,9 +1533,6 @@ class NodeManager {
     void setup();
     void loop();
     void receive(MyMessage & msg);
-#if FEATURE_TIME == ON
-    void receiveTime(unsigned long ts);
-#endif
 #if FEATURE_INTERRUPTS == ON
     // handle interrupts
     static void _onInterrupt_1();

--- a/NodeManagerLibrary.h
+++ b/NodeManagerLibrary.h
@@ -1296,7 +1296,7 @@ class SensorPulseMeter: public Sensor {
     void onProcess(Request & request);
     void onInterrupt();
   protected:
-    long _count = 20;
+    long _count = 0;
     float _pulse_factor;
     int _initial_value = HIGH;
     int _interrupt_mode = FALLING;

--- a/NodeManagerLibrary.h
+++ b/NodeManagerLibrary.h
@@ -160,7 +160,9 @@
   #include <Wire.h>
   #include "Adafruit_SHT31.h"
 #endif
-
+#ifdef USE_TIME
+  #include <DS3232RTC.h>
+#endif
 /*******************************************************************
    Classes
 */
@@ -1576,6 +1578,10 @@ class NodeManager {
     void _saveSleepSettings();
 #endif
     void _sleepBetweenSend();
+#ifdef USE_TIME
+    bool _time_received = false;
+    void _requestTime();
+#endif
 };
 
 #endif

--- a/NodeManagerLibrary.ino
+++ b/NodeManagerLibrary.ino
@@ -3866,20 +3866,20 @@ void NodeManager::receive(MyMessage &message) {
   }
 }
 
+#if FEATURE_TIME == ON
 // receive the time from the controller and save it
 void NodeManager::receiveTime(unsigned long ts) {
   #ifdef NODEMANAGER_DEBUG
     Serial.print(F("TIME T="));
     Serial.println(ts);
   #endif
-  #if FEATURE_TIME == ON
-    // time is now valid
-    _time_is_valid = true;
-    // set the current system time to the received time
-    setTime(ts);
-    _time_last_sync = now();
-  #endif
+  // time is now valid
+  _time_is_valid = true;
+  // set the current system time to the received time
+  setTime(ts);
+  _time_last_sync = now();
 }
+#endif
 
 // Send a hello message back to the controller
 void NodeManager::hello() {

--- a/NodeManagerLibrary.ino
+++ b/NodeManagerLibrary.ino
@@ -2835,15 +2835,8 @@ void SensorPulseMeter::onSetup() {
 void SensorPulseMeter::onLoop(Child* child) {
   // do not report anything if called by an interrupt
   if (_node->getLastInterruptPin() == _interrupt_pin) return;
-  // time to report the rain so far
+  // time to report the accumulated value so far
   _reportTotal(child);
-  #ifdef NODEMANAGER_DEBUG
-    Serial.print(_name);
-    Serial.print(F(" I="));
-    Serial.print(child->child_id);
-    Serial.print(F(" T="));
-    Serial.println(((ChildFloat*)child)->getValueFloat());
-  #endif
   // reset the counter
   _count = 0;
 }
@@ -2871,6 +2864,13 @@ void SensorPulseMeter::onInterrupt() {
 // return the total based on the pulses counted
 void SensorPulseMeter::_reportTotal(Child* child) {
   ((ChildFloat*)child)->setValueFloat(_count / _pulse_factor);
+  #ifdef NODEMANAGER_DEBUG
+    Serial.print(_name);
+    Serial.print(F(" I="));
+    Serial.print(child->child_id);
+    Serial.print(F(" V="));
+    Serial.println(((ChildFloat*)child)->getValueFloat());
+  #endif
 }
 
 /*
@@ -2898,6 +2898,14 @@ SensorPowerMeter::SensorPowerMeter(NodeManager& node_manager, int pin, int child
 // return the total based on the pulses counted
 void SensorPowerMeter::_reportTotal(Child* child) {
   ((ChildDouble*)child)->setValueDouble(_count / _pulse_factor);
+  #ifdef NODEMANAGER_DEBUG
+    Serial.print(_name);
+    Serial.print(F(" I="));
+    Serial.print(child->child_id);
+    Serial.print(F(" V="));
+    Serial.println(((ChildDouble*)child)->getValueDouble());
+    Serial.println(_count);
+  #endif
 }
 
 /*
@@ -2914,6 +2922,13 @@ SensorWaterMeter::SensorWaterMeter(NodeManager& node_manager, int pin, int child
 // return the total based on the pulses counted
 void SensorWaterMeter::_reportTotal(Child* child) {
   ((ChildDouble*)child)->setValueDouble(_count / _pulse_factor);
+  #ifdef NODEMANAGER_DEBUG
+    Serial.print(_name);
+    Serial.print(F(" I="));
+    Serial.print(child->child_id);
+    Serial.print(F(" V="));
+    Serial.println(((ChildDouble*)child)->getValueDouble());
+  #endif
 }
 #endif
 

--- a/NodeManagerLibrary.ino
+++ b/NodeManagerLibrary.ino
@@ -6,7 +6,7 @@
    PowerManager
 */
 
-#ifndef DISABLE_POWER_MANAGER
+#if FEATURE_POWER_MANAGER == ON
 PowerManager::PowerManager(int ground_pin, int vcc_pin, int wait_time) {
   setPowerPins(ground_pin, vcc_pin, wait_time);
 }
@@ -120,7 +120,7 @@ void Timer::unset() {
 // update the timer at every cycle
 void Timer::update() {
   if (! isRunning()) return;
-#ifndef DISABLE_SLEEP
+#if FEATURE_SLEEP == ON
   if (_node->isSleepingNode()) {
     // millis() is not reliable while sleeping so calculate how long a sleep cycle would last in seconds and update the elapsed time
     _elapsed += _node->getSleepSeconds();
@@ -128,7 +128,7 @@ void Timer::update() {
 #endif
     // use millis() to calculate the elapsed time in seconds
     _elapsed = (long)((millis() - _last_millis)/1000);
-#ifndef DISABLE_SLEEP
+#if FEATURE_SLEEP == ON
   }
 #endif
   _first_run = false;
@@ -236,7 +236,7 @@ Child::Child(Sensor* __sensor, int _child_id, int _presentation, int _type, cons
   description = _description;
   _sensor = __sensor;
   _sensor->registerChild(this);
-#ifndef DISABLE_TRACK_LAST_VALUE
+#if FEATURE_TRACK_LAST_VALUE == ON
   force_update_timer = new Timer(_sensor->_node);
 #endif
 }
@@ -246,7 +246,7 @@ void Child::sendValue() {
 // Print the child's value (variable type depending on the child class) to the given output
 void Child::printOn(Print& p) {
 }
-#ifndef DISABLE_TRACK_LAST_VALUE
+#if FEATURE_TRACK_LAST_VALUE == ON
 // check if it is an updated value, implemented by the subclasses
 bool Child::isNewValue() {
 }
@@ -276,7 +276,7 @@ int ChildInt::getValueInt() {
 void ChildInt::sendValue() {
   if (_samples == 0) return;
   _sensor->_node->sendMessage(child_id,type,_value);
-#ifndef DISABLE_TRACK_LAST_VALUE
+#if FEATURE_TRACK_LAST_VALUE == ON
   _last_value = _value;
 #endif
   _total = 0;
@@ -288,7 +288,7 @@ void ChildInt::printOn(Print& p) {
   p.print(_value);
 }
 
-#ifndef DISABLE_TRACK_LAST_VALUE
+#if FEATURE_TRACK_LAST_VALUE == ON
 // check if it is an updated value
 bool ChildInt::isNewValue() {
   return _last_value != _value;
@@ -319,7 +319,7 @@ float ChildFloat::getValueFloat() {
 void ChildFloat::sendValue() {
   if (_samples == 0) return;
   _sensor->_node->sendMessage(child_id,type,_value);
-#ifndef DISABLE_TRACK_LAST_VALUE
+#if FEATURE_TRACK_LAST_VALUE == ON
   _last_value = _value;
 #endif
   _total = 0;
@@ -331,7 +331,7 @@ void ChildFloat::printOn(Print& p) {
   p.print(_value);
 }
 
-#ifndef DISABLE_TRACK_LAST_VALUE
+#if FEATURE_TRACK_LAST_VALUE == ON
 // check if it is an updated value
 bool ChildFloat::isNewValue() {
   return _last_value != _value;
@@ -362,7 +362,7 @@ double ChildDouble::getValueDouble() {
 void ChildDouble::sendValue() {
   if (_samples == 0) return;
   _sensor->_node->sendMessage(child_id,type,_value);
-#ifndef DISABLE_TRACK_LAST_VALUE
+#if FEATURE_TRACK_LAST_VALUE == ON
   _last_value = _value;
 #endif
   _total = 0;
@@ -374,7 +374,7 @@ void ChildDouble::printOn(Print& p) {
   p.print(_value);
 }
 
-#ifndef DISABLE_TRACK_LAST_VALUE
+#if FEATURE_TRACK_LAST_VALUE == ON
 // check if it is an updated value
 bool ChildDouble::isNewValue() {
   return _last_value != _value;
@@ -402,7 +402,7 @@ const char* ChildString::getValueString() {
 // send the value back to the controller
 void ChildString::sendValue() {
   _sensor->_node->sendMessage(child_id,type,_value);
-#ifndef DISABLE_TRACK_LAST_VALUE
+#if FEATURE_TRACK_LAST_VALUE == ON
   _last_value = _value;
 #endif
   _value = "";
@@ -413,7 +413,7 @@ void ChildString::printOn(Print& p) {
   p.print(_value);
 }
 
-#ifndef DISABLE_TRACK_LAST_VALUE
+#if FEATURE_TRACK_LAST_VALUE == ON
 // check if it is an updated value
 bool ChildString::isNewValue() {
   return strcmp(_value, _last_value) != 0;
@@ -451,7 +451,7 @@ void Sensor::setSamples(int value) {
 void Sensor::setSamplesInterval(int value) {
   _samples_interval = value;
 }
-#ifndef DISABLE_TRACK_LAST_VALUE
+#if FEATURE_TRACK_LAST_VALUE == ON
 void Sensor::setTrackLastValue(bool value) {
   _track_last_value = value;
 }
@@ -462,7 +462,7 @@ void Sensor::setForceUpdateMinutes(int value) {
   }
 }
 #endif
-#ifndef DISABLE_POWER_MANAGER
+#if FEATURE_POWER_MANAGER == ON
 void Sensor::setPowerPins(int ground_pin, int vcc_pin, int wait_time) {
   if (_powerManager == nullptr) return;
   _powerManager->setPowerPins(ground_pin, vcc_pin, wait_time);
@@ -476,7 +476,7 @@ void Sensor::powerOff() {
   _powerManager->powerOff();
 }
 #endif
-#ifndef DISABLE_INTERRUPTS
+#if FEATURE_INTERRUPTS == ON
 int Sensor::getInterruptPin() {
   return _interrupt_pin;
 }
@@ -508,7 +508,7 @@ bool Sensor::isReportIntervalConfigured() {
   return _report_timer->isConfigured();
 }
 
-#ifndef DISABLE_INTERRUPTS
+#if FEATURE_INTERRUPTS == ON
 // listen for interrupts on the given pin so interrupt() will be called when occurring
 void Sensor::setInterrupt(int pin, int mode, int initial) {
   _interrupt_pin = pin;
@@ -574,13 +574,13 @@ void Sensor::loop(MyMessage* message) {
     }
   }
   // turn the sensor on
-#ifndef DISABLE_POWER_MANAGER
+#if FEATURE_POWER_MANAGER == ON
   powerOn();
 #endif
   // iterates over all the children
   for (List<Child*>::iterator itr = children.begin(); itr != children.end(); ++itr) {
     Child* child = *itr;
-#ifndef DISABLE_TRACK_LAST_VALUE
+#if FEATURE_TRACK_LAST_VALUE == ON
     // update the force update timer if running
     if (child->force_update_timer->isRunning()) child->force_update_timer->update();
 #endif
@@ -598,7 +598,7 @@ void Sensor::loop(MyMessage* message) {
     // process the result and send a response back if 1) is not a loop 2) not tracking last value 3) tracking last value and there is a new value 4) tracking last value and timer is over
     if (
       message != nullptr 
-#ifndef DISABLE_TRACK_LAST_VALUE
+#if FEATURE_TRACK_LAST_VALUE == ON
       || ! _track_last_value || 
       _track_last_value && child->isNewValue() || 
       _track_last_value && child->force_update_timer->isRunning() && child->force_update_timer->isOver()
@@ -607,14 +607,14 @@ void Sensor::loop(MyMessage* message) {
         child->sendValue();
   }
   // turn the sensor off
-#ifndef DISABLE_POWER_MANAGER
+#if FEATURE_POWER_MANAGER == ON
   powerOff();
 #endif
   // if called from loop(), restart the report timer if over
   if (message == nullptr && _report_timer->isRunning() && _report_timer->isOver()) _report_timer->restart();
 }
 
-#ifndef DISABLE_INTERRUPTS
+#if FEATURE_INTERRUPTS == ON
 // receive and handle an interrupt
 void Sensor::interrupt() {
   // call the implementation of onInterrupt()
@@ -637,7 +637,7 @@ Child* Sensor::getChild(int child_id) {
   return nullptr;
 }
 
-#ifndef DISABLE_POWER_MANAGER
+#if FEATURE_POWER_MANAGER == ON
 void Sensor::setPowerManager(PowerManager& powerManager) {
   _powerManager = &powerManager;
 }
@@ -3284,7 +3284,7 @@ void SensorConfiguration::onReceive(MyMessage* message) {
   if (child_id == 0) {
     switch(function) {
       case 1: _node->hello(); break;
-#ifndef DISABLE_SLEEP
+#if FEATURE_SLEEP == ON
       case 3: _node->setSleepSeconds(request.getValueInt()); break;
       case 4: _node->setSleepMinutes(request.getValueInt()); break;
       case 5: _node->setSleepHours(request.getValueInt()); break;
@@ -3293,7 +3293,7 @@ void SensorConfiguration::onReceive(MyMessage* message) {
 #ifndef MY_GATEWAY_ESP8266
       case 6: _node->reboot(); return;
 #endif
-#ifndef DISABLE_EEPROM
+#if FEATURE_EEPROM == ON
       case 7: _node->clearEeprom(); break;
       case 27: _node->saveToMemory(0,request.getValueInt()); break;
       case 40: _node->setSaveSleepSettings(request.getValueInt()); break;
@@ -3301,14 +3301,14 @@ void SensorConfiguration::onReceive(MyMessage* message) {
       case 8: _node->sendMessage(CONFIGURATION_CHILD_ID,V_CUSTOM,VERSION); return;
       case 9: _node->wakeup(); break;
       case 10: _node->setRetries(request.getValueInt()); break;
-#ifndef DISABLE_INTERRUPTS
+#if FEATURE_INTERRUPTS == ON
       case 19: _node->setSleepInterruptPin(request.getValueInt()); break;
       case 28: _node->setInterruptMinDelta(request.getValueInt()); break;
 #endif
       case 20: _node->setSleepBetweenSend(request.getValueInt()); break;
       case 21: _node->setAck(request.getValueInt()); break;
       case 22: _node->setIsMetric(request.getValueInt()); break;
-#ifndef DISABLE_POWER_MANAGER
+#if FEATURE_POWER_MANAGER == ON
       case 24: _node->powerOn(); break;
       case 25: _node->powerOff(); break;
 #endif
@@ -3332,11 +3332,11 @@ void SensorConfiguration::onReceive(MyMessage* message) {
         case 1: sensor->setPin(request.getValueInt()); break;
         case 5: sensor->setSamples(request.getValueInt()); break;
         case 6: sensor->setSamplesInterval(request.getValueInt()); break;
-#ifndef DISABLE_TRACK_LAST_VALUE
+#if FEATURE_TRACK_LAST_VALUE == ON
         case 7: sensor->setTrackLastValue(request.getValueInt()); break;
         case 9: sensor->setForceUpdateMinutes(request.getValueInt()); break;
 #endif
-#ifndef DISABLE_POWER_MANAGER
+#if FEATURE_POWER_MANAGER == ON
         case 13: sensor->powerOn(); break;
         case 14: sensor->powerOff(); break;
 #endif
@@ -3577,7 +3577,7 @@ NodeManager::NodeManager(int sensorcount) {
   }
 }
 
-#ifndef DISABLE_INTERRUPTS
+#if FEATURE_INTERRUPTS == ON
 int NodeManager::_last_interrupt_pin = -1;
 long NodeManager::_last_interrupt_1 = millis();
 long NodeManager::_last_interrupt_2 = millis();
@@ -3591,14 +3591,14 @@ void NodeManager::setRetries(int value) {
 int NodeManager::getRetries() {
   return _retries;
 }
-#ifndef DISABLE_SLEEP
+#if FEATURE_SLEEP == ON
 void NodeManager::setSleepSeconds(int value) {
   // set the status to AWAKE if the time provided is 0, SLEEP otherwise
   if (value == 0) _status = AWAKE;
   else _status = SLEEP;
   // store the time
   _sleep_time = value;
-#ifndef DISABLE_EEPROM
+#if FEATURE_EEPROM == ON
   // save sleep settings to eeprom
   if (_save_sleep_settings) _saveSleepSettings();
 #endif
@@ -3616,7 +3616,7 @@ long NodeManager::getSleepSeconds() {
   return _sleep_time;
 }
 #endif
-#ifndef DISABLE_INTERRUPTS
+#if FEATURE_INTERRUPTS == ON
 void NodeManager::setSleepInterruptPin(int value) {
   _sleep_interrupt_pin = value;
 }
@@ -3634,7 +3634,7 @@ void NodeManager::setInterruptMinDelta(long value) {
   _interrupt_min_delta = value;
 }
 #endif
-#ifndef DISABLE_POWER_MANAGER
+#if FEATURE_POWER_MANAGER == ON
 void NodeManager::setPowerPins(int ground_pin, int vcc_pin, int wait_time) {
   if (_powerManager == nullptr) return;
   _powerManager->setPowerPins(ground_pin, vcc_pin, wait_time);
@@ -3666,7 +3666,7 @@ void NodeManager::setIsMetric(bool value) {
 bool NodeManager::getIsMetric() {
   return _is_metric;
 }
-#ifndef DISABLE_EEPROM
+#if FEATURE_EEPROM == ON
 void NodeManager::setSaveSleepSettings(bool value) {
   _save_sleep_settings = value;
 }
@@ -3725,7 +3725,7 @@ void NodeManager::before() {
     Serial.print(F(" B="));
     Serial.println(MY_CAP_RXBUF);
   #endif
-#ifndef DISABLE_EEPROM
+#if FEATURE_EEPROM == ON
   // restore the sleep settings saved in the eeprom
   if (_save_sleep_settings) _loadSleepSettings();
 #endif
@@ -3779,7 +3779,7 @@ void NodeManager::setup() {
     Serial.print(F(" M="));
     Serial.println(_is_metric);
   #endif
-#ifdef ENABLE_TIME
+#if FEATURE_TIME == ON
   // sync the time with the controller
   syncTime();
 #endif
@@ -3789,7 +3789,7 @@ void NodeManager::setup() {
     // call each sensor's setup()
     sensor->setup();
   }
-#ifndef DISABLE_INTERRUPTS
+#if FEATURE_INTERRUPTS == ON
   // setup the interrupt pins
   setupInterrupts();
 #endif
@@ -3797,18 +3797,18 @@ void NodeManager::setup() {
 
 // run the main function for all the register sensors
 void NodeManager::loop() {
-#ifdef ENABLE_TIME
+#if FEATURE_TIME == ON
   // if the time was last updated more than 60 minutes ago, update it
   if (_time_is_valid && (now() - _time_last_sync) > 60*60) syncTime();
 #endif
   // turn on the pin powering all the sensors
-#ifndef DISABLE_POWER_MANAGER
+#if FEATURE_POWER_MANAGER == ON
   powerOn();
 #endif
   // run loop for all the registered sensors
   for (List<Sensor*>::iterator itr = sensors.begin(); itr != sensors.end(); ++itr) {
     Sensor* sensor = *itr;
-#ifndef DISABLE_INTERRUPTS
+#if FEATURE_INTERRUPTS == ON
     if (_last_interrupt_pin != -1 && sensor->getInterruptPin() == _last_interrupt_pin) {
       // if there was an interrupt for this sensor, call the sensor's interrupt() and then loop()
       _message.clear();
@@ -3827,10 +3827,10 @@ void NodeManager::loop() {
     }
   }
   // turn off the pin powering all the sensors
-#ifndef DISABLE_POWER_MANAGER
+#if FEATURE_POWER_MANAGER == ON
   powerOff();
 #endif
-#ifndef DISABLE_SLEEP
+#if FEATURE_SLEEP == ON
   // continue/start sleeping as requested
   if (isSleepingNode()) _sleep();
 #endif
@@ -3854,13 +3854,13 @@ void NodeManager::receive(MyMessage &message) {
   Sensor* sensor = getSensorWithChild(message.sensor);
   if (sensor != nullptr) {
     // turn on the pin powering all the sensors
-    #ifndef DISABLE_POWER_MANAGER
+    #if FEATURE_POWER_MANAGER == ON
       powerOn();
     #endif
     // call the sensor's receive()
     sensor->receive(message);
     // turn off the pin powering all the sensors
-    #ifndef DISABLE_POWER_MANAGER
+    #if FEATURE_POWER_MANAGER == ON
       powerOff();
     #endif
   }
@@ -3872,7 +3872,7 @@ void NodeManager::receiveTime(unsigned long ts) {
     Serial.print(F("TIME T="));
     Serial.println(ts);
   #endif
-  #ifdef ENABLE_TIME
+  #if FEATURE_TIME == ON
     // time is now valid
     _time_is_valid = true;
     // set the current system time to the received time
@@ -3906,7 +3906,7 @@ void NodeManager::reboot() {
   #endif
 }
 
-#ifndef DISABLE_EEPROM
+#if FEATURE_EEPROM == ON
 // clear the EEPROM
 void NodeManager::clearEeprom() {
   #ifdef NODEMANAGER_DEBUG
@@ -3959,7 +3959,7 @@ float NodeManager::getVcc() {
   #endif
 }
 
-#ifndef DISABLE_INTERRUPTS
+#if FEATURE_INTERRUPTS == ON
 // setup the interrupt pins
 void NodeManager::setupInterrupts() {
   // configure wakeup pin if needed
@@ -4056,7 +4056,7 @@ int NodeManager::getAvailableChildId(int child_id) {
   return 254;
 }
 
-#ifndef DISABLE_INTERRUPTS
+#if FEATURE_INTERRUPTS == ON
 // handle an interrupt
 void NodeManager::_onInterrupt_1() {
   long now = millis();
@@ -4133,7 +4133,7 @@ void NodeManager::_sendMessage(int child_id, int type) {
   }
 }
 
-#ifndef DISABLE_POWER_MANAGER
+#if FEATURE_POWER_MANAGER == ON
 void NodeManager::setPowerManager(PowerManager& powerManager) {
   _powerManager = &powerManager;
 }
@@ -4156,7 +4156,7 @@ Sensor* NodeManager::getSensorWithChild(int child_id) {
   return nullptr;  
 }
 
-#ifdef ENABLE_TIME
+#if FEATURE_TIME == ON
 // sync the time with the controller
 void NodeManager::syncTime() {
   _time_is_valid = false;
@@ -4176,7 +4176,7 @@ void NodeManager::syncTime() {
 // wrapper of smart sleep
 void NodeManager::_sleep() {
   long sleep_time = _sleep_time;
-#ifdef ENABLE_TIME
+#if FEATURE_TIME == ON
   // if there is time still to sleep, sleep for that timeframe only
   if (_remainder_sleep_time > 0) sleep_time = _remainder_sleep_time;
 #endif
@@ -4189,7 +4189,7 @@ void NodeManager::_sleep() {
   #endif
   // go to sleep
   int interrupt = -1;
-#ifndef DISABLE_INTERRUPTS
+#if FEATURE_INTERRUPTS == ON
   // setup interrupt pins
   int interrupt_1_pin = _interrupt_1_mode == MODE_NOT_DEFINED ? INTERRUPT_NOT_DEFINED  : digitalPinToInterrupt(INTERRUPT_PIN_1);
   int interrupt_2_pin = _interrupt_2_mode == MODE_NOT_DEFINED ? INTERRUPT_NOT_DEFINED  : digitalPinToInterrupt(INTERRUPT_PIN_2);
@@ -4225,7 +4225,7 @@ void NodeManager::_sleep() {
   #ifdef NODEMANAGER_DEBUG
     Serial.println(F("AWAKE"));
   #endif
-#ifdef ENABLE_TIME
+#if FEATURE_TIME == ON
   // keep track of the old time so to calculate the amount of time slept
   long old_time = now();
   // sync the time with the controller
@@ -4239,7 +4239,7 @@ void NodeManager::_sleep() {
 #endif
 }
 
-#ifndef DISABLE_EEPROM
+#if FEATURE_EEPROM == ON
 // load the configuration stored in the eeprom
 void NodeManager::_loadSleepSettings() {
   if (loadState(EEPROM_SLEEP_SAVED) == 1) {

--- a/NodeManagerLibrary.ino
+++ b/NodeManagerLibrary.ino
@@ -3771,6 +3771,12 @@ void NodeManager::presentation() {
 
 // setup NodeManager
 void NodeManager::setup() {
+#ifdef USE_TIME
+  // the function to get the time from the RTC
+  setSyncProvider(RTC.get);  
+  // Request latest time from controller at startup
+  requestTime();  
+#endif
   // retrieve and store isMetric from the controller
   if (_get_controller_config) _is_metric = getControllerConfig().isMetric;
   #ifdef NODEMANAGER_DEBUG
@@ -3881,6 +3887,9 @@ void NodeManager::receiveTime(unsigned long ts) {
   #ifdef NODEMANAGER_DEBUG
     Serial.print(F("TIME T="));
     Serial.print(_timestamp);
+  #endif
+  #ifdef USE_TIME
+    RTC.set(ts);
   #endif
 }
 
@@ -4249,4 +4258,22 @@ void NodeManager::_saveSleepSettings() {
 void NodeManager::_sleepBetweenSend() {
   if (_sleep_between_send > 0) sleep(_sleep_between_send);
 }
+
+#ifdef USE_TIME
+void NodeManager::_requestTime() {
+  /*
+  unsigned long now = millis();
+  // If no time has been received yet, request it every 10 second from controller
+  // When time has been received, request update every hour
+  if ((!timeReceived && (now-lastRequest) > (10UL*1000UL))
+    || (timeReceived && (now-lastRequest) > (60UL*1000UL*60UL))) {
+    // Request time from controller. 
+    Serial.println("requesting time");
+    requestTime();  
+    lastRequest = now;
+    
+  }*/
+}
+#endif
+
 #endif

--- a/NodeManagerLibrary.ino
+++ b/NodeManagerLibrary.ino
@@ -3875,8 +3875,15 @@ void NodeManager::receiveTime(unsigned long ts) {
   #endif
   // time is now valid
   _time_is_valid = true;
+#if FEATURE_RTC == ON
+  // set the RTC time to the time received from the controller
+  RTC.set(ts);
+  // sync the system time with the RTC
+  setSyncProvider(RTC.get);
+#else
   // set the current system time to the received time
   setTime(ts);
+#endif
   _time_last_sync = now();
 }
 #endif
@@ -4228,8 +4235,13 @@ void NodeManager::_sleep() {
 #if FEATURE_TIME == ON
   // keep track of the old time so to calculate the amount of time slept
   long old_time = now();
+#if FEATURE_RTC == ON
+  // sync the time with the RTC
+  setSyncProvider(RTC.get);
+#else
   // sync the time with the controller
   syncTime();
+#endif
   // calculate the remainder time to sleep if woken up by an interrupt
   if (interrupt > -1) {
     if (_remainder_sleep_time == -1) _remainder_sleep_time = _sleep_time;

--- a/README.md
+++ b/README.md
@@ -78,6 +78,25 @@ SensorPlantowerPMS  | 3     | USE_PMS            | Plantower PMS particulate mat
 SensorVL53L0X       | 1     | USE_VL53L0X        | VL53L0X laser time-of-flight distance sensor via I²C, sleep pin supported (optional)              | https://github.com/pololu/vl53l0x-arduino
 DisplaySSD1306      | 1     | USE_SSD1306        | SSD1306 128x64 OLED display (I²C); By default displays values of all sensors and children         | https://github.com/greiman/SSD1306Ascii.git
 
+### Advanced features
+
+NodeManager provides useful built-in features which can be disabled if you need to save some storage for your code. 
+To enable/disable a buil-in feature:
+* Install the required library if any
+* Enable the corresponding feature by setting it to ON in the main sketch. To disable it, set it to OFF
+
+A list of buil-in features and the required dependencies is presented below:
+
+Feature                     | Default | Description                                                                                      | Dependencies
+----------------------------|---------|--------------------------------------------------------------------------------------------------|----------------------------------------------------------
+FEATURE_POWER_MANAGER       | ON      | allow powering on your sensors only while the node is awake                                      | - 
+FEATURE_INTERRUPTS          | ON      | allow managing interrupt-based sensors like a PIR or a door sensor                               | - 
+FEATURE_TRACK_LAST_VALUE    | ON      | allow reporting a measure only when different from the previous one                              | - 
+FEATURE_EEPROM              | ON      | allow keeping track of some information in the EEPROM                                            | - 
+FEATURE_SLEEP               | ON      | allow managing automatically the complexity behind battery-powered sleeping sensors              | - 
+FEATURE_TIME                | OFF     | allow keeping the current system time in sync with the controller                                | https://github.com/PaulStoffregen/Time
+FEATURE_RTC                 | OFF     | allow keeping the current system time in sync with an attached RTC device                        | https://github.com/JChristensen/DS3232RTC
+
 ## Installation
 
 * Download the package or clone the git repository from https://github.com/mysensors/NodeManager
@@ -177,9 +196,11 @@ You can interact with each class provided by NodeManager through a set of API fu
 ### NodeManager API
 
 ~~~c
+    NodeManager(int sensorcount = 0);
     // [10] send the same message multiple times (default: 1)
     void setRetries(int value);
     int getRetries();
+#if FEATURE_SLEEP == ON
     // [3] set the duration (in seconds) of a sleep cycle
     void setSleepSeconds(int value);
     long getSleepSeconds();
@@ -189,28 +210,30 @@ You can interact with each class provided by NodeManager through a set of API fu
     void setSleepHours(int value);
     // [29] set the duration (in days) of a sleep cycle
     void setSleepDays(int value);
+#endif
+#if FEATURE_INTERRUPTS == ON
     // [19] if enabled, when waking up from the interrupt, the board stops sleeping. Disable it when attaching e.g. a motion sensor (default: true)
     void setSleepInterruptPin(int value);
     // configure the interrupt pin and mode. Mode can be CHANGE, RISING, FALLING (default: MODE_NOT_DEFINED)
     void setInterrupt(int pin, int mode, int initial = -1);
     // [28] ignore two consecutive interrupts if happening within this timeframe in milliseconds (default: 100)
     void setInterruptMinDelta(long value);
+#endif
     // [20] optionally sleep interval in milliseconds before sending each message to the radio network (default: 0)
     void setSleepBetweenSend(int value);
-    int getSleepBetweenSend();
     // register a sensor
     void registerSensor(Sensor* sensor);
     // to save battery the sensor can be optionally connected to two pins which will act as vcc and ground and activated on demand
+#if FEATURE_POWER_MANAGER == ON
     void setPowerPins(int ground_pin, int vcc_pin, int wait_time = 50);
     // [24] manually turn the power on
     void powerOn();
     // [25] manually turn the power off
     void powerOff();
+#endif
     // [21] set this to true if you want destination node to send ack back to this node (default: false)
     void setAck(bool value);
     bool getAck();
-    // request and return the current timestamp from the controller
-    long getTimestamp();
     // Request the controller's configuration on startup (default: true)
     void setGetControllerConfig(bool value);
     // [22] Manually set isMetric setting
@@ -224,20 +247,26 @@ You can interact with each class provided by NodeManager through a set of API fu
     void hello();
     // [6] reboot the board
     void reboot();
-    // [7] clear the EEPROM
-    void clearEeprom();
     // [9] wake up the board
     void wakeup();
+#if FEATURE_EEPROM == ON
+    // [7] clear the EEPROM
+    void clearEeprom();
     // return the value stored at the requested index from the EEPROM
     int loadFromMemory(int index);
     // [27] save the given index of the EEPROM the provided value
     void saveToMemory(int index, int value);
+    // [40] if set save the sleep settings in memory, also when changed remotely (default: false)
+    void setSaveSleepSettings(bool value);
+#endif
     // return vcc in V
     float getVcc();
+#if FEATURE_INTERRUPTS == ON
     // setup the configured interrupt pins
     void setupInterrupts();
     // return the pin from which the last interrupt came
     int getLastInterruptPin();
+#endif
     // [36] set the default interval in minutes all the sensors will report their measures. If the same function is called on a specific sensor, this will not change the previously set value. or sleeping sensors, the elapsed time can be evaluated only upon wake up (default: 10 minutes)
     void setReportIntervalSeconds(int value);
     // [37] set the default interval in minutes all the sensors will report their measures. If the same function is called on a specific sensor, this will not change the previously set value. or sleeping sensors, the elapsed time can be evaluated only upon wake up (default: 10 minutes)
@@ -254,16 +283,39 @@ You can interact with each class provided by NodeManager through a set of API fu
     void setRebootPin(int value);
     // [32] turn the ADC off so to save 0.2 mA
     void setADCOff();
-    // [40] if set save the sleep settings in memory, also when changed remotely (default: false)
-    void setSaveSleepSettings(bool value);
+#if FEATURE_TIME == ON
+    // [41] synchronize the local time with the controller
+    void syncTime();
+    // [42] returns the current system time
+    long getTime();
+    void receiveTime(unsigned long ts);
+#endif
+#if FEATURE_INTERRUPTS == ON
+    // handle interrupts
+    static void _onInterrupt_1();
+    static void _onInterrupt_2();
+#endif
+    // send a message by providing the source child, type of the message and value
+	  void sendMessage(int child_id, int type, int value);
+    void sendMessage(int child_id, int type, float value);
+    void sendMessage(int child_id, int type, double value);
+    void sendMessage(int child_id, int type, const char* value);
+#if FEATURE_POWER_MANAGER == ON
+    void setPowerManager(PowerManager& powerManager);
+#endif
+    int getAvailableChildId(int child_id = -255);
+    List<Sensor*> sensors;
+    Child* getChild(int child_id);
+    Sensor* getSensorWithChild(int child_id);
 ~~~
 
 ### Sensor API
 
 The following methods are available for all the sensors:
 ~~~c
+    Sensor(NodeManager& node_manager, int pin = -1);
     // return the name of the sensor
-    char* getName();
+    const char* getName();
     // [1] where the sensor is attached to (default: not set)
     void setPin(int value);
     int getPin();
@@ -271,16 +323,20 @@ The following methods are available for all the sensors:
     void setSamples(int value);
     // [6] If more then one sample has to be taken, set the interval in milliseconds between measurements (default: 0)
     void setSamplesInterval(int value);
+#if FEATURE_TRACK_LAST_VALUE == ON
     // [7] if true will report the measure only if different than the previous one (default: false)
     void setTrackLastValue(bool value);
     // [9] if track last value is enabled, force to send an update after the configured number of minutes
     void setForceUpdateMinutes(int value);
+#endif
+#if FEATURE_POWER_MANAGER == ON
     // to save battery the sensor can be optionally connected to two pins which will act as vcc and ground and activated on demand
     void setPowerPins(int ground_pin, int vcc_pin, int wait_time = 50);
     // [13] manually turn the power on
     void powerOn();
     // [14] manually turn the power off
     void powerOff();
+#endif
     // [17] After how many minutes the sensor will report back its measure (default: 10 minutes)
     void setReportIntervalSeconds(int value);
     // [16] After how many minutes the sensor will report back its measure (default: 10 minutes)
@@ -291,14 +347,25 @@ The following methods are available for all the sensors:
     void setReportIntervalDays(int value);
     // return true if the report interval has been already configured
     bool isReportIntervalConfigured();
+#if FEATURE_INTERRUPTS == ON
     // return the pin the interrupt is attached to
     int getInterruptPin();
     // listen for interrupts on the given pin so interrupt() will be called when occurring
     void setInterrupt(int pin, int mode, int initial);
+#endif
+#if FEATURE_POWER_MANAGER == ON
     // set a previously configured PowerManager to the sensor so to powering it up with custom pins
-    void setPowerManager(const PowerManager& powerManager);
+    void setPowerManager(PowerManager& powerManager);
+#endif
     // list of configured child
     List<Child*> children;
+#if FEATURE_INTERRUPTS == ON
+    void interrupt();
+#endif
+    Child* getChild(int child_id);
+    // register a child
+    void registerChild(Child* child);
+    NodeManager* _node;
 ~~~
 
 ### Built-in sensors API

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ FEATURE_TRACK_LAST_VALUE    | ON      | allow reporting a measure only when diff
 FEATURE_EEPROM              | ON      | allow keeping track of some information in the EEPROM                                            | - 
 FEATURE_SLEEP               | ON      | allow managing automatically the complexity behind battery-powered sleeping sensors              | - 
 FEATURE_TIME                | OFF     | allow keeping the current system time in sync with the controller                                | https://github.com/PaulStoffregen/Time
-FEATURE_RTC                 | OFF     | allow keeping the current system time in sync with an attached RTC device                        | https://github.com/JChristensen/DS3232RTC
+FEATURE_RTC                 | OFF     | allow keeping the current system time in sync with an attached RTC device (requires FEATURE_TIME)| https://github.com/JChristensen/DS3232RTC
 
 ## Installation
 


### PR DESCRIPTION
This PR is to optionally allow the node to keep track of the current time, either with an attached RTC or by requesting the time to the controller.

* Added time support through the Arduino's time library when FEATURE_TIME is turned on (https://github.com/PaulStoffregen/Time). Fixes #83, #84
* Automatically synchronize the local clock 1) during setup() 2) during loop() if last updated more than 60 minutes ago, 3) after waking up from sleep
* Added RTC support (DS3232 and DS3231 through https://github.com/JChristensen/DS3232RTC) when FEATURE_RTC is on. RTC time is always set during setup() (through syncTime() and receiveTime()) and refreshed with the controller every hour. System time is updated with the RTC after waking up from sleep. FEATURE_RTC  automatically enables also FEATURE_TIME. Fixes #183
* If woken up by an interrupt, the remainder sleep time is resumed. Fixes #167
* Introduced syncTime() (deprecating getTimestamp()) which requests a time update to the controller for 10 times before giving up. Time is received in receiveTime() and set with setTime() or with RTC.set() when RTC is enabled
* Timer class updated to use system time when time lib is enabled (regardless if sleep mode is enabled or not)
* Exposed syncTime() and getTime() through the remote API
* SensorPulseMeter and subclasses supports sleep mode when FEATURE_TIME is enabled. No code changes needed: with Timer using the system time and the remainder sleep time resumed when waking up from sleep, measures are reported every hour regardless. Fixes #265