### PR TITLE
Fixed SensorSignal compilation error with v2.1.1 library

### DIFF
--- a/NodeManager.ino
+++ b/NodeManager.ino
@@ -135,7 +135,7 @@ SensorSHT31         | 2     | USE_SHT31          | SHT31 sensor, return temperat
 //#define MY_SMART_SLEEP_WAIT_DURATION_MS 500
 #define MY_SPLASH_SCREEN_DISABLED
 //#define MY_DISABLE_RAM_ROUTING_TABLE_FEATURE
-//#define MY_DISABLE_SIGNAL_REPORT
+//#define MY_SIGNAL_REPORT_ENABLED
 
 // Optimizations when running on 2032 Coin Cell. Also set node.setSleepBetweenSend(500) and run the board at 1Mhz
 //#define MY_TRANSPORT_UPLINK_CHECK_DISABLED

--- a/NodeManagerLibrary.h
+++ b/NodeManagerLibrary.h
@@ -534,6 +534,7 @@ class SensorBattery: public Sensor {
       float _battery_volts_per_bit = 0.003363075;
 };
 
+#ifdef MY_SIGNAL_REPORT_ENABLED
 /*
    SensorSignal: report RSSI signal strength from the radio
 */
@@ -548,6 +549,7 @@ class SensorSignal: public Sensor {
   protected:
     int _signal_command = SR_RX_RSSI;
 };
+#endif
 
 /*
    SensorConfiguration: allow remote configuration of the board and any configured sensor

--- a/NodeManagerLibrary.ino
+++ b/NodeManagerLibrary.ino
@@ -719,6 +719,7 @@ void SensorBattery::onReceive(MyMessage* message) {
 }
 #endif
 
+#ifdef MY_SIGNAL_REPORT_ENABLED
 /*
    SensorSignal
 */
@@ -753,6 +754,7 @@ void SensorSignal::onReceive(MyMessage* message) {
   if (child == nullptr) return;
   if (message->getCommand() == C_REQ && message->type == child->type) onLoop(child);
 }
+#endif
 #endif
 
 #ifdef USE_ANALOG_INPUT
@@ -3360,6 +3362,7 @@ void SensorConfiguration::onReceive(MyMessage* message) {
           default: return;
         }
       }
+      #ifdef MY_SIGNAL_REPORT_ENABLED
       if (strcmp(sensor->getName(),"SIGNAL") == 0) {
         SensorSignal* custom_sensor = (SensorSignal*)sensor;
         switch(function) {
@@ -3367,6 +3370,7 @@ void SensorConfiguration::onReceive(MyMessage* message) {
           default: return;
         }
       }
+      #endif
       #endif
       #ifdef USE_ANALOG_INPUT
       if (strcmp(sensor->getName(),"ANALOG_I") == 0 || strcmp(sensor->getName(),"LDR") == 0 || strcmp(sensor->getName(),"RAIN") == 0 || strcmp(sensor->getName(),"SOIL") == 0) {


### PR DESCRIPTION
This PR fixes #256.
* SensorSignal is not available unless MY_SIGNAL_REPORT_ENABLED is defined
* MY_SIGNAL_REPORT_ENABLED replaces 2.2.0-beta MY_DISABLE_SIGNAL_REPORT in the main sketch