### PR TITLE
Add ability to configure SensorSwitch to interpret LOW as the active/triggered state

### DIFF
--- a/NodeManager.cpp
+++ b/NodeManager.cpp
@@ -1447,7 +1447,6 @@ void SensorSwitch::onInterrupt() {
       Serial.print(F(" V="));
       Serial.println(value);
     #endif
-    _value_int = value;
     // allow the signal to be restored to its normal value
     if (_trigger_time > 0) _node_manager->sleepOrWait(_trigger_time);
   } else {

--- a/NodeManager.cpp
+++ b/NodeManager.cpp
@@ -1388,6 +1388,9 @@ void SensorSwitch::setTriggerTime(int value) {
 void SensorSwitch::setInitial(int value) {
   _initial = value;
 }
+void SensorSwitch::setActiveState(int value) {
+  _active_state = value;
+}
 
 // what to do during before
 void SensorSwitch::onBefore() {
@@ -1420,6 +1423,7 @@ void SensorSwitch::onProcess(Request & request) {
     case 102: setDebounce(request.getValueInt()); break;
     case 103: setTriggerTime(request.getValueInt()); break;
     case 104: setInitial(request.getValueInt()); break;
+    case 105: setActiveState(request.getValueInt()); break;
     default: return;
   }
   _send(_msg_service.set(function));
@@ -1433,6 +1437,8 @@ void SensorSwitch::onInterrupt() {
   int value = digitalRead(_pin);
   // process the value
   if ( (_mode == RISING && value == HIGH ) || (_mode == FALLING && value == LOW) || (_mode == CHANGE) )  {
+    // invert the value if Active State is set to LOW
+    _value_int = _active_state == LOW ? !value : value;
     #if DEBUG == 1
       Serial.print(F("SWITCH I="));
       Serial.print(_child_id);

--- a/NodeManager.h
+++ b/NodeManager.h
@@ -904,6 +904,8 @@ class SensorSwitch: public Sensor {
     void setTriggerTime(int value);
     // [104] Set initial value on the interrupt pin (default: HIGH)
     void setInitial(int value);
+    // [105] Set active state (default: HIGH) 
+    void setActiveState(int value);
     // define what to do at each stage of the sketch
     void onBefore();
     void onSetup();
@@ -916,6 +918,7 @@ class SensorSwitch: public Sensor {
     int _trigger_time = 0;
     int _mode = CHANGE;
     int _initial = HIGH;
+    int _active_state = HIGH;
 };
 
 /*

--- a/README.md
+++ b/README.md
@@ -673,6 +673,8 @@ Each sensor class can expose additional methods.
     void setTriggerTime(int value);
     // [104] Set initial value on the interrupt pin (default: HIGH)
     void setInitial(int value);
+    // [105] Set active state (default: HIGH) 
+    void setActiveState(int value);
 ~~~
 
 *  SensorDs18b20


### PR DESCRIPTION
e.g. the digital output on the LM393 light sensor goes LOW when triggered

Apologies for PR against master branch - the development branch is quite different and I haven't tested this change with it.