### PR TITLE
Add option for SensorSwitch to interpret LOW as the active/triggered state

### DIFF
--- a/NodeManagerLibrary.h
+++ b/NodeManagerLibrary.h
@@ -855,6 +855,8 @@ class SensorSwitch: public Sensor {
     void setTriggerTime(int value);
     // [104] Set initial value on the interrupt pin (default: HIGH)
     void setInitial(int value);
+    // [105] Set active state (default: HIGH) 
+    void setActiveState(int value);
     // define what to do at each stage of the sketch
     void onSetup();
     void onLoop(Child* child);
@@ -865,6 +867,7 @@ class SensorSwitch: public Sensor {
     int _trigger_time = 0;
     int _mode = CHANGE;
     int _initial = HIGH;
+    int _active_state = HIGH;
 };
 
 /*

--- a/NodeManagerLibrary.ino
+++ b/NodeManagerLibrary.ino
@@ -1512,6 +1512,9 @@ void SensorSwitch::setTriggerTime(int value) {
 void SensorSwitch::setInitial(int value) {
   _initial = value;
 }
+void SensorSwitch::setActiveState(int value) {
+  _active_state = value;
+}
 
 // what to do during setup
 void SensorSwitch::onSetup() {
@@ -1544,6 +1547,8 @@ void SensorSwitch::onInterrupt() {
   int value = digitalRead(_pin);
   // process the value
   if ( (_mode == RISING && value == HIGH ) || (_mode == FALLING && value == LOW) || (_mode == CHANGE) )  {
+    // invert the value if Active State is set to LOW
+    if (_active_state == LOW) value = !value;
     #ifdef NODEMANAGER_DEBUG
       Serial.print(_name);
       Serial.print(F(" I="));
@@ -3465,6 +3470,7 @@ void SensorConfiguration::onReceive(MyMessage* message) {
           case 102: custom_sensor->setDebounce(request.getValueInt()); break;
           case 103: custom_sensor->setTriggerTime(request.getValueInt()); break;
           case 104: custom_sensor->setInitial(request.getValueInt()); break;
+          case 105: custom_sensor->setActiveState(request.getValueInt()); break;
           default: return;
         }
       }

--- a/README.md
+++ b/README.md
@@ -462,6 +462,8 @@ Each sensor class exposes additional methods.
     void setTriggerTime(int value);
     // [104] Set initial value on the interrupt pin (default: HIGH)
     void setInitial(int value);
+    // [105] Set active state (default: HIGH) 
+    void setActiveState(int value);    
 ~~~
 
 *  SensorDs18b20


### PR DESCRIPTION
e.g. the digital output on the LM393 light sensor goes LOW when triggered

Tested on master branch - see #264
Compiled but not tested on development branch