### PR TITLE
SensorSwitch refactor

### DIFF
--- a/NodeManager.ino
+++ b/NodeManager.ino
@@ -53,9 +53,9 @@ SensorDHT11         | 2     | USE_DHT            | DHT11 sensor, return temperat
 SensorDHT22         | 2     | USE_DHT            | DHT22 sensor, return temperature/humidity based on the attached DHT sensor                        | https://github.com/mysensors/MySensorsArduinoExamples/tree/master/libraries/DHT
 SensorSHT21         | 2     | USE_SHT21          | SHT21 sensor, return temperature/humidity based on the attached SHT21 sensor                      | https://github.com/SodaqMoja/Sodaq_SHT2x
 SensorHTU21D        | 2     | USE_SHT21          | HTU21D sensor, return temperature/humidity based on the attached HTU21D sensor                    | https://github.com/SodaqMoja/Sodaq_SHT2x
-SensorInterrupt     | 1     | USE_INTERRUPT_BASED| Generic interrupt-based sensor, wake up the board when a pin changes status                                       | -
-SensorDoor          | 1     | USE_INTERRUPT_BASED| Door sensor, wake up the board and report when an attached magnetic sensor has been opened/closed | -
-SensorMotion        | 1     | USE_INTERRUPT_BASED| Motion sensor, wake up the board and report when an attached PIR has triggered                    | -
+SensorInterrupt     | 1     | USE_INTERRUPT      | Generic interrupt-based sensor, wake up the board when a pin changes status                                       | -
+SensorDoor          | 1     | USE_INTERRUPT      | Door sensor, wake up the board and report when an attached magnetic sensor has been opened/closed | -
+SensorMotion        | 1     | USE_INTERRUPT      | Motion sensor, wake up the board and report when an attached PIR has triggered                    | -
 SensorDs18b20       | 1+    | USE_DS18B20        | DS18B20 sensor, return the temperature based on the attached sensor                               | https://github.com/milesburton/Arduino-Temperature-Control-Library
 SensorBH1750        | 1     | USE_BH1750         | BH1750 sensor, return light level in lux                                                          | https://github.com/claws/BH1750
 SensorMLX90614      | 2     | USE_MLX90614       | MLX90614 contactless temperature sensor, return ambient and object temperature                    | https://github.com/adafruit/Adafruit-MLX90614-Library
@@ -233,7 +233,7 @@ FEATURE_RTC                 | OFF     | allow keeping the current system time in
 //#define USE_DIGITAL_OUTPUT
 //#define USE_DHT
 //#define USE_SHT21
-#define USE_INTERRUPT_BASED
+//#define USE_INTERRUPT
 //#define USE_DS18B20
 //#define USE_BH1750
 //#define USE_MLX90614
@@ -306,7 +306,7 @@ NodeManager node;
 //SensorDHT22 dht22(node,6);
 //SensorSHT21 sht21(node);
 //SensorHTU21D htu21(node);
-SensorInterrupt interrupt(node,3);
+//SensorInterrupt interrupt(node,3);
 //SensorDoor door(node,3);
 //SensorMotion motion(node,3);
 //SensorDs18b20 ds18b20(node,6);

--- a/NodeManager.ino
+++ b/NodeManager.ino
@@ -53,9 +53,9 @@ SensorDHT11         | 2     | USE_DHT            | DHT11 sensor, return temperat
 SensorDHT22         | 2     | USE_DHT            | DHT22 sensor, return temperature/humidity based on the attached DHT sensor                        | https://github.com/mysensors/MySensorsArduinoExamples/tree/master/libraries/DHT
 SensorSHT21         | 2     | USE_SHT21          | SHT21 sensor, return temperature/humidity based on the attached SHT21 sensor                      | https://github.com/SodaqMoja/Sodaq_SHT2x
 SensorHTU21D        | 2     | USE_SHT21          | HTU21D sensor, return temperature/humidity based on the attached HTU21D sensor                    | https://github.com/SodaqMoja/Sodaq_SHT2x
-SensorSwitch        | 1     | USE_SWITCH         | Generic switch, wake up the board when a pin changes status                                       | -
-SensorDoor          | 1     | USE_SWITCH         | Door sensor, wake up the board and report when an attached magnetic sensor has been opened/closed | -
-SensorMotion        | 1     | USE_SWITCH         | Motion sensor, wake up the board and report when an attached PIR has triggered                    | -
+SensorInterrupt     | 1     | USE_INTERRUPT_BASED| Generic interrupt-based sensor, wake up the board when a pin changes status                                       | -
+SensorDoor          | 1     | USE_INTERRUPT_BASED| Door sensor, wake up the board and report when an attached magnetic sensor has been opened/closed | -
+SensorMotion        | 1     | USE_INTERRUPT_BASED| Motion sensor, wake up the board and report when an attached PIR has triggered                    | -
 SensorDs18b20       | 1+    | USE_DS18B20        | DS18B20 sensor, return the temperature based on the attached sensor                               | https://github.com/milesburton/Arduino-Temperature-Control-Library
 SensorBH1750        | 1     | USE_BH1750         | BH1750 sensor, return light level in lux                                                          | https://github.com/claws/BH1750
 SensorMLX90614      | 2     | USE_MLX90614       | MLX90614 contactless temperature sensor, return ambient and object temperature                    | https://github.com/adafruit/Adafruit-MLX90614-Library
@@ -233,7 +233,7 @@ FEATURE_RTC                 | OFF     | allow keeping the current system time in
 //#define USE_DIGITAL_OUTPUT
 //#define USE_DHT
 //#define USE_SHT21
-//#define USE_SWITCH
+#define USE_INTERRUPT_BASED
 //#define USE_DS18B20
 //#define USE_BH1750
 //#define USE_MLX90614
@@ -306,7 +306,7 @@ NodeManager node;
 //SensorDHT22 dht22(node,6);
 //SensorSHT21 sht21(node);
 //SensorHTU21D htu21(node);
-//SensorSwitch sensorSwitch(node,3);
+SensorInterrupt interrupt(node,3);
 //SensorDoor door(node,3);
 //SensorMotion motion(node,3);
 //SensorDs18b20 ds18b20(node,6);

--- a/NodeManagerLibrary.h
+++ b/NodeManagerLibrary.h
@@ -853,7 +853,7 @@ class SensorHTU21D: public SensorSHT21 {
 /*
  * SensorInterrupt
  */
-#ifdef USE_INTERRUPT_BASED
+#ifdef USE_INTERRUPT
 class SensorInterrupt: public Sensor {
   public:
     SensorInterrupt(NodeManager& node_manager, int pin, int child_id = -255);
@@ -1564,6 +1564,8 @@ class NodeManager {
     void setupInterrupts();
     // return the pin from which the last interrupt came
     int getLastInterruptPin();
+    // return the value of the pin from which the last interrupt came
+    int getLastInterruptValue();
 #endif
     // [36] set the default interval in minutes all the sensors will report their measures. If the same function is called on a specific sensor, this will not change the previously set value. or sleeping sensors, the elapsed time can be evaluated only upon wake up (default: 10 minutes)
     void setReportIntervalSeconds(int value);
@@ -1628,6 +1630,7 @@ class NodeManager {
     int _interrupt_1_initial = -1;
     int _interrupt_2_initial = -1;
     static int _last_interrupt_pin;
+    static int _last_interrupt_value;
     static long _interrupt_min_delta;
     static long _last_interrupt_1;
     static long _last_interrupt_2;

--- a/NodeManagerLibrary.h
+++ b/NodeManagerLibrary.h
@@ -851,12 +851,12 @@ class SensorHTU21D: public SensorSHT21 {
 #endif
 
 /*
- * SensorSwitch
+ * SensorInterrupt
  */
-#ifdef USE_SWITCH
-class SensorSwitch: public Sensor {
+#ifdef USE_INTERRUPT_BASED
+class SensorInterrupt: public Sensor {
   public:
-    SensorSwitch(NodeManager& node_manager, int pin, int child_id = -255);
+    SensorInterrupt(NodeManager& node_manager, int pin, int child_id = -255);
     // [101] set the interrupt mode. Can be CHANGE, RISING, FALLING (default: CHANGE)
     void setMode(int value);
     // [102] milliseconds to wait before reading the input (default: 0)
@@ -883,7 +883,7 @@ class SensorSwitch: public Sensor {
 /*
  * SensorDoor
  */
-class SensorDoor: public SensorSwitch {
+class SensorDoor: public SensorInterrupt {
   public:
     SensorDoor(NodeManager& node_manager, int pin, int child_id = -255);
 };
@@ -891,7 +891,7 @@ class SensorDoor: public SensorSwitch {
 /*
  * SensorMotion
  */
-class SensorMotion: public SensorSwitch {
+class SensorMotion: public SensorInterrupt {
   public:
     SensorMotion(NodeManager& node_manager, int pin, int child_id = -255);
     void onSetup();

--- a/NodeManagerLibrary.ino
+++ b/NodeManagerLibrary.ino
@@ -1489,35 +1489,35 @@ SensorHTU21D::SensorHTU21D(NodeManager& nodeManager, int child_id): SensorSHT21(
 }
 #endif 
 
-#ifdef USE_SWITCH
+#ifdef USE_INTERRUPT_BASED
 /*
- * SensorSwitch
+ * SensorInterrupt
  */
-SensorSwitch::SensorSwitch(NodeManager& node_manager, int pin, int child_id): Sensor(node_manager, pin) {
-  _name = "SWITCH";
+SensorInterrupt::SensorInterrupt(NodeManager& node_manager, int pin, int child_id): Sensor(node_manager, pin) {
+  _name = "INTERRUPT";
   children.allocateBlocks(1);
-  new ChildInt(this,_node->getAvailableChildId(child_id),S_CUSTOM,V_TRIPPED,_name);
+  new ChildInt(this,_node->getAvailableChildId(child_id),S_CUSTOM,V_CUSTOM,_name);
 }
 
 // setter/getter
-void SensorSwitch::setMode(int value) {
+void SensorInterrupt::setMode(int value) {
   _mode = value;
 }
-void SensorSwitch::setDebounce(int value) {
+void SensorInterrupt::setDebounce(int value) {
   _debounce = value;
 }
-void SensorSwitch::setTriggerTime(int value) {
+void SensorInterrupt::setTriggerTime(int value) {
   _trigger_time = value;
 }
-void SensorSwitch::setInitial(int value) {
+void SensorInterrupt::setInitial(int value) {
   _initial = value;
 }
-void SensorSwitch::setActiveState(int value) {
+void SensorInterrupt::setActiveState(int value) {
   _active_state = value;
 }
 
 // what to do during setup
-void SensorSwitch::onSetup() {
+void SensorInterrupt::onSetup() {
   // set the interrupt pin so it will be called only when waking up from that interrupt
   setInterrupt(_pin,_mode,_initial);
   // report immediately
@@ -1525,11 +1525,11 @@ void SensorSwitch::onSetup() {
 }
 
 // what to do during loop
-void SensorSwitch::onLoop(Child* child) {
+void SensorInterrupt::onLoop(Child* child) {
 }
 
 // what to do as the main task when receiving a message
-void SensorSwitch::onReceive(MyMessage* message) {
+void SensorInterrupt::onReceive(MyMessage* message) {
   Child* child = getChild(message->sensor);
   if (child == nullptr) return;
   if (message->getCommand() == C_REQ && message->type == V_STATUS) {
@@ -1539,7 +1539,7 @@ void SensorSwitch::onReceive(MyMessage* message) {
 }
 
 // what to do when receiving an interrupt
-void SensorSwitch::onInterrupt() {
+void SensorInterrupt::onInterrupt() {
   Child* child = children.get(1);
   // wait to ensure the the input is not floating
   if (_debounce > 0) _node->sleepOrWait(_debounce);
@@ -1570,7 +1570,7 @@ void SensorSwitch::onInterrupt() {
 /*
  * SensorDoor
  */
-SensorDoor::SensorDoor(NodeManager& node_manager, int pin, int child_id): SensorSwitch(node_manager, pin, child_id) {
+SensorDoor::SensorDoor(NodeManager& node_manager, int pin, int child_id): SensorInterrupt(node_manager, pin, child_id) {
   _name = "DOOR";
   children.get(1)->presentation = S_DOOR;
   children.get(1)->type = V_TRIPPED;
@@ -1580,7 +1580,7 @@ SensorDoor::SensorDoor(NodeManager& node_manager, int pin, int child_id): Sensor
 /*
  * SensorMotion
  */
-SensorMotion::SensorMotion(NodeManager& node_manager, int pin, int child_id): SensorSwitch(node_manager, pin, child_id) {
+SensorMotion::SensorMotion(NodeManager& node_manager, int pin, int child_id): SensorInterrupt(node_manager, pin, child_id) {
   _name = "MOTION";
   children.get(1)->presentation = S_MOTION;
   children.get(1)->type = V_TRIPPED;
@@ -1589,7 +1589,7 @@ SensorMotion::SensorMotion(NodeManager& node_manager, int pin, int child_id): Se
 
 // what to do during setup
 void SensorMotion::onSetup() {
-  SensorSwitch::onSetup();
+  SensorInterrupt::onSetup();
   // set initial value to LOW
   setInitial(LOW);
 }
@@ -3658,8 +3658,8 @@ void SensorConfiguration::onReceive(MyMessage* message) {
       }
       #endif
       #ifdef USE_SWITCH
-      if (strcmp(sensor->getName(),"SWITCH") == 0 || strcmp(sensor->getName(),"DOOR") == 0 || strcmp(sensor->getName(),"MOTION") == 0) {
-        SensorSwitch* custom_sensor = (SensorSwitch*)sensor;
+      if (strcmp(sensor->getName(),"INTERRUPT") == 0 || strcmp(sensor->getName(),"DOOR") == 0 || strcmp(sensor->getName(),"MOTION") == 0) {
+        SensorInterrupt* custom_sensor = (SensorInterrupt*)sensor;
         switch(function) {
           case 101: custom_sensor->setMode(request.getValueInt()); break;
           case 102: custom_sensor->setDebounce(request.getValueInt()); break;

--- a/README.md
+++ b/README.md
@@ -53,9 +53,9 @@ SensorDHT11         | 2     | USE_DHT            | DHT11 sensor, return temperat
 SensorDHT22         | 2     | USE_DHT            | DHT22 sensor, return temperature/humidity based on the attached DHT sensor                        | https://github.com/mysensors/MySensorsArduinoExamples/tree/master/libraries/DHT
 SensorSHT21         | 2     | USE_SHT21          | SHT21 sensor, return temperature/humidity based on the attached SHT21 sensor                      | https://github.com/SodaqMoja/Sodaq_SHT2x
 SensorHTU21D        | 2     | USE_SHT21          | HTU21D sensor, return temperature/humidity based on the attached HTU21D sensor                    | https://github.com/SodaqMoja/Sodaq_SHT2x
-SensorInterrupt     | 1     | USE_INTERRUPT_BASED| Generic interrupt-based sensor, wake up the board when a pin changes status                                       | -
-SensorDoor          | 1     | USE_INTERRUPT_BASED| Door sensor, wake up the board and report when an attached magnetic sensor has been opened/closed | -
-SensorMotion        | 1     | USE_INTERRUPT_BASED| Motion sensor, wake up the board and report when an attached PIR has triggered                    | -
+SensorInterrupt     | 1     | USE_INTERRUPT      | Generic interrupt-based sensor, wake up the board when a pin changes status                                       | -
+SensorDoor          | 1     | USE_INTERRUPT      | Door sensor, wake up the board and report when an attached magnetic sensor has been opened/closed | -
+SensorMotion        | 1     | USE_INTERRUPT      | Motion sensor, wake up the board and report when an attached PIR has triggered                    | -
 SensorDs18b20       | 1+    | USE_DS18B20        | DS18B20 sensor, return the temperature based on the attached sensor                               | https://github.com/milesburton/Arduino-Temperature-Control-Library
 SensorBH1750        | 1     | USE_BH1750         | BH1750 sensor, return light level in lux                                                          | https://github.com/claws/BH1750
 SensorMLX90614      | 2     | USE_MLX90614       | MLX90614 contactless temperature sensor, return ambient and object temperature                    | https://github.com/adafruit/Adafruit-MLX90614-Library
@@ -269,6 +269,8 @@ You can interact with each class provided by NodeManager through a set of API fu
     void setupInterrupts();
     // return the pin from which the last interrupt came
     int getLastInterruptPin();
+    // return the value of the pin from which the last interrupt came
+    int getLastInterruptValue();
 #endif
     // [36] set the default interval in minutes all the sensors will report their measures. If the same function is called on a specific sensor, this will not change the previously set value. or sleeping sensors, the elapsed time can be evaluated only upon wake up (default: 10 minutes)
     void setReportIntervalSeconds(int value);
@@ -836,7 +838,7 @@ The following sketch can be used to report back to the controller when a motion 
  * NodeManager modules
  */
 
-#define USE_INTERRUPT_BASED
+#define USE_INTERRUPT
 
 /***********************************
  * Load NodeManager Library

--- a/README.md
+++ b/README.md
@@ -53,9 +53,9 @@ SensorDHT11         | 2     | USE_DHT            | DHT11 sensor, return temperat
 SensorDHT22         | 2     | USE_DHT            | DHT22 sensor, return temperature/humidity based on the attached DHT sensor                        | https://github.com/mysensors/MySensorsArduinoExamples/tree/master/libraries/DHT
 SensorSHT21         | 2     | USE_SHT21          | SHT21 sensor, return temperature/humidity based on the attached SHT21 sensor                      | https://github.com/SodaqMoja/Sodaq_SHT2x
 SensorHTU21D        | 2     | USE_SHT21          | HTU21D sensor, return temperature/humidity based on the attached HTU21D sensor                    | https://github.com/SodaqMoja/Sodaq_SHT2x
-SensorSwitch        | 1     | USE_SWITCH         | Generic switch, wake up the board when a pin changes status                                       | -
-SensorDoor          | 1     | USE_SWITCH         | Door sensor, wake up the board and report when an attached magnetic sensor has been opened/closed | -
-SensorMotion        | 1     | USE_SWITCH         | Motion sensor, wake up the board and report when an attached PIR has triggered                    | -
+SensorInterrupt     | 1     | USE_INTERRUPT_BASED| Generic interrupt-based sensor, wake up the board when a pin changes status                                       | -
+SensorDoor          | 1     | USE_INTERRUPT_BASED| Door sensor, wake up the board and report when an attached magnetic sensor has been opened/closed | -
+SensorMotion        | 1     | USE_INTERRUPT_BASED| Motion sensor, wake up the board and report when an attached PIR has triggered                    | -
 SensorDs18b20       | 1+    | USE_DS18B20        | DS18B20 sensor, return the temperature based on the attached sensor                               | https://github.com/milesburton/Arduino-Temperature-Control-Library
 SensorBH1750        | 1     | USE_BH1750         | BH1750 sensor, return light level in lux                                                          | https://github.com/claws/BH1750
 SensorMLX90614      | 2     | USE_MLX90614       | MLX90614 contactless temperature sensor, return ambient and object temperature                    | https://github.com/adafruit/Adafruit-MLX90614-Library
@@ -455,7 +455,7 @@ Each sensor class exposes additional methods.
     void setPinOn(int value);
 ~~~
 
-*  SensorSwitch / SensorDoor / SensorMotion
+*  SensorInterrupt / SensorDoor / SensorMotion
 ~~~c
     // [101] set the interrupt mode. Can be CHANGE, RISING, FALLING (default: CHANGE)
     void setMode(int value);
@@ -836,7 +836,7 @@ The following sketch can be used to report back to the controller when a motion 
  * NodeManager modules
  */
 
-#define USE_SWITCH
+#define USE_INTERRUPT_BASED
 
 /***********************************
  * Load NodeManager Library


### PR DESCRIPTION
This PR is for refactoring the SensorSwitch class.

* SensorSwitch renamed into SensorInterrupt to avoid misunderstanding (switch may sound like a relay, instead it is a general purpose interrupt based sensor)
* Dependent module USE_SWITCH renamed into USE_INTERRUPT
* SensorInterrupt now using S_CUSTOM,V_CUSTOM (fixes #271)
* The value from the pin which generated the interrupt is store just after the interrupt takes place and made available with NodeManager::getLastInterruptValue() (fixes #273)
* Adjusted SensorInterrupt to use getLastInterruptValue() instead of reading the value within the class code