### PR TITLE
Add support for LCD devices

### DIFF
--- a/NodeManager.ino
+++ b/NodeManager.ino
@@ -106,7 +106,7 @@ FEATURE_RTC                 | OFF     | allow keeping the current system time in
 #define SKETCH_NAME "NodeManager"
 #define SKETCH_VERSION "1.0"
 //#define MY_DEBUG
-//#define MY_NODE_ID 99
+#define MY_NODE_ID 99
 
 // NRF24 radio settings
 #define MY_RADIO_NRF24
@@ -225,8 +225,8 @@ FEATURE_RTC                 | OFF     | allow keeping the current system time in
  * NodeManager modules
  */
 
-#define USE_ANALOG_INPUT
-//#define USE_THERMISTOR
+//#define USE_ANALOG_INPUT
+#define USE_THERMISTOR
 //#define USE_ML8511
 //#define USE_ACS712
 //#define USE_DIGITAL_INPUT
@@ -291,11 +291,11 @@ NodeManager node;
 //PowerManager power(5,6);
 
 // Attached sensors
-SensorAnalogInput analog(node,A0);
+//SensorAnalogInput analog(node,A0);
 //SensorLDR ldr(node,A0);
 //SensorRain rain(node,A0);
 //SensorSoilMoisture soil(node,A0);
-//SensorThermistor thermistor(node,A0);
+SensorThermistor thermistor(node,A0);
 //SensorML8511 ml8511(node,A0);
 //SensorACS712 acs712(node,A0);
 //SensorDigitalInput digitalIn(node,6);
@@ -328,7 +328,7 @@ SensorAnalogInput analog(node,A0);
 //SensorPowerMeter powerMeter(node,3);
 //SensorWaterMeter waterMeter(node,3);
 //SensorPlantowerPMS pms(node,6,7);
-//SensorVL53L0X vl53l0x(node, /*XSHUT_PIN=*/2);
+//SensorVL53L0X vl53l0x(node,3);
 //SensorSHT31 sht31(node);
 //SensorSI7021 si7021(node);
 //SensorChirp chirp(node);
@@ -349,7 +349,7 @@ void before() {
   * Configure your sensors below
   */
   // report measures of every attached sensors every 10 seconds
-  node.setReportIntervalSeconds(10);
+  //node.setReportIntervalSeconds(10);
   // report measures of every attached sensors every 10 minutes
   //node.setReportIntervalMinutes(10);
   // set the node to sleep in 5 minutes cycles
@@ -390,7 +390,7 @@ void loop() {
 }
 
 // receive
-void receive(MyMessage &message) {
+void receive(const MyMessage &message) {
   // call NodeManager receive routine
   node.receive(message);
 }

--- a/NodeManager.ino
+++ b/NodeManager.ino
@@ -285,7 +285,7 @@ NodeManager node;
  */
 
 // built-in sensors
-//SensorBattery battery(node);
+SensorBattery battery(node);
 //SensorConfiguration configuration(node);
 //SensorSignal signal(node);
 //PowerManager power(5,6);
@@ -344,6 +344,8 @@ DisplaySSD1306 ssd1306(node);
 void before() {
   // setup the serial port baud rate
   Serial.begin(MY_BAUD_RATE);
+  ssd1306.setCaption("Display");
+node.setReportIntervalSeconds(10);
 
   /*
   * Configure your sensors below

--- a/NodeManager.ino
+++ b/NodeManager.ino
@@ -227,7 +227,7 @@ FEATURE_RTC                 | OFF     | allow keeping the current system time in
  */
 
 //#define USE_ANALOG_INPUT
-#define USE_THERMISTOR
+//#define USE_THERMISTOR
 //#define USE_ML8511
 //#define USE_ACS712
 //#define USE_DIGITAL_INPUT
@@ -257,7 +257,7 @@ FEATURE_RTC                 | OFF     | allow keeping the current system time in
 //#define USE_SHT31
 //#define USE_SI7021
 //#define USE_CHIRP
-#define USE_HD44780
+//#define USE_HD44780
 
 /***********************************
  * NodeManager advanced settings
@@ -287,7 +287,7 @@ NodeManager node;
  */
 
 // built-in sensors
-SensorBattery battery(node);
+//SensorBattery battery(node);
 //SensorConfiguration configuration(node);
 //SensorSignal signal(node);
 //PowerManager power(5,6);
@@ -297,7 +297,7 @@ SensorBattery battery(node);
 //SensorLDR ldr(node,A0);
 //SensorRain rain(node,A0);
 //SensorSoilMoisture soil(node,A0);
-SensorThermistor thermistor(node,A0);
+//SensorThermistor thermistor(node,A0);
 //SensorML8511 ml8511(node,A0);
 //SensorACS712 acs712(node,A0);
 //SensorDigitalInput digitalIn(node,6);
@@ -335,10 +335,7 @@ SensorThermistor thermistor(node,A0);
 //SensorSHT31 sht31(node);
 //SensorSI7021 si7021(node);
 //SensorChirp chirp(node);
-DisplayHD44780 hd44780(node);
-
-// Other devices
-
+//DisplayHD44780 hd44780(node);
 
 /***********************************
  * Main Sketch
@@ -348,9 +345,8 @@ DisplayHD44780 hd44780(node);
 void before() {
   // setup the serial port baud rate
   Serial.begin(MY_BAUD_RATE);
-  hd44780.setI2CAddress(0x3f);
 
-//node.setReportIntervalSeconds(10);
+
 
   /*
   * Configure your sensors below

--- a/NodeManager.ino
+++ b/NodeManager.ino
@@ -225,7 +225,7 @@ FEATURE_RTC                 | OFF     | allow keeping the current system time in
  * NodeManager modules
  */
 
-//#define USE_ANALOG_INPUT
+#define USE_ANALOG_INPUT
 //#define USE_THERMISTOR
 //#define USE_ML8511
 //#define USE_ACS712
@@ -252,7 +252,7 @@ FEATURE_RTC                 | OFF     | allow keeping the current system time in
 //#define USE_PULSE_METER
 //#define USE_PMS
 //#define USE_VL53L0X
-//#define USE_SSD1306
+#define USE_SSD1306
 //#define USE_SHT31
 //#define USE_SI7021
 //#define USE_CHIRP
@@ -291,7 +291,7 @@ NodeManager node;
 //PowerManager power(5,6);
 
 // Attached sensors
-//SensorAnalogInput analog(node,A0);
+SensorAnalogInput analog(node,A0);
 //SensorLDR ldr(node,A0);
 //SensorRain rain(node,A0);
 //SensorSoilMoisture soil(node,A0);
@@ -334,7 +334,7 @@ NodeManager node;
 //SensorChirp chirp(node);
 
 // Other devices
-//DisplaySSD1306 ssd1306(node);
+DisplaySSD1306 ssd1306(node);
 
 /***********************************
  * Main Sketch
@@ -349,7 +349,7 @@ void before() {
   * Configure your sensors below
   */
   // report measures of every attached sensors every 10 seconds
-  //node.setReportIntervalSeconds(10);
+  node.setReportIntervalSeconds(10);
   // report measures of every attached sensors every 10 minutes
   //node.setReportIntervalMinutes(10);
   // set the node to sleep in 5 minutes cycles

--- a/NodeManager.ino
+++ b/NodeManager.ino
@@ -79,7 +79,8 @@ SensorVL53L0X       | 1     | USE_VL53L0X        | VL53L0X laser time-of-flight 
 DisplaySSD1306      | 1     | USE_SSD1306        | SSD1306 128x64 OLED display (I²C); By default displays values of all sensors and children         | https://github.com/greiman/SSD1306Ascii.git
 SensorSHT31         | 2     | USE_SHT31          | SHT31 sensor, return temperature/humidity based on the attached SHT31 sensor                      | https://github.com/adafruit/Adafruit_SHT31
 SensorSI7021        | 2     | USE_SI7021         | SI7021 sensor, return temperature/humidity based on the attached SI7021 sensor                    | https://github.com/sparkfun/SparkFun_Si701_Breakout_Arduino_Library
-SensorChirp         | 3     | USE_CHIRP          | Chirp soil moisture sensor (includes temperature and light sensors)                               |  https://github.com/Apollon77/I2CSoilMoistureSensor
+SensorChirp         | 3     | USE_CHIRP          | Chirp soil moisture sensor (includes temperature and light sensors)                               | https://github.com/Apollon77/I2CSoilMoistureSensor
+DisplayHD44780      | 1     | USE_HD44780        | Supports most Hitachi HD44780 based LCDs, by default displays values of all sensors and children  | https://github.com/cyberang3l/NewLiquidCrystal
 
 NodeManager provides useful built-in features which can be disabled if you need to save some storage for your code. 
 To enable/disable a buil-in feature:
@@ -106,7 +107,7 @@ FEATURE_RTC                 | OFF     | allow keeping the current system time in
 #define SKETCH_NAME "NodeManager"
 #define SKETCH_VERSION "1.0"
 //#define MY_DEBUG
-#define MY_NODE_ID 99
+//#define MY_NODE_ID 99
 
 // NRF24 radio settings
 #define MY_RADIO_NRF24
@@ -252,10 +253,11 @@ FEATURE_RTC                 | OFF     | allow keeping the current system time in
 //#define USE_PULSE_METER
 //#define USE_PMS
 //#define USE_VL53L0X
-#define USE_SSD1306
+//#define USE_SSD1306
 //#define USE_SHT31
 //#define USE_SI7021
 //#define USE_CHIRP
+#define USE_HD44780
 
 /***********************************
  * NodeManager advanced settings
@@ -329,12 +331,14 @@ SensorThermistor thermistor(node,A0);
 //SensorWaterMeter waterMeter(node,3);
 //SensorPlantowerPMS pms(node,6,7);
 //SensorVL53L0X vl53l0x(node,3);
+//DisplaySSD1306 ssd1306(node);
 //SensorSHT31 sht31(node);
 //SensorSI7021 si7021(node);
 //SensorChirp chirp(node);
+DisplayHD44780 hd44780(node);
 
 // Other devices
-DisplaySSD1306 ssd1306(node);
+
 
 /***********************************
  * Main Sketch
@@ -344,8 +348,9 @@ DisplaySSD1306 ssd1306(node);
 void before() {
   // setup the serial port baud rate
   Serial.begin(MY_BAUD_RATE);
-  ssd1306.setCaption("Display");
-node.setReportIntervalSeconds(10);
+  hd44780.setI2CAddress(0x3f);
+
+//node.setReportIntervalSeconds(10);
 
   /*
   * Configure your sensors below

--- a/NodeManagerLibrary.h
+++ b/NodeManagerLibrary.h
@@ -1409,8 +1409,8 @@ class SensorVL53L0X: public Sensor {
 class Display: public Sensor {
   public:
     Display(NodeManager& node_manager, int child_id = -255);
+    // set a static caption text on header of the display
     void setCaption(const char* value);
-    // display specific functions, subclasses have to implement
     // print a static caption on top of the screen
     virtual void printCaption(const char* value);
     // print the given string

--- a/NodeManagerLibrary.h
+++ b/NodeManagerLibrary.h
@@ -507,7 +507,7 @@ class Sensor {
     void presentation();
     void setup();
     void loop(MyMessage* message);
-    void receive(MyMessage &message);
+    void receive(MyMessage* message);
     // abstract functions, subclasses need to implement
     virtual void onBefore();
     virtual void onSetup();
@@ -1399,10 +1399,37 @@ class SensorVL53L0X: public Sensor {
 #endif
 
 /*
+ * Display class
+ */
+#if defined(USE_SSD1306)
+class Display: public Sensor {
+  public:
+    Display(NodeManager& node_manager, int child_id = -255);
+    void setCaption(const char* value);
+    // display specific functions, subclasses have to implement
+    // print a static caption on top of the screen
+    virtual void printCaption(const char* value);
+    // print the given string
+    virtual void print(const char* value);
+    // print the given string and goes to the next line
+    virtual void println(const char* value);
+    // print the value of the given child
+    virtual void printChild(Child* child);
+    // clear the display
+    virtual void clear();
+    // define what to do at each stage of the sketch
+    void onSetup();
+    void onLoop(Child* child);
+    void onReceive(MyMessage* message);
+  protected:
+};
+#endif
+
+/*
  * SSD1306 OLED display
  */
 #ifdef USE_SSD1306
-class DisplaySSD1306: public Sensor {
+class DisplaySSD1306: public Display {
   public:
     DisplaySSD1306(NodeManager& node_manager, int child_id = -255);
     // set device
@@ -1413,20 +1440,22 @@ class DisplaySSD1306: public Sensor {
     void setFont(const uint8_t* font);
     // [102] set the contrast of the display (0-255)
     void setContrast(uint8_t value);
-    // [103] set the displayed text
-    void setText(const char* value);
     // [104] Rotate the display 180 degree (use rotate=false to revert)
     void rotateDisplay(bool rotate = true);
     // [105] Text font size (possible are 1 and 2; default is 1)
     void setFontSize(int fontsize);
     // [106] Text caption font size (possible are 1 and 2; default is 2)
-    void setHeaderFontSize(int fontsize);
+    void setCaptionFontSize(int fontsize);
     // [107] Invert display (black text on color background; use invert=false to revert)
     void invertDisplay(bool invert = true);
+    // display specific functions, subclasses have to implement
+    virtual void printCaption(const char* value);
+    virtual void print(const char* value);
+    virtual void println(const char* value);
+    virtual void printChild(Child* child);
+    virtual void clear();
     // define what to do at each stage of the sketch
     void onSetup();
-    void onLoop(Child* child);
-    void onReceive(MyMessage* message);
     void updateDisplay();
   protected:
     virtual void _display(const char*displaystr = 0);
@@ -1435,6 +1464,8 @@ class DisplaySSD1306: public Sensor {
     uint8_t _i2caddress = 0x3c;
     int _fontsize = 1;
     int _caption_fontsize = 2;
+    uint8_t* _font = Adafruit5x7;
+    uint8_t _contrast = -1;
 };
 #endif
 
@@ -1621,7 +1652,7 @@ class NodeManager {
     void presentation();
     void setup();
     void loop();
-    void receive(MyMessage & msg);
+    void receive(const MyMessage & msg);
   private:
 #if FEATURE_POWER_MANAGER == ON
     PowerManager* _powerManager = nullptr;

--- a/NodeManagerLibrary.h
+++ b/NodeManagerLibrary.h
@@ -168,6 +168,10 @@
   #include <Wire.h>
   #include <I2CSoilMoistureSensor.h>
 #endif
+#ifdef USE_HD44780
+  #include <Wire.h> 
+  #include <LiquidCrystal_I2C.h>
+#endif
 
 // include third party libraries for enabled features
 #ifdef MY_GATEWAY_SERIAL
@@ -1401,7 +1405,7 @@ class SensorVL53L0X: public Sensor {
 /*
  * Display class
  */
-#if defined(USE_SSD1306)
+#if defined(USE_SSD1306) || defined(USE_HD44780)
 class Display: public Sensor {
   public:
     Display(NodeManager& node_manager, int child_id = -255);
@@ -1468,6 +1472,33 @@ class DisplaySSD1306: public Display {
     int _caption_fontsize = 2;
     uint8_t* _font = Adafruit5x7;
     uint8_t _contrast = -1;
+};
+#endif
+
+/*
+ * Hitachi HD44780 display
+ */
+#ifdef USE_HD44780
+class DisplayHD44780: public Display {
+  public:
+    DisplayHD44780(NodeManager& node_manager, int child_id = -255);
+    // set i2c address (default: 0x38)
+    void setI2CAddress(uint8_t i2caddress);
+    // set the backlight (default: HIGH)
+    void setBacklight(uint8_t value);
+    // display specific functions
+    void printCaption(const char* value);
+    void print(const char* value);
+    void println(const char* value);
+    void printChild(Child* child);
+    void clear();
+    void setCursor(int col,int row);
+    // define what to do at each stage of the sketch
+    void onSetup();
+  protected:
+    LiquidCrystal_I2C* _lcd;
+    uint8_t _i2caddress = 0x38;
+    int _column = 0;
 };
 #endif
 

--- a/NodeManagerLibrary.h
+++ b/NodeManagerLibrary.h
@@ -1417,11 +1417,14 @@ class Display: public Sensor {
     virtual void printChild(Child* child);
     // clear the display
     virtual void clear();
+    // set the cursor to the given position
+    virtual void setCursor(int col,int row);
     // define what to do at each stage of the sketch
     void onSetup();
     void onLoop(Child* child);
     void onReceive(MyMessage* message);
   protected:
+  const char* _caption = "";
 };
 #endif
 
@@ -1448,17 +1451,16 @@ class DisplaySSD1306: public Display {
     void setCaptionFontSize(int fontsize);
     // [107] Invert display (black text on color background; use invert=false to revert)
     void invertDisplay(bool invert = true);
-    // display specific functions, subclasses have to implement
-    virtual void printCaption(const char* value);
-    virtual void print(const char* value);
-    virtual void println(const char* value);
-    virtual void printChild(Child* child);
-    virtual void clear();
+    // display specific functions
+    void printCaption(const char* value);
+    void print(const char* value);
+    void println(const char* value);
+    void printChild(Child* child);
+    void clear();
+    void setCursor(int col,int row);
     // define what to do at each stage of the sketch
     void onSetup();
-    void updateDisplay();
   protected:
-    virtual void _display(const char*displaystr = 0);
     SSD1306AsciiAvrI2c *_oled;
     const DevType* _dev = &Adafruit128x64;
     uint8_t _i2caddress = 0x3c;

--- a/NodeManagerLibrary.ino
+++ b/NodeManagerLibrary.ino
@@ -3126,7 +3126,7 @@ int SensorVL53L0X::_getDistance() {
 /*
  * Display
  */
-#if defined(USE_SSD1306)
+#if defined(USE_SSD1306) || defined(USE_HD44780)
 // constructor
 Display::Display(NodeManager& node_manager, int child_id): Sensor(node_manager) {
   _name = "";
@@ -3305,6 +3305,62 @@ void DisplaySSD1306::onSetup() {
   _oled->begin(_dev, _i2caddress);
   _oled->setFont(_font);
   if (_contrast > -1) _oled->setContrast(_contrast);
+  clear();
+}
+#endif
+
+/*
+ * Hitachi HD44780 display
+ */
+#ifdef USE_HD44780
+// constructor
+DisplayHD44780::DisplayHD44780(NodeManager& node_manager, int child_id): Display(node_manager, child_id) {
+  _name = "HD44780";
+  children.get(1)->description = _name;
+}
+
+// setter/getter
+void DisplayHD44780::setI2CAddress(uint8_t i2caddress) {
+  _i2caddress = i2caddress;
+}
+void DisplayHD44780::setBacklight(uint8_t value) {
+  _lcd->setBacklight(value);
+}
+
+// display specific function
+void DisplayHD44780::printCaption(const char* value) {
+  if (strlen(value) > 0) println(value);
+}
+
+void DisplayHD44780::print(const char* value) {
+  // print the string
+  _lcd->print(value);
+}
+
+void DisplayHD44780::println(const char* value) {
+  if (value != nullptr) print(value);
+  _column = _column + 1;
+  setCursor(0,_column);
+}
+
+void DisplayHD44780::printChild(Child* child) {
+  child->printOn(*_lcd);
+}
+
+void DisplayHD44780::clear() {
+  _column = 0;
+  _lcd->clear();
+}
+
+void DisplayHD44780::setCursor(int col,int row) {
+  _lcd->setCursor(col,row);
+}
+
+// what to do during setup
+void DisplayHD44780::onSetup() {
+  _lcd = new LiquidCrystal_I2C(_i2caddress, 2, 1, 0, 4, 5, 6, 7, 3, POSITIVE);
+  _lcd->begin(16,2);
+  _lcd->home();
   clear();
 }
 #endif

--- a/NodeManagerLibrary.ino
+++ b/NodeManagerLibrary.ino
@@ -3773,8 +3773,8 @@ void SensorConfiguration::onReceive(MyMessage* message) {
             case 201: custom_sensor_2->setPulseWidth(request.getValueInt()); break;
             case 202: custom_sensor_2->setPinOff(request.getValueInt()); break;
             case 203: custom_sensor_2->setPinOn(request.getValueInt()); break;
-          default: return;
-        }
+            default: return;
+          }
         }
       }
       #endif

--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ DisplaySSD1306      | 1     | USE_SSD1306        | SSD1306 128x64 OLED display (
 SensorSHT31         | 2     | USE_SHT31          | SHT31 sensor, return temperature/humidity based on the attached SHT31 sensor                      | https://github.com/adafruit/Adafruit_SHT31
 SensorSI7021        | 2     | USE_SI7021         | SI7021 sensor, return temperature/humidity based on the attached SI7021 sensor                    | https://github.com/sparkfun/SparkFun_Si701_Breakout_Arduino_Library
 SensorChirp         | 3     | USE_CHIRP          | Chirp soil moisture sensor (includes temperature and light sensors)                               |  https://github.com/Apollon77/I2CSoilMoistureSensor
+DisplayHD44780      | 1     | USE_HD44780        | Supports most Hitachi HD44780 based LCDs, by default displays values of all sensors and children  | https://github.com/cyberang3l/NewLiquidCrystal
 
 ### Advanced features
 
@@ -610,8 +611,6 @@ Each sensor class exposes additional methods.
     void setFont(const uint8_t* font);
     // [102] set the contrast of the display (0-255)
     void setContrast(uint8_t value);
-    // [103] set the displayed text
-    void setText(const char* value);
     // [104] Rotate the display 180 degree (use rotate=false to revert)
     void rotateDisplay(bool rotate = true);
     // [105] Text font size (possible are 1 and 2; default is 1)


### PR DESCRIPTION
This PR is for allowing to use different types of LCDs by providing common functions out of the box.

 Created a **Display** class, derived from Sensor. All LCD-based classes have to inherit from Display:
* A V_TEXT child is created in the constructor and presented as S_INFO 
* `onLoop()` goes through all the sensors and children and display description and value. For the most common types, a unit is also displayed (e.g. "C" or "F" for temperature, "%" for humidity etc.)
* `onReceive()` displays the string received from the controller on the display. In this way the sensor can be used just to display a message set remotely by the controller. if the string contains a "," at the second position, it means the first char is the row number (e.g. 4,abcd will print abcd at row 4)
* The display is updated based on the reporting interval set, like all the other sensors
* Subclasses have to implement the following methods:
```
    // print a static caption on top of the screen
    virtual void printCaption(const char* value);
    // print the given string
    virtual void print(const char* value);
    // print the given string and goes to the next line
    virtual void println(const char* value);
    // print the value of the given child
    virtual void printChild(Child* child);
    // clear the display
    virtual void clear();
    // set the cursor to the given position
    virtual void setCursor(int col,int row);
```
Modified the existing **DisplaySSD1306** class (#281):
* Child is already created by Display, just setting its description in the constructor
* setFont() and setContrast() changed to store the value locally since _oled could be null if called in before()
* setHeaderFontSize() renamed into setCaptionFontSize();
* Removed setText(). Text can be set with V_TEXT messages to the child
* Removed updateDisplay(), print() can be used instead from the code. Removed _display() now part of onLoop() of the Display class
* Sensor name is not displayed anymore, description is used instead

Added DisplayHD44780 class for supporting Hitachi HD44780 LCD display (fixes #280):
* Requires USE_HD44780 and https://github.com/cyberang3l/NewLiquidCrystal library

Fixes receive() bug #287