### PR TITLE
Add support for SD card reader

### DIFF
--- a/NodeManager.ino
+++ b/NodeManager.ino
@@ -98,6 +98,7 @@ FEATURE_EEPROM              | ON      | allow keeping track of some information 
 FEATURE_SLEEP               | ON      | allow managing automatically the complexity behind battery-powered sleeping sensors              | - 
 FEATURE_TIME                | OFF     | allow keeping the current system time in sync with the controller                                | https://github.com/PaulStoffregen/Time
 FEATURE_RTC                 | OFF     | allow keeping the current system time in sync with an attached RTC device (requires FEATURE_TIME)| https://github.com/JChristensen/DS3232RTC
+FEATURE_SD                  | OFF     | allow for reading from and writing to SD cards                                                   | -
 
 /**********************************
  * MySensors node configuration
@@ -274,6 +275,7 @@ FEATURE_RTC                 | OFF     | allow keeping the current system time in
 #define FEATURE_SLEEP ON
 #define FEATURE_TIME OFF
 #define FEATURE_RTC OFF
+#define FEATURE_SD ON
 
 /***********************************
  * Load NodeManager Library

--- a/NodeManager.ino
+++ b/NodeManager.ino
@@ -275,7 +275,7 @@ FEATURE_SD                  | OFF     | allow for reading from and writing to SD
 #define FEATURE_SLEEP ON
 #define FEATURE_TIME OFF
 #define FEATURE_RTC OFF
-#define FEATURE_SD ON
+#define FEATURE_SD OFF
 
 /***********************************
  * Load NodeManager Library

--- a/NodeManagerLibrary.h
+++ b/NodeManagerLibrary.h
@@ -187,6 +187,9 @@
 #if FEATURE_CONDITIONAL_REPORT == ON
   #include <float.h>
 #endif
+#if FEATURE_SD == ON
+  #include <SD.h>
+#endif
 
 /*******************************************************************
    Classes
@@ -1680,6 +1683,12 @@ class NodeManager {
     List<Sensor*> sensors;
     Child* getChild(int child_id);
     Sensor* getSensorWithChild(int child_id);
+#if FEATURE_SD == ON
+    Sd2Card sd_card;
+    SdVolume sd_volume;
+    SdFile sd_root;
+    SdFile sd_file;
+#endif
     // hook into the main sketch functions
     void before();
     void presentation();

--- a/NodeManagerLibrary.ino
+++ b/NodeManagerLibrary.ino
@@ -4148,6 +4148,28 @@ void NodeManager::setup() {
   // sync the time with the controller
   syncTime();
 #endif
+#if FEATURE_SD == ON
+  // initialize connection to the SD card
+  if (sd_card.init(SPI_HALF_SPEED)) {
+    #ifdef NODEMANAGER_DEBUG
+      Serial.print(F("SD T="));
+      switch(sd_card.type()) {
+        case SD_CARD_TYPE_SD1:
+          Serial.println("SD1"); break;
+        case SD_CARD_TYPE_SD2:
+          Serial.println("SD2"); break;
+        case SD_CARD_TYPE_SDHC:
+        Serial.println("SDHC"); break;
+        default:
+        Serial.println("Unknown");
+      }
+    #endif
+    // initialize the volume
+    sd_volume.init(sd_card);
+    // open up the volume
+    sd_root.openRoot(sd_volume);
+  }
+#endif
   // run setup for all the registered sensors
   for (List<Sensor*>::iterator itr = sensors.begin(); itr != sensors.end(); ++itr) {
     Sensor* sensor = *itr;

--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ FEATURE_EEPROM              | OFF     | allow keeping track of some information 
 FEATURE_SLEEP               | ON      | allow managing automatically the complexity behind battery-powered sleeping sensors              | - 
 FEATURE_TIME                | OFF     | allow keeping the current system time in sync with the controller                                | https://github.com/PaulStoffregen/Time
 FEATURE_RTC                 | OFF     | allow keeping the current system time in sync with an attached RTC device (requires FEATURE_TIME)| https://github.com/JChristensen/DS3232RTC
+FEATURE_SD                  | OFF     | allow for reading from and writing to SD cards                                                   | -
 
 ## Installation
 
@@ -313,6 +314,12 @@ You can interact with each class provided by NodeManager through a set of API fu
     List<Sensor*> sensors;
     Child* getChild(int child_id);
     Sensor* getSensorWithChild(int child_id);
+#if FEATURE_SD == ON
+    Sd2Card sd_card;
+    SdVolume sd_volume;
+    SdFile sd_root;
+    SdFile sd_file;
+#endif
 ~~~
 
 ### Sensor API


### PR DESCRIPTION
This PR adds support for an attached SD card reader (fixes #277)
* Added FEATURE_SD, default to OFF
* When enabled, the NodeManager's class will expose `sd_card, sd_volume, sd_root, sd_file`
* In NodeManager::setup() the card is initialized and card type is printed out. Root volume is also opened and `sd_file `can be used to read/write on the SD card
* Allow SD card access when running on a Sensebender Gateway (#275)

Reference: https://www.kitronik.co.uk/pdf/SD_SimpleExample.pde.txt