### PR TITLE
Add support for SparkFun APDS-9960 Gesture Sensor

### DIFF
--- a/NodeManager.ino
+++ b/NodeManager.ino
@@ -265,7 +265,7 @@ FEATURE_SD                  | OFF     | allow for reading from and writing to SD
 //#define USE_HD44780
 //#define USE_TTP
 //#define USE_SERVO
-#define USE_APDS9960
+//#define USE_APDS9960
 
 /***********************************
  * NodeManager advanced settings
@@ -348,7 +348,7 @@ NodeManager node;
 //DisplayHD44780 hd44780(node);
 //SensorTTP ttp(node);
 //SensorServo servo(node,6);
-SensorAPDS9960 apsd9960(node,3);
+//SensorAPDS9960 apsd9960(node,3);
 
 /***********************************
  * Main Sketch

--- a/NodeManager.ino
+++ b/NodeManager.ino
@@ -83,6 +83,7 @@ SensorChirp         | 3     | USE_CHIRP          | Chirp soil moisture sensor (i
 DisplayHD44780      | 1     | USE_HD44780        | Supports most Hitachi HD44780 based LCDs, by default displays values of all sensors and children  | https://github.com/cyberang3l/NewLiquidCrystal
 SensorTTP           | 1     | USE_TTP            | TTP226/TTP229 Touch control sensor                                                                | -
 SensorServo         | 1     | USE_SERVO          | Control a generic Servo motor sensor                                                              | -
+SensorAPDS9960      | 1     | USE_APDS9960       | SparkFun RGB and Gesture Sensor                                                                   | https://github.com/sparkfun/APDS-9960_RGB_and_Gesture_Sensor
 
 NodeManager provides useful built-in features which can be disabled if you need to save some storage for your code. 
 To enable/disable a buil-in feature:
@@ -264,6 +265,7 @@ FEATURE_SD                  | OFF     | allow for reading from and writing to SD
 //#define USE_HD44780
 //#define USE_TTP
 //#define USE_SERVO
+#define USE_APDS9960
 
 /***********************************
  * NodeManager advanced settings
@@ -346,6 +348,7 @@ NodeManager node;
 //DisplayHD44780 hd44780(node);
 //SensorTTP ttp(node);
 //SensorServo servo(node,6);
+SensorAPDS9960 apsd9960(node,3);
 
 /***********************************
  * Main Sketch

--- a/NodeManagerLibrary.h
+++ b/NodeManagerLibrary.h
@@ -175,6 +175,10 @@
 #ifdef USE_SERVO
   #include <Servo.h>
 #endif
+#ifdef USE_APDS9960
+  #include <Wire.h>
+  #include <SparkFun_APDS9960.h>
+#endif
 
 // include third party libraries for enabled features
 #ifdef MY_GATEWAY_SERIAL
@@ -1626,6 +1630,22 @@ class SensorServo: public Sensor {
   protected:
     Servo _servo;
     int _value;
+};
+#endif
+
+/*
+ * SparkFun RGB and Gesture Sensor
+ */
+#ifdef USE_APDS9960
+class SensorAPDS9960: public Sensor {
+  public:
+    SensorAPDS9960(NodeManager& node_manager, int pin, int child_id = -255);
+    // define what to do at each stage of the sketch
+    void onSetup();
+    void onLoop(Child* child);
+    void onInterrupt();
+  protected:
+  SparkFun_APDS9960* _apds;
 };
 #endif
 

--- a/NodeManagerLibrary.ino
+++ b/NodeManagerLibrary.ino
@@ -3712,6 +3712,62 @@ int SensorTTP::_fetchData() {
 /*
  * SensorServo
  */
+#ifdef USE_APDS9960
+// constructor
+SensorAPDS9960::SensorAPDS9960(NodeManager& node_manager, int pin, int child_id): Sensor(node_manager, pin) {
+  _name = "APDS9960";
+  children.allocateBlocks(1);
+  new ChildString(this,_node->getAvailableChildId(child_id),S_INFO,V_TEXT,_name);
+}
+
+// what to do during setup
+void SensorAPDS9960::onSetup() {
+  _apds = new SparkFun_APDS9960();
+  pinMode(_pin, INPUT);
+  // set the interrupt
+  setInterrupt(_pin,FALLING,HIGH);
+  // report immediately
+  _report_timer->unset();
+  // initialize the library
+  _apds->init();
+  _apds->enableGestureSensor(true);
+}
+
+// what to do during loop
+void SensorAPDS9960::onLoop(Child *child) {
+}
+
+// what to do on interrupt
+void SensorAPDS9960::onInterrupt() {
+  char* gesture = "";
+  Child* child = children.get(1);
+  if ( _apds->isGestureAvailable() ) {
+    switch ( _apds->readGesture() ) {
+      case DIR_UP: gesture = "UP"; break;
+      case DIR_DOWN: gesture = "DOWN"; break;
+      case DIR_LEFT: gesture = "LEFT"; break;
+      case DIR_RIGHT: gesture = "RIGHT"; break;
+      case DIR_NEAR: gesture = "NEAR"; break;
+      case DIR_FAR: gesture = "FAR"; break;
+      default: gesture = "NONE"; break;
+    }
+    #ifdef NODEMANAGER_DEBUG
+      Serial.print(_name);
+      Serial.print(F(" I="));
+      Serial.print(child->child_id);
+      Serial.print(F(" G="));
+      Serial.println(gesture);
+    #endif
+    // store it in the child so it will be sent back 
+    ((ChildString*)child)->setValueString(gesture);
+  }
+}
+
+#endif
+
+/*
+ * SensorServo
+ */
 #ifdef USE_SERVO
 // constructor
 SensorServo::SensorServo(NodeManager& node_manager, int pin, int child_id): Sensor(node_manager, pin) {

--- a/NodeManagerLibrary.ino
+++ b/NodeManagerLibrary.ino
@@ -3712,6 +3712,55 @@ int SensorTTP::_fetchData() {
 /*
  * SensorServo
  */
+#ifdef USE_SERVO
+// constructor
+SensorServo::SensorServo(NodeManager& node_manager, int pin, int child_id): Sensor(node_manager, pin) {
+  _name = "SERVO";
+  children.allocateBlocks(1);
+  new ChildInt(this, _node->getAvailableChildId(child_id), S_DIMMER, V_PERCENTAGE ,_name);
+}
+
+// what to do during setup
+void SensorServo::onSetup() {
+  _servo.attach(_pin);
+}
+
+// what to do during loop
+void SensorServo::onLoop(Child *child) {
+}
+
+// what to do as the main task when receiving a message
+void SensorServo::onReceive(MyMessage* message) {
+  Child* child = getChild(message->sensor);
+  if (child == nullptr) return;
+  if (message->getCommand() == C_SET) setPercentage(message->getInt());
+  if (message->getCommand() == C_REQ) ((ChildInt*)child)->setValueInt(_value);
+}
+
+// set the servo to the given percentage
+void SensorServo::setPercentage(int value) {
+   _value = value;
+  // set the servo to the given value
+  _servo.write(map(_value,0,100,0,180));
+  // set the value so to send it back
+  Child* child = children.get(1);
+  if (child == nullptr) return;
+  ((ChildInt*)child)->setValueInt(_value);
+  #ifdef NODEMANAGER_DEBUG
+    Serial.print(_name);
+    Serial.print(F(" I="));
+    Serial.print(child->child_id);
+    Serial.print(F(" P="));
+    Serial.print(_pin);
+    Serial.print(F(" V="));
+    Serial.println(_value);
+  #endif
+}
+#endif
+
+/*
+ * SensorAPDS9960
+ */
 #ifdef USE_APDS9960
 // constructor
 SensorAPDS9960::SensorAPDS9960(NodeManager& node_manager, int pin, int child_id): Sensor(node_manager, pin) {
@@ -3761,56 +3810,6 @@ void SensorAPDS9960::onInterrupt() {
     // store it in the child so it will be sent back 
     ((ChildString*)child)->setValueString(gesture);
   }
-}
-
-#endif
-
-/*
- * SensorServo
- */
-#ifdef USE_SERVO
-// constructor
-SensorServo::SensorServo(NodeManager& node_manager, int pin, int child_id): Sensor(node_manager, pin) {
-  _name = "SERVO";
-  children.allocateBlocks(1);
-  new ChildInt(this, _node->getAvailableChildId(child_id), S_DIMMER, V_PERCENTAGE ,_name);
-}
-
-// what to do during setup
-void SensorServo::onSetup() {
-  _servo.attach(_pin);
-}
-
-// what to do during loop
-void SensorServo::onLoop(Child *child) {
-}
-
-// what to do as the main task when receiving a message
-void SensorServo::onReceive(MyMessage* message) {
-  Child* child = getChild(message->sensor);
-  if (child == nullptr) return;
-  if (message->getCommand() == C_SET) setPercentage(message->getInt());
-  if (message->getCommand() == C_REQ) ((ChildInt*)child)->setValueInt(_value);
-}
-
-// set the servo to the given percentage
-void SensorServo::setPercentage(int value) {
-   _value = value;
-  // set the servo to the given value
-  _servo.write(map(_value,0,100,0,180));
-  // set the value so to send it back
-  Child* child = children.get(1);
-  if (child == nullptr) return;
-  ((ChildInt*)child)->setValueInt(_value);
-  #ifdef NODEMANAGER_DEBUG
-    Serial.print(_name);
-    Serial.print(F(" I="));
-    Serial.print(child->child_id);
-    Serial.print(F(" P="));
-    Serial.print(_pin);
-    Serial.print(F(" V="));
-    Serial.println(_value);
-  #endif
 }
 #endif
 

--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ SensorChirp         | 3     | USE_CHIRP          | Chirp soil moisture sensor (i
 DisplayHD44780      | 1     | USE_HD44780        | Supports most Hitachi HD44780 based LCDs, by default displays values of all sensors and children  | https://github.com/cyberang3l/NewLiquidCrystal
 SensorTTP           | 1     | USE_TTP            | TTP226/TTP229 Touch control sensor                                                                | -
 SensorServo         | 1     | USE_SERVO          | Control a generic Servo motor sensor                                                              | -
+SensorAPDS9960      | 1     | USE_APDS9960       | SparkFun RGB and Gesture Sensor                                                                   | https://github.com/sparkfun/APDS-9960_RGB_and_Gesture_Sensor
 
 ### Advanced features
 


### PR DESCRIPTION
This PR is for starting supporting the APDS-9960 sensor (fixes #201). The gesture sensor only is supported in this first release:
* Added SensorAPDS9960 depending on USE_APDS9960
* Gesture sensor is implemented through a V_TEXT child presenting as S_INFO and attached to an interrupt pin. When the interrupt triggers, the gesture is sent back to the controller as a string

According to https://github.com/sparkfun/APDS-9960_RGB_and_Gesture_Sensor/tree/master/Libraries/Arduino/APDS-9960_RGB_and_Gesture_Sensor_Arduino_Library/examples, this sensor can be also used in many ways but apparently not on the same time making the implementation more difficult (same sensor with a "type" input? multiple sensors with a superclass?)