### PR TITLE
Add support for Neopixel LED

### DIFF
--- a/NodeManager.ino
+++ b/NodeManager.ino
@@ -84,6 +84,7 @@ DisplayHD44780      | 1     | USE_HD44780        | Supports most Hitachi HD44780
 SensorTTP           | 1     | USE_TTP            | TTP226/TTP229 Touch control sensor                                                                | -
 SensorServo         | 1     | USE_SERVO          | Control a generic Servo motor sensor                                                              | -
 SensorAPDS9960      | 1     | USE_APDS9960       | SparkFun RGB and Gesture Sensor                                                                   | https://github.com/sparkfun/APDS-9960_RGB_and_Gesture_Sensor
+SensorNeopixel      | 1     | USE_NEOPIXEL       | Control a Neopixel LED                                                                            | https://github.com/adafruit/Adafruit_NeoPixel
 
 NodeManager provides useful built-in features which can be disabled if you need to save some storage for your code. 
 To enable/disable a buil-in feature:
@@ -266,6 +267,7 @@ FEATURE_SD                  | OFF     | allow for reading from and writing to SD
 //#define USE_TTP
 //#define USE_SERVO
 //#define USE_APDS9960
+//#define USE_NEOPIXEL
 
 /***********************************
  * NodeManager advanced settings
@@ -349,6 +351,7 @@ NodeManager node;
 //SensorTTP ttp(node);
 //SensorServo servo(node,6);
 //SensorAPDS9960 apsd9960(node,3);
+//SensorNeopixel neopixel(node,6);
 
 /***********************************
  * Main Sketch

--- a/NodeManagerLibrary.h
+++ b/NodeManagerLibrary.h
@@ -179,6 +179,9 @@
   #include <Wire.h>
   #include <SparkFun_APDS9960.h>
 #endif
+#ifdef USE_NEOPIXEL
+  #include <Adafruit_NeoPixel.h>
+#endif
 
 // include third party libraries for enabled features
 #ifdef MY_GATEWAY_SERIAL
@@ -1646,6 +1649,27 @@ class SensorAPDS9960: public Sensor {
     void onInterrupt();
   protected:
   SparkFun_APDS9960* _apds;
+};
+#endif
+
+/*
+ * Neopixel LED Sensor
+ */
+#ifdef USE_NEOPIXEL
+class SensorNeopixel: public Sensor {
+  public:
+    SensorNeopixel(NodeManager& node_manager, int pin, int child_id = -255);
+    // set how many NeoPixels are attached
+    void setNumPixels(int value);
+    // format expeted is "<pixel_number>,<RGB color in a packed 32 bit format>"
+    void setColor(char* string);
+    // define what to do at each stage of the sketch
+    void onSetup();
+    void onLoop(Child* child);
+    void onReceive(MyMessage* message);
+  protected:
+  Adafruit_NeoPixel* _pixels;
+  int _num_pixels = 16;
 };
 #endif
 

--- a/NodeManagerLibrary.ino
+++ b/NodeManagerLibrary.ino
@@ -3814,6 +3814,62 @@ void SensorAPDS9960::onInterrupt() {
 #endif
 
 /*
+ * SensorNeopixel
+ */
+#ifdef USE_NEOPIXEL
+// constructor
+SensorNeopixel::SensorNeopixel(NodeManager& node_manager, int pin, int child_id): Sensor(node_manager, pin) {
+  _name = "NEOPIXEL";
+  children.allocateBlocks(1);
+  new ChildInt(this, _node->getAvailableChildId(child_id), S_COLOR_SENSOR, V_RGB ,_name);
+}
+
+// setter/getter
+void SensorNeopixel::setNumPixels(int value) {
+  _num_pixels = value;
+}
+
+// what to do during setup
+void SensorNeopixel::onSetup() {
+  _pixels = new Adafruit_NeoPixel(_num_pixels, _pin, NEO_GRB + NEO_KHZ800);
+  _pixels->begin();
+}
+
+// what to do during loop
+void SensorNeopixel::onLoop(Child *child) {
+}
+
+// what to do as the main task when receiving a message
+void SensorNeopixel::onReceive(MyMessage* message) {
+  Child* child = getChild(message->sensor);
+  if (child == nullptr) return;
+  if (message->getCommand() == C_REQ && message->type == child->type) {
+    setColor(message->getString());
+  }
+}
+
+void SensorNeopixel::setColor(char* string) {
+    Child* child = children.get(1);
+    // if the second char is not a comma, return
+    if (strncmp(string+1,",",1) != 0) return;
+    int pixel_num = atoi(string);
+    int color = atoi(string+2);
+    #ifdef NODEMANAGER_DEBUG
+      Serial.print(_name);
+      Serial.print(F(" I="));
+      Serial.print(child->child_id);
+      Serial.print(F(" N="));
+      Serial.print(pixel_num);
+      Serial.print(F(" C="));
+      Serial.println(color);
+    #endif
+    _pixels->setPixelColor(pixel_num,color);
+    _pixels->show();
+    ((ChildInt*)child)->setValueInt(color);
+}
+#endif
+
+/*
    SensorConfiguration
 */
 // contructor

--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ DisplayHD44780      | 1     | USE_HD44780        | Supports most Hitachi HD44780
 SensorTTP           | 1     | USE_TTP            | TTP226/TTP229 Touch control sensor                                                                | -
 SensorServo         | 1     | USE_SERVO          | Control a generic Servo motor sensor                                                              | -
 SensorAPDS9960      | 1     | USE_APDS9960       | SparkFun RGB and Gesture Sensor                                                                   | https://github.com/sparkfun/APDS-9960_RGB_and_Gesture_Sensor
+SensorNeopixel      | 1     | USE_NEOPIXEL       | Control a Neopixel LED                                                                            | https://github.com/adafruit/Adafruit_NeoPixel
 
 ### Advanced features
 
@@ -670,6 +671,14 @@ Each sensor class exposes additional methods.
 ~~~c
     // set the servo to the given percentage
     void setPercentage(int value);
+~~~
+
+* SensorNeopixel
+~~~c
+    // set how many NeoPixels are attached
+    void setNumPixels(int value);
+    // format expeted is "<pixel_number>,<RGB color in a packed 32 bit format>"
+    void setColor(char* string);
 ~~~
 
 ### Remote API


### PR DESCRIPTION
This PR add support for Neopixel LED (fixes #203):
* Added SensorNeopixel depending on USE_NEOPIXEL
* Single V_RGB child presenting as S_COLOR_SENSOR
* Number of pixels can be set with setNumPixels()
* To set the color of a pixel, either send a V_RGB message to its child or call setColor(). Format expected is "<pixel_number>,<RGB color in a packed 32 bit format>" 