### PR TITLE
SensorInterrupt Enhancements

### DIFF
--- a/NodeManager.ino
+++ b/NodeManager.ino
@@ -241,7 +241,7 @@ FEATURE_SD                  | OFF     | allow reading from and writing to SD car
 //#define USE_DIGITAL_OUTPUT
 //#define USE_DHT
 //#define USE_SHT21
-//#define USE_INTERRUPT
+#define USE_INTERRUPT
 //#define USE_DS18B20
 //#define USE_BH1750
 //#define USE_MLX90614
@@ -321,7 +321,7 @@ NodeManager node;
 //SensorHTU21D htu21(node);
 //SensorInterrupt interrupt(node,3);
 //SensorDoor door(node,3);
-//SensorMotion motion(node,3);
+SensorMotion motion(node,3);
 //SensorDs18b20 ds18b20(node,6);
 //SensorBH1750 bh1750(node);
 //SensorMLX90614 mlx90614(node);

--- a/NodeManager.ino
+++ b/NodeManager.ino
@@ -241,7 +241,7 @@ FEATURE_SD                  | OFF     | allow reading from and writing to SD car
 //#define USE_DIGITAL_OUTPUT
 //#define USE_DHT
 //#define USE_SHT21
-#define USE_INTERRUPT
+//#define USE_INTERRUPT
 //#define USE_DS18B20
 //#define USE_BH1750
 //#define USE_MLX90614
@@ -321,7 +321,7 @@ NodeManager node;
 //SensorHTU21D htu21(node);
 //SensorInterrupt interrupt(node,3);
 //SensorDoor door(node,3);
-SensorMotion motion(node,3);
+//SensorMotion motion(node,3);
 //SensorDs18b20 ds18b20(node,6);
 //SensorBH1750 bh1750(node);
 //SensorMLX90614 mlx90614(node);

--- a/NodeManagerLibrary.h
+++ b/NodeManagerLibrary.h
@@ -931,6 +931,10 @@ class SensorInterrupt: public Sensor {
     void setActiveState(int value);
     // [106] Set armed, if false the sensor will not trigger until armed (default: true) 
     void setArmed(bool value);
+#if FEATURE_TIME == ON
+    // [107] when keeping track of the time, trigger only after X consecutive interrupts within the same minute (default: 1)
+    void setThreshold(int value);
+#endif
     // define what to do at each stage of the sketch
     void onSetup();
     void onLoop(Child* child);
@@ -943,6 +947,11 @@ class SensorInterrupt: public Sensor {
     int _initial = HIGH;
     int _active_state = HIGH;
     bool _armed = true;
+#if FEATURE_TIME == ON
+    int _threshold = 1;
+    int _counter = 0;
+    int _current_minute = minute();
+#endif
 };
 
 /*

--- a/NodeManagerLibrary.h
+++ b/NodeManagerLibrary.h
@@ -929,6 +929,8 @@ class SensorInterrupt: public Sensor {
     void setInitial(int value);
     // [105] Set active state (default: HIGH) 
     void setActiveState(int value);
+    // [106] Set armed, if false the sensor will not trigger until armed (default: true) 
+    void setArmed(bool value);
     // define what to do at each stage of the sketch
     void onSetup();
     void onLoop(Child* child);
@@ -940,6 +942,7 @@ class SensorInterrupt: public Sensor {
     int _mode = CHANGE;
     int _initial = HIGH;
     int _active_state = HIGH;
+    bool _armed = true;
 };
 
 /*

--- a/NodeManagerLibrary.ino
+++ b/NodeManagerLibrary.ino
@@ -1531,6 +1531,10 @@ void SensorInterrupt::setInitial(int value) {
 void SensorInterrupt::setActiveState(int value) {
   _active_state = value;
 }
+void SensorInterrupt::setArmed(bool value) {
+  _armed = value;
+}
+
 
 // what to do during setup
 void SensorInterrupt::onSetup() {
@@ -1574,7 +1578,7 @@ void SensorInterrupt::onInterrupt() {
       Serial.print(F(" V="));
       Serial.println(value);
     #endif
-    ((ChildInt*)child)->setValueInt(value);
+    if (_armed) ((ChildInt*)child)->setValueInt(value);
     // allow the signal to be restored to its normal value
     if (_trigger_time > 0) _node->sleepOrWait(_trigger_time);
   } else {
@@ -4101,6 +4105,7 @@ void SensorConfiguration::onReceive(MyMessage* message) {
           case 103: custom_sensor->setTriggerTime(request.getValueInt()); break;
           case 104: custom_sensor->setInitial(request.getValueInt()); break;
           case 105: custom_sensor->setActiveState(request.getValueInt()); break;
+          case 106: custom_sensor->setArmed(request.getValueInt()); break;
           default: return;
         }
       }

--- a/NodeManagerLibrary.ino
+++ b/NodeManagerLibrary.ino
@@ -1534,6 +1534,11 @@ void SensorInterrupt::setActiveState(int value) {
 void SensorInterrupt::setArmed(bool value) {
   _armed = value;
 }
+#if FEATURE_TIME == ON
+void SensorInterrupt::setThreshold(int value) {
+  _threshold = value;      
+}
+#endif
 
 
 // what to do during setup
@@ -1560,6 +1565,12 @@ void SensorInterrupt::onReceive(MyMessage* message) {
 
 // what to do when receiving an interrupt
 void SensorInterrupt::onInterrupt() {
+#if FEATURE_TIME == ON
+  // if this interrupt came in a new minute, reset the counter
+  if (minute() != _current_minute) _counter = 0;
+  // increase the counter
+  _counter = _counter + 1;
+#endif
   Child* child = children.get(1);
   // wait to ensure the the input is not floating
   if (_debounce > 0) _node->sleepOrWait(_debounce);
@@ -1578,7 +1589,12 @@ void SensorInterrupt::onInterrupt() {
       Serial.print(F(" V="));
       Serial.println(value);
     #endif
-    if (_armed) ((ChildInt*)child)->setValueInt(value);
+    if (! _armed) return;
+#if FEATURE_TIME == ON
+    // report only when there are at least _threshold triggers
+    if (_counter < _threshold) return;
+#endif
+    ((ChildInt*)child)->setValueInt(value);
     // allow the signal to be restored to its normal value
     if (_trigger_time > 0) _node->sleepOrWait(_trigger_time);
   } else {
@@ -4106,6 +4122,7 @@ void SensorConfiguration::onReceive(MyMessage* message) {
           case 104: custom_sensor->setInitial(request.getValueInt()); break;
           case 105: custom_sensor->setActiveState(request.getValueInt()); break;
           case 106: custom_sensor->setArmed(request.getValueInt()); break;
+          case 107: custom_sensor->setThreshold(request.getValueInt()); break;
           default: return;
         }
       }

--- a/README.md
+++ b/README.md
@@ -508,6 +508,10 @@ Each sensor class exposes additional methods.
     void setActiveState(int value);    
     // [106] Set armed, if false the sensor will not trigger until armed (default: true) 
     void setArmed(bool value);
+#if FEATURE_TIME == ON
+    // [107] when keeping track of the time, trigger only after X consecutive interrupts within the same minute (default: 1)
+    void setThreshold(int value);
+#endif
 ~~~
 
 *  SensorDs18b20

--- a/README.md
+++ b/README.md
@@ -506,6 +506,8 @@ Each sensor class exposes additional methods.
     void setInitial(int value);
     // [105] Set active state (default: HIGH) 
     void setActiveState(int value);    
+    // [106] Set armed, if false the sensor will not trigger until armed (default: true) 
+    void setArmed(bool value);
 ~~~
 
 *  SensorDs18b20


### PR DESCRIPTION
This PR implements some enhancements to SensorInterrupt and its subclasses:
* The sensor can be armed/disarmed remotely through the setArmed() function, also available through the remote API (alternative was to create an additional S_BINARY child but was a less clean solution). If disarmed, the board still wakes on an interrupt but value is not reported to the controller. Fixes #138 
* Add option to send the message only after X consecutive triggers within the same minute. Threshold is set through setThreshold() also available through the remote API and default to 1. Available only when FEATURE_TIME is ON since requires the Time library. Uses additional 1.300 bytes. Fixes #29 