### PR TITLE
Inter-sensor communication

### DIFF
--- a/NodeManager.ino
+++ b/NodeManager.ino
@@ -20,8 +20,10 @@
 
  DESCRIPTION
 
-NodeManager is intended to take care on your behalf of all those common tasks a MySensors node has to accomplish, 
-speeding up the development cycle of your projects.
+NodeManager is intended to take care on your behalf of all those common tasks that a MySensors node has to accomplish, speeding up the development cycle of your projects. 
+Consider it as a sort of frontend for your MySensors projects. When you need to add a sensor (which requires just uncommeting a single line),
+NodeManager will take care of importing the required library, presenting the sensor to the gateway/controller, executing periodically the main function of the sensor 
+(e.g. measure a temperature, detect a motion, etc.), allowing you to interact with the sensor and even configuring it remotely.
 
 Documentation available on: https://github.com/mysensors/NodeManager
 NodeManager provides built-in implementation of a number of sensors through ad-hoc classes. 
@@ -314,7 +316,7 @@ NodeManager node;
 //SensorML8511 ml8511(node,A0);
 //SensorACS712 acs712(node,A0);
 //SensorDigitalInput digitalIn(node,6);
-//SensorDigitalOutput digitalOut(node,7);
+//SensorDigitalOutput digitalOut(node,6);
 //SensorRelay relay(node,6);
 //SensorLatchingRelay latching(node,6);
 //SensorDHT11 dht11(node,6);

--- a/NodeManager.ino
+++ b/NodeManager.ino
@@ -22,6 +22,7 @@
 
 NodeManager is intended to take care on your behalf of all those common tasks a MySensors node has to accomplish, 
 speeding up the development cycle of your projects.
+
 Documentation available on: https://github.com/mysensors/NodeManager
 NodeManager provides built-in implementation of a number of sensors through ad-hoc classes. 
 
@@ -53,7 +54,7 @@ SensorDHT11         | 2     | USE_DHT            | DHT11 sensor, return temperat
 SensorDHT22         | 2     | USE_DHT            | DHT22 sensor, return temperature/humidity based on the attached DHT sensor                        | https://github.com/mysensors/MySensorsArduinoExamples/tree/master/libraries/DHT
 SensorSHT21         | 2     | USE_SHT21          | SHT21 sensor, return temperature/humidity based on the attached SHT21 sensor                      | https://github.com/SodaqMoja/Sodaq_SHT2x
 SensorHTU21D        | 2     | USE_SHT21          | HTU21D sensor, return temperature/humidity based on the attached HTU21D sensor                    | https://github.com/SodaqMoja/Sodaq_SHT2x
-SensorInterrupt     | 1     | USE_INTERRUPT      | Generic interrupt-based sensor, wake up the board when a pin changes status                                       | -
+SensorInterrupt     | 1     | USE_INTERRUPT      | Generic interrupt-based sensor, wake up the board when a pin changes status                       | -
 SensorDoor          | 1     | USE_INTERRUPT      | Door sensor, wake up the board and report when an attached magnetic sensor has been opened/closed | -
 SensorMotion        | 1     | USE_INTERRUPT      | Motion sensor, wake up the board and report when an attached PIR has triggered                    | -
 SensorDs18b20       | 1+    | USE_DS18B20        | DS18B20 sensor, return the temperature based on the attached sensor                               | https://github.com/milesburton/Arduino-Temperature-Control-Library
@@ -105,7 +106,7 @@ FEATURE_RECEIVE             | ON      | allow the node to receive messages; can 
 FEATURE_TIME                | OFF     | allow keeping the current system time in sync with the controller                                | https://github.com/PaulStoffregen/Time
 FEATURE_RTC                 | OFF     | allow keeping the current system time in sync with an attached RTC device (requires FEATURE_TIME)| https://github.com/JChristensen/DS3232RTC
 FEATURE_SD                  | OFF     | allow reading from and writing to SD cards                                                       | -
-FEATURE_HOOKING             | OFF     | allow cusotm code to be hooked in the out of the box sensors                                     | -
+FEATURE_HOOKING             | OFF     | allow custom code to be hooked in the out of the box sensors                                     | -
 
 /**********************************
  * MySensors node configuration
@@ -127,8 +128,7 @@ FEATURE_HOOKING             | OFF     | allow cusotm code to be hooked in the ou
 
 // RFM69 radio settings
 //#define MY_RADIO_RFM69
-//#define MY_RFM69_FREQUENCY RF69_868MHZ
-//#define MY_RFM69_FREQUENCY RFM69_868MHZ
+//#define MY_RFM69_FREQUENCY RFM69_433MHZ
 //#define MY_IS_RFM69HW
 //#define MY_RFM69_NEW_DRIVER
 //#define MY_RFM69_ENABLE_ENCRYPTION
@@ -238,8 +238,8 @@ FEATURE_HOOKING             | OFF     | allow cusotm code to be hooked in the ou
 //#define USE_THERMISTOR
 //#define USE_ML8511
 //#define USE_ACS712
-#define USE_DIGITAL_INPUT
-#define USE_DIGITAL_OUTPUT
+//#define USE_DIGITAL_INPUT
+//#define USE_DIGITAL_OUTPUT
 //#define USE_DHT
 //#define USE_SHT21
 //#define USE_INTERRUPT
@@ -286,7 +286,7 @@ FEATURE_HOOKING             | OFF     | allow cusotm code to be hooked in the ou
 #define FEATURE_TIME OFF
 #define FEATURE_RTC OFF
 #define FEATURE_SD OFF
-#define FEATURE_HOOKING ON
+#define FEATURE_HOOKING OFF
 
 /***********************************
  * Load NodeManager Library
@@ -313,8 +313,8 @@ NodeManager node;
 //SensorThermistor thermistor(node,A0);
 //SensorML8511 ml8511(node,A0);
 //SensorACS712 acs712(node,A0);
-SensorDigitalInput digitalIn(node,6);
-SensorDigitalOutput digitalOut(node,7);
+//SensorDigitalInput digitalIn(node,6);
+//SensorDigitalOutput digitalOut(node,7);
 //SensorRelay relay(node,6);
 //SensorLatchingRelay latching(node,6);
 //SensorDHT11 dht11(node,6);
@@ -351,30 +351,20 @@ SensorDigitalOutput digitalOut(node,7);
 //DisplayHD44780 hd44780(node);
 //SensorTTP ttp(node);
 //SensorServo servo(node,6);
-//SensorAPDS9960 apsd9960(node,3);
+//SensorAPDS9960 apds9960(node,3);
 //SensorNeopixel neopixel(node,6);
 
 /***********************************
  * Main Sketch
  */
 
-void hook(Sensor* sensor) {
-  Serial.print("INPUT: ");
-  int digital_in = ((ChildInt*)sensor->children.get(1))->getValueInt();
-  Serial.println(digital_in);
-  Serial.print("OUTPUT: ");
-  Serial.println(digital_in);
-  digitalOut.setStatus(digitalOut.children.get(1),digital_in);
-}
-
 // before
 void before() {
   // setup the serial port baud rate
   Serial.begin(MY_BAUD_RATE);
   
-  uint16_t ptr = &hook;
-  digitalIn.setPostLoopFunction(ptr);
-  node.setReportIntervalSeconds(10);
+  
+  
   /*
   * Configure your sensors below
   */

--- a/NodeManagerLibrary.h
+++ b/NodeManagerLibrary.h
@@ -548,10 +548,16 @@ class Sensor {
     void setPowerManager(PowerManager& powerManager);
 #endif
 #if FEATURE_HOOKING == ON
+    // set a custom hook function to be called when the sensor executes its setup() function
+    void setSetupHook(void (*function)(Sensor* sensor));
     // set a custom hook function to be called just before the sensor executes its loop() function
-    void setPreLoopFunction(void (*function)(Sensor* sensor));
+    void setPreLoopHook(void (*function)(Sensor* sensor));
     // set a custom hook function to be called just after the sensor executes its loop() function
-    void setPostLoopFunction(void (*function)(Sensor* sensor));
+    void setPostLoopHook(void (*function)(Sensor* sensor));
+    // set a custom hook function to be called when the sensor executes its interrupt() function
+    void setInterruptHook(void (*function)(Sensor* sensor));
+    // set a custom hook function to be called when the sensor executes its receive() function
+    void setReceiveHook(void (*function)(Sensor* sensor, MyMessage* message));
 #endif
     // list of configured child
     List<Child*> children;
@@ -592,8 +598,11 @@ class Sensor {
 #endif
     Timer* _report_timer;
 #if FEATURE_HOOKING == ON
-    void (*_pre_loop_function)(Sensor* sensor);
-    void (*_post_loop_function)(Sensor* sensor);
+    void (*_setup_hook)(Sensor* sensor);
+    void (*_pre_loop_hook)(Sensor* sensor);
+    void (*_post_loop_hook)(Sensor* sensor);
+    void (*_interrupt_hook)(Sensor* sensor);
+    void (*_receive_hook)(Sensor* sensor, MyMessage* message);
 #endif
 };
 

--- a/NodeManagerLibrary.h
+++ b/NodeManagerLibrary.h
@@ -93,6 +93,9 @@
 #ifndef FEATURE_SD
   #define FEATURE_SD OFF
 #endif
+#ifndef FEATURE_HOOKING
+  #define FEATURE_HOOKING OFF
+#endif
 
 /***********************************
   Libraries
@@ -544,6 +547,12 @@ class Sensor {
     // set a previously configured PowerManager to the sensor so to powering it up with custom pins
     void setPowerManager(PowerManager& powerManager);
 #endif
+#if FEATURE_HOOKING == ON
+    // set a custom hook function to be called just before the sensor executes its loop() function
+    void setPreLoopFunction(void (*function)(Sensor* sensor));
+    // set a custom hook function to be called just after the sensor executes its loop() function
+    void setPostLoopFunction(void (*function)(Sensor* sensor));
+#endif
     // list of configured child
     List<Child*> children;
 #if FEATURE_INTERRUPTS == ON
@@ -582,6 +591,10 @@ class Sensor {
     PowerManager* _powerManager = nullptr;
 #endif
     Timer* _report_timer;
+#if FEATURE_HOOKING == ON
+    void (*_pre_loop_function)(Sensor* sensor);
+    void (*_post_loop_function)(Sensor* sensor);
+#endif
 };
 
 /*

--- a/NodeManagerLibrary.ino
+++ b/NodeManagerLibrary.ino
@@ -580,6 +580,10 @@ void Sensor::before() {
 // call the sensor-specific implementation of setup
 void Sensor::setup() {
   onSetup();
+#if FEATURE_HOOKING == ON
+  // if a hook function is defined, call it
+  if (_setup_hook != 0) _setup_hook(this); 
+#endif
 }
 
 // call the sensor-specific implementation of loop
@@ -597,7 +601,7 @@ void Sensor::loop(MyMessage* message) {
   }
 #if FEATURE_HOOKING == ON
   // if a hook function is defined, call it
-  if (_pre_loop_function != 0) _pre_loop_function(this); 
+  if (_pre_loop_hook != 0) _pre_loop_hook(this); 
 #endif
   // turn the sensor on
 #if FEATURE_POWER_MANAGER == ON
@@ -634,7 +638,7 @@ void Sensor::loop(MyMessage* message) {
   }
 #if FEATURE_HOOKING == ON
   // if a hook function is defined, call it
-  if (_post_loop_function != 0) _post_loop_function(this); 
+  if (_post_loop_hook != 0) _post_loop_hook(this); 
 #endif
   // turn the sensor off
 #if FEATURE_POWER_MANAGER == ON
@@ -649,6 +653,10 @@ void Sensor::loop(MyMessage* message) {
 void Sensor::interrupt() {
   // call the implementation of onInterrupt()
   onInterrupt();
+#if FEATURE_HOOKING == ON
+  // if a hook function is defined, call it
+  if (_interrupt_hook != 0) _interrupt_hook(this); 
+#endif
 }
 #endif
 
@@ -657,6 +665,10 @@ void Sensor::interrupt() {
 void Sensor::receive(MyMessage* message) {
   // a request would make the sensor executing its main task passing along the message
   loop(message);
+#if FEATURE_HOOKING == ON
+  // if a hook function is defined, call it
+  if (_receive_hook != 0) _receive_hook(this,message); 
+#endif
 }
 #endif
 
@@ -675,11 +687,20 @@ void Sensor::setPowerManager(PowerManager& powerManager) {
 }
 #endif
 #if FEATURE_HOOKING == ON
-void Sensor::setPreLoopFunction(void (*function)(Sensor* sensor)) {
-  _pre_loop_function = function;
+void Sensor::setSetupHook(void (*function)(Sensor* sensor)) {
+  _setup_hook = function;
 }
-void Sensor::setPostLoopFunction(void (*function)(Sensor* sensor)) {
-  _post_loop_function = function;
+void Sensor::setPreLoopHook(void (*function)(Sensor* sensor)) {
+  _pre_loop_hook = function;
+}
+void Sensor::setPostLoopHook(void (*function)(Sensor* sensor)) {
+  _post_loop_hook = function;
+}
+void Sensor::setInterruptHook(void (*function)(Sensor* sensor)) {
+  _interrupt_hook = function;
+}
+void Sensor::setReceiveHook(void (*function)(Sensor* sensor, MyMessage* message)) {
+  _receive_hook = function;
 }
 #endif
 

--- a/NodeManagerLibrary.ino
+++ b/NodeManagerLibrary.ino
@@ -595,6 +595,10 @@ void Sensor::loop(MyMessage* message) {
       if (! _report_timer->isOver() && ! first_run) return;
     }
   }
+#if FEATURE_HOOKING == ON
+  // if a hook function is defined, call it
+  if (_pre_loop_function != 0) _pre_loop_function(this); 
+#endif
   // turn the sensor on
 #if FEATURE_POWER_MANAGER == ON
   powerOn();
@@ -628,6 +632,10 @@ void Sensor::loop(MyMessage* message) {
 #endif
         child->sendValue();
   }
+#if FEATURE_HOOKING == ON
+  // if a hook function is defined, call it
+  if (_post_loop_function != 0) _post_loop_function(this); 
+#endif
   // turn the sensor off
 #if FEATURE_POWER_MANAGER == ON
   powerOff();
@@ -664,6 +672,14 @@ Child* Sensor::getChild(int child_id) {
 #if FEATURE_POWER_MANAGER == ON
 void Sensor::setPowerManager(PowerManager& powerManager) {
   _powerManager = &powerManager;
+}
+#endif
+#if FEATURE_HOOKING == ON
+void Sensor::setPreLoopFunction(void (*function)(Sensor* sensor)) {
+  _pre_loop_function = function;
+}
+void Sensor::setPostLoopFunction(void (*function)(Sensor* sensor)) {
+  _post_loop_function = function;
 }
 #endif
 

--- a/README.md
+++ b/README.md
@@ -1,15 +1,13 @@
-NodeManager is intended to take care on your behalf of all those common tasks a MySensors node has to accomplish, speeding up the development cycle of your projects.
-
-NodeManager will help you with the following:
-
-* Sleep manager: allows managing automatically the complexity behind battery-powered sensors spending most of their time sleeping
-* Power manager: allows powering on your sensors only while the node is awake
-* Battery manager: provides common functionalities to read and report the battery level
-* Remote configuration: allows configuring remotely the node without the need to have physical access to it
-* Built-in sensors: for the most common sensors, provide embedded code so to allow their configuration with a single line
+NodeManager is intended to take care on your behalf of all those common tasks that a MySensors node has to accomplish, speeding up the development cycle of your projects. 
+Consider it as a sort of frontend for your MySensors projects. When you need to add a sensor (which requires just uncommeting a single line),
+NodeManager will take care of importing the required library, presenting the sensor to the gateway/controller, executing periodically the main function of the sensor 
+(e.g. measure a temperature, detect a motion, etc.), allowing you to interact with the sensor and even configuring it remotely.
 
 ## Features
 
+* Allows managing automatically the complexity behind battery-powered sensors spending most of their time sleeping
+* Provides common functionalities to read and report the battery level
+* For the most common sensors, provide embedded code so to allow their configuration with a single line
 * Manage all the aspects of a sleeping cycle by leveraging smart sleep
 * Allow configuring the node and any attached sensors remotely
 * Allow waking up a sleeping node remotely at the end of a sleeping cycle
@@ -17,8 +15,6 @@ NodeManager will help you with the following:
 * Report battery level periodically and automatically or on demand
 * Calculate battery level without requiring an additional pin and the resistors
 * Report signal level periodically and automatically or on demand
-* Allow rebooting the board remotely
-* Provide out-of-the-box sensors personalities and automatically execute their main task at each cycle
 * Allow collecting and averaging multiple samples, tracking the last value and forcing periodic updates for any sensor
 * Provide buil-in capabilities to handle interrupt-based sensors 
 
@@ -106,7 +102,8 @@ FEATURE_SLEEP               | ON      | allow managing automatically the complex
 FEATURE_RECEIVE             | ON      | allow the node to receive messages; can be used by the remote API or for triggering the sensors  | - 
 FEATURE_TIME                | OFF     | allow keeping the current system time in sync with the controller                                | https://github.com/PaulStoffregen/Time
 FEATURE_RTC                 | OFF     | allow keeping the current system time in sync with an attached RTC device (requires FEATURE_TIME)| https://github.com/JChristensen/DS3232RTC
-FEATURE_SD                  | OFF     | allow reading from and writing to SD cards                                                   | -
+FEATURE_SD                  | OFF     | allow reading from and writing to SD cards                                                       | -
+FEATURE_HOOKING             | OFF     | allow custom code to be hooked in the out of the box sensors                                     | -
 
 ## Installation
 
@@ -384,6 +381,18 @@ The following methods are available for all the sensors:
     List<Child*> children;
 #if FEATURE_INTERRUPTS == ON
     void interrupt();
+#endif
+#if FEATURE_HOOKING == ON
+    // set a custom hook function to be called when the sensor executes its setup() function
+    void setSetupHook(void (*function)(Sensor* sensor));
+    // set a custom hook function to be called just before the sensor executes its loop() function
+    void setPreLoopHook(void (*function)(Sensor* sensor));
+    // set a custom hook function to be called just after the sensor executes its loop() function
+    void setPostLoopHook(void (*function)(Sensor* sensor));
+    // set a custom hook function to be called when the sensor executes its interrupt() function
+    void setInterruptHook(void (*function)(Sensor* sensor));
+    // set a custom hook function to be called when the sensor executes its receive() function
+    void setReceiveHook(void (*function)(Sensor* sensor, MyMessage* message));
 #endif
     Child* getChild(int child_id);
     // register a child
@@ -1234,13 +1243,15 @@ v1.6:
 v1.7:
 * Reviewed the entire NodeManager's architecture with children now automatically created from within each sensor
 * Optimized the code so to use the memory in a more efficient manner
-* Improved the overall user experience also with sensors' patterns in the main sketch
-* NodeManager's advanced features can be enabled/disabled by setting the corresponding FEATURE_* define
+* Improved the overall user experience, also with sensors' patterns in the main sketch
 * Sensors can now be enabled by uncommenting the corresponding USE_* define and requiring a single line to be created and initialized
+* NodeManager's advanced features can be enabled/disabled by setting the corresponding FEATURE_* define
 * Simplified the configuration of each sensor, now without the need of getting the sensor back through a nasty casting
 * Merged config.h into the main sketch so to centralize the configuration in a single place
 * Added time-aware capability, with or without an attached RTC
-* SensorBattery, SensorSignal and SensorConfiguration are now regular sensors
+* Intra-sensor communication now possible with the possibility for the user to nicely hook into the sensor's code
+* Batery and signal reports are now available through the regular sensors SensorBattery and SensorSignal
+* Remote API interaction for all the sensors has been moved into the regular sensor SensorConfiguration
 * Fixed bug preventing negative temperatures to be reported for all the sensors
 * Added ability for each sensor to report only when value is above or below a configured threshold
 * Addded support for SD card reader
@@ -1254,7 +1265,7 @@ v1.7:
 * Added support for HD44780 i2c LCD
 * Added support for MG996R Servo sensor
 * Added support for VL53L0X laser time-of-flight distance sensor
-* Added SensorPlantowerPMS particulate matter sensors
+* Added support for SensorPlantowerPMS particulate matter sensors
 * Added support for SHT31 temperature and humidity sensor
 * Added support for SI7021 temperature and humidity sensor
 * Added support for for Neopixel LED

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ SensorDHT11         | 2     | USE_DHT            | DHT11 sensor, return temperat
 SensorDHT22         | 2     | USE_DHT            | DHT22 sensor, return temperature/humidity based on the attached DHT sensor                        | https://github.com/mysensors/MySensorsArduinoExamples/tree/master/libraries/DHT
 SensorSHT21         | 2     | USE_SHT21          | SHT21 sensor, return temperature/humidity based on the attached SHT21 sensor                      | https://github.com/SodaqMoja/Sodaq_SHT2x
 SensorHTU21D        | 2     | USE_SHT21          | HTU21D sensor, return temperature/humidity based on the attached HTU21D sensor                    | https://github.com/SodaqMoja/Sodaq_SHT2x
-SensorInterrupt     | 1     | USE_INTERRUPT      | Generic interrupt-based sensor, wake up the board when a pin changes status                                       | -
+SensorInterrupt     | 1     | USE_INTERRUPT      | Generic interrupt-based sensor, wake up the board when a pin changes status                       | -
 SensorDoor          | 1     | USE_INTERRUPT      | Door sensor, wake up the board and report when an attached magnetic sensor has been opened/closed | -
 SensorMotion        | 1     | USE_INTERRUPT      | Motion sensor, wake up the board and report when an attached PIR has triggered                    | -
 SensorDs18b20       | 1+    | USE_DS18B20        | DS18B20 sensor, return the temperature based on the attached sensor                               | https://github.com/milesburton/Arduino-Temperature-Control-Library


### PR DESCRIPTION
This PR is to enable users to hook with custom code into the out of the box sensors and ultimately allow inter-sensor communication without the need to involve the controller (fixes #307):
* Added FEATURE_HOOKING, OFF by default
* Added setSetupHook(), setPreLoopFunction(), setPostLoopFunction(), setInterruptHook(), setReceiveHook() to the Sensor class
* The provided function must have the following constructor: `void function(Sensor* sensor)` (setReceiveHook() must have `void function(Sensor* sensor, MyMessage* message)`) so the user will have a direct reference to the sensor from within its custom code. Of course public only functions and variables will be accessible

Example:
```c
// set the digital output of a pin, equals to the digital input of another pin
void hook(Sensor* sensor) {
  Serial.print("INPUT: ");
  int digital_in = ((ChildInt*)sensor->children.get(1))->getValueInt();
  Serial.println(digital_in);
  Serial.print("OUTPUT: ");
  Serial.println(digital_in);
  digitalOut.setStatus(digitalOut.children.get(1),digital_in);
}

// before
void before() {
  // setup the serial port baud rate
  Serial.begin(MY_BAUD_RATE);
  
  digitalIn.setPostLoopFunction(&hook);
  node.setReportIntervalSeconds(10);
}
```

Another option to implement this kind of communication would be by extending an existing class (see #310)