### PR TITLE
Fix compilation errors for non-AVR chips

### DIFF
--- a/NodeManager.ino
+++ b/NodeManager.ino
@@ -20,21 +20,27 @@
 
  DESCRIPTION
 
-NodeManager is intended to take care on your behalf of all those common tasks that a MySensors node has to accomplish, speeding up the development cycle of your projects. 
-Consider it as a sort of frontend for your MySensors projects. When you need to add a sensor (which requires just uncommeting a single line),
-NodeManager will take care of importing the required library, presenting the sensor to the gateway/controller, executing periodically the main function of the sensor 
-(e.g. measure a temperature, detect a motion, etc.), allowing you to interact with the sensor and even configuring it remotely.
+NodeManager is intended to take care on your behalf of all those common tasks that a 
+MySensors node has to accomplish, speeding up the development cycle of your projects. 
+Consider it as a sort of frontend for your MySensors projects. When you need to add 
+a sensor (which requires just uncommeting a single line),
+NodeManager will take care of importing the required library, presenting the sensor 
+to the gateway/controller, executing periodically the main function of the sensor 
+(e.g. measure a temperature, detect a motion, etc.), allowing you to interact with 
+the sensor and even configuring it remotely.
 
 Documentation available on: https://github.com/mysensors/NodeManager
-NodeManager provides built-in implementation of a number of sensors through ad-hoc classes. 
+NodeManager provides built-in implementation of a number of sensors through ad-hoc 
+classes. 
 
 To use a buil-in sensor:
 * Install the required library if any
 * Enable the corresponding module (uncomment it) in the main sketch
 * Declare the sensor (uncomment it) in the main sketch
 
-Once created, the sensor will automatically present one or more child to the gateway and controller.
-A list of buil-in sensors, module to enable, required dependencies and the number of child automatically created is presented below:
+Once created, the sensor will automatically present one or more child to the gateway 
+and controller. A list of buil-in sensors, module to enable, required dependencies 
+and the number of child automatically created is presented below:
 
 Sensor Name         |#Child | Module to enable   | Description                                                                                       | Dependencies
 --------------------|-------|--------------------|---------------------------------------------------------------------------------------------------|----------------------------------------------------------
@@ -89,10 +95,11 @@ SensorServo         | 1     | USE_SERVO          | Control a generic Servo motor
 SensorAPDS9960      | 1     | USE_APDS9960       | SparkFun RGB and Gesture Sensor                                                                   | https://github.com/sparkfun/APDS-9960_RGB_and_Gesture_Sensor
 SensorNeopixel      | 1     | USE_NEOPIXEL       | Control a Neopixel LED                                                                            | https://github.com/adafruit/Adafruit_NeoPixel
 
-NodeManager provides useful built-in features which can be disabled if you need to save some storage for your code. 
-To enable/disable a buil-in feature:
+NodeManager provides useful built-in features which can be disabled if you need 
+to save some storage for your code. To enable/disable a buil-in feature:
 * Install the required library if any
-* Enable the corresponding feature by setting it to ON in the main sketch. To disable it, set it to OFF
+* Enable the corresponding feature by setting it to ON in the main sketch. To 
+disable it, set it to OFF
 
 A list of buil-in features and the required dependencies is presented below:
 

--- a/NodeManager.ino
+++ b/NodeManager.ino
@@ -39,7 +39,7 @@ A list of buil-in sensors, module to enable, required dependencies and the numbe
 Sensor Name         |#Child | Module to enable   | Description                                                                                       | Dependencies
 --------------------|-------|--------------------|---------------------------------------------------------------------------------------------------|----------------------------------------------------------
 SensorBattery       | 1     | -                  | Built-in sensor for automatic battery reporting                                                   | - 
-SensorSignal        | 1     | -                  | Built-in sensor for automatic signal level reporting                                              | -
+SensorSignal        | 1     | USE_SIGNAL         | Built-in sensor for automatic signal level reporting                                              | -
 SensorConfiguration | 1     | -                  | Built-in sensor for OTA remote configuration of any registered sensor                             | -
 SensorAnalogInput   | 1     | USE_ANALOG_INPUT   | Generic analog sensor, return a pin's analog value or its percentage                              | -
 SensorLDR           | 1     | USE_ANALOG_INPUT   | LDR sensor, return the light level of an attached light resistor in percentage                    | -
@@ -236,6 +236,7 @@ FEATURE_HOOKING             | OFF     | allow custom code to be hooked in the ou
  * NodeManager modules for supported sensors
  */
 
+#define USE_SIGNAL
 //#define USE_ANALOG_INPUT
 //#define USE_THERMISTOR
 //#define USE_ML8511
@@ -304,7 +305,7 @@ NodeManager node;
 // built-in sensors
 //SensorBattery battery(node);
 //SensorConfiguration configuration(node);
-//SensorSignal signal(node);
+SensorSignal signal(node);
 //PowerManager power(5,6);
 
 // Attached sensors

--- a/NodeManager.ino
+++ b/NodeManager.ino
@@ -38,9 +38,9 @@ A list of buil-in sensors, module to enable, required dependencies and the numbe
 
 Sensor Name         |#Child | Module to enable   | Description                                                                                       | Dependencies
 --------------------|-------|--------------------|---------------------------------------------------------------------------------------------------|----------------------------------------------------------
-SensorBattery       | 1     | -                  | Built-in sensor for automatic battery reporting                                                   | - 
+SensorBattery       | 1     | USE_BATTERY        | Built-in sensor for automatic battery reporting                                                   | - 
 SensorSignal        | 1     | USE_SIGNAL         | Built-in sensor for automatic signal level reporting                                              | -
-SensorConfiguration | 1     | -                  | Built-in sensor for OTA remote configuration of any registered sensor                             | -
+SensorConfiguration | 1     | USE_CONFIGURATION  | Built-in sensor for OTA remote configuration of any registered sensor                             | -
 SensorAnalogInput   | 1     | USE_ANALOG_INPUT   | Generic analog sensor, return a pin's analog value or its percentage                              | -
 SensorLDR           | 1     | USE_ANALOG_INPUT   | LDR sensor, return the light level of an attached light resistor in percentage                    | -
 SensorRain          | 1     | USE_ANALOG_INPUT   | Rain sensor, return the percentage of rain from an attached analog sensor                         | -
@@ -236,7 +236,9 @@ FEATURE_HOOKING             | OFF     | allow custom code to be hooked in the ou
  * NodeManager modules for supported sensors
  */
 
-#define USE_SIGNAL
+//#define USE_BATTERY
+//#define USE_SIGNAL
+//#define USE_CONFIGURATION
 //#define USE_ANALOG_INPUT
 //#define USE_THERMISTOR
 //#define USE_ML8511
@@ -305,7 +307,7 @@ NodeManager node;
 // built-in sensors
 //SensorBattery battery(node);
 //SensorConfiguration configuration(node);
-SensorSignal signal(node);
+//SensorSignal signal(node);
 //PowerManager power(5,6);
 
 // Attached sensors

--- a/NodeManagerLibrary.h
+++ b/NodeManagerLibrary.h
@@ -636,6 +636,7 @@ class Sensor {
 #endif
 };
 
+#ifdef USE_BATTERY
 /*
    SensorBattery: report battery level
 */
@@ -663,6 +664,7 @@ class SensorBattery: public Sensor {
       int _battery_pin = -1;
       float _battery_volts_per_bit = 0.003363075;
 };
+#endif
 
 #ifdef USE_SIGNAL
 /*
@@ -681,6 +683,7 @@ class SensorSignal: public Sensor {
 };
 #endif
 
+#ifdef USE_CONFIGURATION
 /*
    SensorConfiguration: allow remote configuration of the board and any configured sensor
 */
@@ -694,6 +697,7 @@ class SensorConfiguration: public Sensor {
     void onReceive(MyMessage* message);
   protected:
 };
+#endif
 
 #ifdef USE_ANALOG_INPUT
 /*

--- a/NodeManagerLibrary.h
+++ b/NodeManagerLibrary.h
@@ -55,9 +55,9 @@
   #define CHIP_STM32
 #endif
 #if defined(ESP8266) || defined(MY_GATEWAY_ESP8266)
-  #define CHIP_ESP
+  #define CHIP_ESP8266
 #endif
-#if !defined(CHIP_ESP) && !defined(CHIP_STM32)
+#if !defined(CHIP_ESP8266) && !defined(CHIP_STM32)
   #define CHIP_AVR
 #endif
 
@@ -128,13 +128,16 @@
 #ifdef MY_USE_UDP
     #include <WiFiUdp.h>
 #endif
-#ifdef MY_GATEWAY_ESP8266
+#ifdef CHIP_ESP8266
   #include <ESP8266WiFi.h>
 #endif
 // load MySensors library
 #include <MySensors.h>
 
 // include third party libraries
+#ifdef USE_SIGNAL
+  #define MY_SIGNAL_REPORT_ENABLED
+#endif
 #ifdef USE_DHT
   #include <DHT.h>
 #endif
@@ -661,7 +664,7 @@ class SensorBattery: public Sensor {
       float _battery_volts_per_bit = 0.003363075;
 };
 
-#ifdef MY_SIGNAL_REPORT_ENABLED
+#ifdef USE_SIGNAL
 /*
    SensorSignal: report RSSI signal strength from the radio
 */

--- a/NodeManagerLibrary.h
+++ b/NodeManagerLibrary.h
@@ -39,6 +39,29 @@
 #define EEPROM_USER_START 100
 
 /***********************************
+   Chip type
+*/
+// 168 and 328 Arduinos
+#if defined (__AVR_ATtiny24__) || defined(__AVR_ATtiny44__) || defined(__AVR_ATtiny84__)
+  #define CHIP_TINYX4
+#endif
+#if defined (__AVR_ATtiny25__) || defined(__AVR_ATtiny45__) || defined(__AVR_ATtiny85__)
+  #define CHIP_TINYX5
+#endif
+#if defined(__AVR_ATmega32U4__) || defined(__AVR_ATmega1280__) || defined(__AVR_ATmega2560__)
+  #define CHIP_MEGA
+#endif
+#if defined(ARDUINO_ARCH_STM32F0) || defined(ARDUINO_ARCH_STM32F1) || defined(ARDUINO_ARCH_STM32F3) || defined(ARDUINO_ARCH_STM32F4) || defined(ARDUINO_ARCH_STM32L4)
+  #define CHIP_STM32
+#endif
+#if defined(ESP8266) || defined(MY_GATEWAY_ESP8266)
+  #define CHIP_ESP
+#endif
+#if !defined(CHIP_ESP) && !defined(CHIP_STM32)
+  #define CHIP_AVR
+#endif
+
+/***********************************
    Default configuration settings
 */
 // define default sketch name and version

--- a/NodeManagerLibrary.ino
+++ b/NodeManagerLibrary.ino
@@ -4643,7 +4643,7 @@ void NodeManager::receive(const MyMessage &message) {
       powerOn();
     #endif
     // call the sensor's receive()
-    sensor->receive(&message);
+    sensor->receive((MyMessage*) &message);
     // turn off the pin powering all the sensors
     #if FEATURE_POWER_MANAGER == ON
       powerOff();

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+# NodeManager
+
 NodeManager is intended to take care on your behalf of all those common tasks that a MySensors node has to accomplish, speeding up the development cycle of your projects. 
 Consider it as a sort of frontend for your MySensors projects. When you need to add a sensor (which requires just uncommeting a single line),
 NodeManager will take care of importing the required library, presenting the sensor to the gateway/controller, executing periodically the main function of the sensor 

--- a/README.md
+++ b/README.md
@@ -31,9 +31,9 @@ A list of buil-in sensors, module to enable, required dependencies and the numbe
 
 Sensor Name         |#Child | Module to enable   | Description                                                                                       | Dependencies
 --------------------|-------|--------------------|---------------------------------------------------------------------------------------------------|----------------------------------------------------------
-SensorBattery       | 1     | -                  | Built-in sensor for automatic battery reporting                                                   | - 
-SensorSignal        | 1     | -                  | Built-in sensor for automatic signal level reporting                                              | -
-SensorConfiguration | 1     | -                  | Built-in sensor for OTA remote configuration of any registered sensor                             | -
+SensorBattery       | 1     | USE_BATTERY        | Built-in sensor for automatic battery reporting                                                   | - 
+SensorSignal        | 1     | USE_SIGNAL         | Built-in sensor for automatic signal level reporting                                              | -
+SensorConfiguration | 1     | USE_CONFIGURATION  | Built-in sensor for OTA remote configuration of any registered sensor                             | -
 SensorAnalogInput   | 1     | USE_ANALOG_INPUT   | Generic analog sensor, return a pin's analog value or its percentage                              | -
 SensorLDR           | 1     | USE_ANALOG_INPUT   | LDR sensor, return the light level of an attached light resistor in percentage                    | -
 SensorRain          | 1     | USE_ANALOG_INPUT   | Rain sensor, return the percentage of rain from an attached analog sensor                         | -


### PR DESCRIPTION
This PR fixes compilation issues with some platforms:
* Added global CHIP_TINYX4, CHIP_TINYX5, CHIP_MEGA, CHIP_STM32, CHIP_ESP, CHIP_AVR defines
* Added USE_SIGNAL which enables MY_SIGNAL_REPORT_ENABLED and SensorSignal
* Added USE_BATTERY which enables SensorBattery
* Added USE_CONFIGURATION which enables SensorConfiguration
* Fixed compilation errors (fixes #300)