### PR TITLE
Add support for buzzer

### DIFF
--- a/NodeManager.ino
+++ b/NodeManager.ino
@@ -318,7 +318,7 @@ NodeManager node;
 //SensorDigitalInput digitalIn(node,6);
 SensorDigitalOutput digitalOut(node,6);
 //SensorRelay relay(node,6);
-//SensorLatchingRelay latching(node,6);
+SensorLatchingRelay latching(node,6);
 //SensorDHT11 dht11(node,6);
 //SensorDHT22 dht22(node,6);
 //SensorSHT21 sht21(node);

--- a/NodeManager.ino
+++ b/NodeManager.ino
@@ -241,7 +241,7 @@ FEATURE_HOOKING             | OFF     | allow custom code to be hooked in the ou
 //#define USE_ML8511
 //#define USE_ACS712
 //#define USE_DIGITAL_INPUT
-#define USE_DIGITAL_OUTPUT
+//#define USE_DIGITAL_OUTPUT
 //#define USE_DHT
 //#define USE_SHT21
 //#define USE_INTERRUPT
@@ -316,9 +316,9 @@ NodeManager node;
 //SensorML8511 ml8511(node,A0);
 //SensorACS712 acs712(node,A0);
 //SensorDigitalInput digitalIn(node,6);
-SensorDigitalOutput digitalOut(node,6);
+//SensorDigitalOutput digitalOut(node,6);
 //SensorRelay relay(node,6);
-SensorLatchingRelay latching(node,6);
+//SensorLatchingRelay latching(node,6);
 //SensorDHT11 dht11(node,6);
 //SensorDHT22 dht22(node,6);
 //SensorSHT21 sht21(node);
@@ -366,7 +366,7 @@ void before() {
   Serial.begin(MY_BAUD_RATE);
   
   
-  
+    
   /*
   * Configure your sensors below
   */

--- a/NodeManager.ino
+++ b/NodeManager.ino
@@ -241,7 +241,7 @@ FEATURE_HOOKING             | OFF     | allow custom code to be hooked in the ou
 //#define USE_ML8511
 //#define USE_ACS712
 //#define USE_DIGITAL_INPUT
-//#define USE_DIGITAL_OUTPUT
+#define USE_DIGITAL_OUTPUT
 //#define USE_DHT
 //#define USE_SHT21
 //#define USE_INTERRUPT
@@ -316,7 +316,7 @@ NodeManager node;
 //SensorML8511 ml8511(node,A0);
 //SensorACS712 acs712(node,A0);
 //SensorDigitalInput digitalIn(node,6);
-//SensorDigitalOutput digitalOut(node,6);
+SensorDigitalOutput digitalOut(node,6);
 //SensorRelay relay(node,6);
 //SensorLatchingRelay latching(node,6);
 //SensorDHT11 dht11(node,6);

--- a/NodeManagerLibrary.h
+++ b/NodeManagerLibrary.h
@@ -831,8 +831,8 @@ class SensorDigitalOutput: public Sensor {
     void setInputIsElapsed(bool value);
     // [107] optionally wait for the given number of milliseconds after changing the status (default: 0)
     void setWaitAfterSet(int value);
-    // [108] when switching on, turns the output off after the given number of seconds (default: 0)
-    void setOnDuration(int value);
+    // [108] when switching on, turns the output off after the given number of milliseconds. For latching relay controls the pulse width (default: 0)
+    void setPulseWidth(int value);
     // manually switch the output to the provided value
     void setStatus(int value);
     // get the current state
@@ -846,7 +846,7 @@ class SensorDigitalOutput: public Sensor {
     bool _legacy_mode = false;
     bool _input_is_elapsed = false;
     int _wait_after_set = 0;
-    int _on_duration = 0;
+    int _pulse_width = 0;
     Timer* _safeguard_timer;
     void _setupPin(Child* child, int pin);
     virtual void _setStatus(int value);
@@ -867,8 +867,6 @@ class SensorRelay: public SensorDigitalOutput {
 class SensorLatchingRelay: public SensorRelay {
   public:
     SensorLatchingRelay(NodeManager& node_manager, int pin, int child_id = -255);
-    // [201] set the duration of the pulse to send in ms to activate the relay (default: 50)
-    void setPulseWidth(int value);
     // [202] set the pin which turns the relay off (default: the pin provided while registering the sensor)
     void setPinOff(int value);
     // [203] set the pin which turns the relay on (default: the pin provided while registering the sensor + 1)
@@ -878,7 +876,6 @@ class SensorLatchingRelay: public SensorRelay {
   protected:
     int _pin_on;
     int _pin_off;
-    int _pulse_width = 50;
     void _setStatus(int value);
 };
 #endif

--- a/NodeManagerLibrary.h
+++ b/NodeManagerLibrary.h
@@ -831,8 +831,10 @@ class SensorDigitalOutput: public Sensor {
     void setInputIsElapsed(bool value);
     // [107] optionally wait for the given number of milliseconds after changing the status (default: 0)
     void setWaitAfterSet(int value);
+    // [108] when switching on, turns the output off after the given number of seconds (default: 0)
+    void setOnDuration(int value);
     // manually switch the output to the provided value
-    void setStatus(Child* child, int value);
+    void setStatus(int value);
     // get the current state
     int getStatus();
     void onSetup();
@@ -844,9 +846,10 @@ class SensorDigitalOutput: public Sensor {
     bool _legacy_mode = false;
     bool _input_is_elapsed = false;
     int _wait_after_set = 0;
+    int _on_duration = 0;
     Timer* _safeguard_timer;
     void _setupPin(Child* child, int pin);
-    virtual void _setStatus(Child* child, int value);
+    virtual void _setStatus(int value);
     int _getValueToWrite(int value);
 };
 
@@ -876,7 +879,7 @@ class SensorLatchingRelay: public SensorRelay {
     int _pin_on;
     int _pin_off;
     int _pulse_width = 50;
-    void _setStatus(Child* child, int value);
+    void _setStatus(int value);
 };
 #endif
 

--- a/NodeManagerLibrary.ino
+++ b/NodeManagerLibrary.ino
@@ -1223,6 +1223,9 @@ void SensorDigitalOutput::setInputIsElapsed(bool value) {
 void SensorDigitalOutput::setWaitAfterSet(int value) {
   _wait_after_set = value;
 }
+void SensorDigitalOutput::setOnDuration(int value) {
+  _on_duration = value*1000;
+}
 
 // main task
 void SensorDigitalOutput::onLoop(Child* child) {
@@ -1231,7 +1234,7 @@ void SensorDigitalOutput::onLoop(Child* child) {
     // update the timer
     _safeguard_timer->update();
     // if the time is over, turn the output off
-    if (_safeguard_timer->isOver()) setStatus(child,OFF);
+    if (_safeguard_timer->isOver()) setStatus(OFF);
   }
 }
 
@@ -1242,7 +1245,7 @@ void SensorDigitalOutput::onReceive(MyMessage* message) {
   // by default handle a SET message but when legacy mode is set when a REQ message is expected instead
   if ( (message->getCommand() == C_SET && ! _legacy_mode) || (message->getCommand() == C_REQ && _legacy_mode)) {
     // switch the output
-    setStatus(child, message->getInt());
+    setStatus(message->getInt());
   }
   if (message->getCommand() == C_REQ && ! _legacy_mode) {
     // just return the current status
@@ -1251,7 +1254,7 @@ void SensorDigitalOutput::onReceive(MyMessage* message) {
 }
 
 // write the value to the output
-void SensorDigitalOutput::setStatus(Child* child, int value) {
+void SensorDigitalOutput::setStatus(int value) {
   // pre-process the input value
   if (_input_is_elapsed) {
     // the input provided is an elapsed time
@@ -1269,12 +1272,12 @@ void SensorDigitalOutput::setStatus(Child* child, int value) {
     // if turning the output on and a safeguard timer is configured, start it
     if (value == ON && _safeguard_timer->isConfigured() && ! _safeguard_timer->isRunning()) _safeguard_timer->start();
   }
-  _setStatus(child, value);
+  _setStatus(value);
   // wait if needed for relay drawing a lot of current
   if (_wait_after_set > 0) _node->sleepOrWait(_wait_after_set);
   // store the new status so it will be sent to the controller
   _status = value;
-  ((ChildInt*)child)->setValueInt(value);
+  ((ChildInt*)children.get(1))->setValueInt(value);
 }
 
 // setup the provided pin for output
@@ -1289,14 +1292,14 @@ void SensorDigitalOutput::_setupPin(Child* child, int pin) {
 }
 
 // switch to the requested status
-void SensorDigitalOutput::_setStatus(Child* child, int value) {
+void SensorDigitalOutput::_setStatus(int value) {
   int value_to_write = _getValueToWrite(value);
   // set the value to the pin
   digitalWrite(_pin, value_to_write);
   #if FEATURE_DEBUG == ON
     Serial.print(_name);
     Serial.print(F(" I="));
-    Serial.print(child->child_id);
+    Serial.print(children.get(1)->child_id);
     Serial.print(F(" P="));
     Serial.print(_pin);
     Serial.print(F(" V="));
@@ -1358,7 +1361,7 @@ void SensorLatchingRelay::onSetup() {
 }
 
 // switch to the requested status
-void SensorLatchingRelay::_setStatus(Child* child, int value) {
+void SensorLatchingRelay::_setStatus(int value) {
   // select the right pin to send the pulse to
   int pin = value == OFF ? _pin_off : _pin_on;
   // set the value
@@ -1367,8 +1370,9 @@ void SensorLatchingRelay::_setStatus(Child* child, int value) {
   _node->sleepOrWait(_pulse_width);
   digitalWrite(pin, ! _on_value);
   #if FEATURE_DEBUG == ON
-    Serial.print(F("LAT I="));
-    Serial.print(child->child_id);
+    Serial.print(_name);
+    Serial.print(F(" I="));
+    Serial.print(children.get(1)->child_id);
     Serial.print(F(" P="));
     Serial.print(pin);
     Serial.print(F(" S="));

--- a/README.md
+++ b/README.md
@@ -491,12 +491,12 @@ Each sensor class exposes additional methods.
     void setInputIsElapsed(bool value);
     // [107] optionally wait for the given number of milliseconds after changing the status (default: 0)
     void setWaitAfterSet(int value);
+    // [108] when switching on, turns the output off after the given number of milliseconds. For latching relay controls the pulse width (default: 0)
+    void setPulseWidth(int value);
 ~~~
 
 * SensorLatchingRelay (in addition to those available for SensorDigitalOutput / SensorRelay)
 ~~~c
-    // [201] set the duration of the pulse to send in ms to activate the relay (default: 50)
-    void setPulseWidth(int value);
     // [202] set the pin which turns the relay off (default: the pin provided while registering the sensor)
     void setPinOff(int value);
     // [203] set the pin which turns the relay on (default: the pin provided while registering the sensor + 1)


### PR DESCRIPTION
This PR introduces some optimizations to support an active buzzer:
* Wire the buzzer and connected it to a digital pin;
* The buzzer can be added to NodeManager by using the SensorRelay class;
* The buzzer can be controller either remotely through the S_BINARY child or by invoking setStatus() from within a hooking function (for linking e.g. a motion sensor with the buzzer)
* Once on, the buzzer can be turned off manually, using setSafeguard() (if you want the buzzer off after some minutes) or with setPulseWidth() (if you want the buzzer to briefly turn on), moved from SensorLatchingRelay into SensorDigitalOutput
* `setStatus(Child* child, int value)` simplified in `setStatus(int value)`

Passive buzzer are not supported at this time