### PR TITLE
Minor fixes to SensorInterrupt and SensorDigitalOutput

### DIFF
--- a/NodeManager.ino
+++ b/NodeManager.ino
@@ -241,10 +241,10 @@ FEATURE_HOOKING             | OFF     | allow custom code to be hooked in the ou
 //#define USE_ML8511
 //#define USE_ACS712
 //#define USE_DIGITAL_INPUT
-//#define USE_DIGITAL_OUTPUT
+#define USE_DIGITAL_OUTPUT
 //#define USE_DHT
 //#define USE_SHT21
-//#define USE_INTERRUPT
+#define USE_INTERRUPT
 //#define USE_DS18B20
 //#define USE_BH1750
 //#define USE_MLX90614
@@ -288,7 +288,7 @@ FEATURE_HOOKING             | OFF     | allow custom code to be hooked in the ou
 #define FEATURE_TIME OFF
 #define FEATURE_RTC OFF
 #define FEATURE_SD OFF
-#define FEATURE_HOOKING OFF
+#define FEATURE_HOOKING ON
 
 /***********************************
  * Load NodeManager Library
@@ -317,7 +317,7 @@ NodeManager node;
 //SensorACS712 acs712(node,A0);
 //SensorDigitalInput digitalIn(node,6);
 //SensorDigitalOutput digitalOut(node,6);
-//SensorRelay relay(node,6);
+SensorRelay relay(node,6);
 //SensorLatchingRelay latching(node,6);
 //SensorDHT11 dht11(node,6);
 //SensorDHT22 dht22(node,6);
@@ -360,11 +360,17 @@ NodeManager node;
  * Main Sketch
  */
 
+SensorInterrupt button(node,3);
+void toggleRelay(Sensor* sensor) {
+  relay.toggleStatus();
+}
 // before
 void before() {
   // setup the serial port baud rate
   Serial.begin(MY_BAUD_RATE);
-  
+  button.setInterruptHook(&toggleRelay);
+  button.setInitial(HIGH);
+  button.setMode(FALLING);
   
     
   /*

--- a/NodeManager.ino
+++ b/NodeManager.ino
@@ -371,6 +371,7 @@ void before() {
   button.setInterruptHook(&toggleRelay);
   button.setInitial(HIGH);
   button.setMode(FALLING);
+  button.setTriggerTime(5000);
   
     
   /*

--- a/NodeManager.ino
+++ b/NodeManager.ino
@@ -241,10 +241,10 @@ FEATURE_HOOKING             | OFF     | allow custom code to be hooked in the ou
 //#define USE_ML8511
 //#define USE_ACS712
 //#define USE_DIGITAL_INPUT
-#define USE_DIGITAL_OUTPUT
+//#define USE_DIGITAL_OUTPUT
 //#define USE_DHT
 //#define USE_SHT21
-#define USE_INTERRUPT
+//#define USE_INTERRUPT
 //#define USE_DS18B20
 //#define USE_BH1750
 //#define USE_MLX90614
@@ -288,7 +288,7 @@ FEATURE_HOOKING             | OFF     | allow custom code to be hooked in the ou
 #define FEATURE_TIME OFF
 #define FEATURE_RTC OFF
 #define FEATURE_SD OFF
-#define FEATURE_HOOKING ON
+#define FEATURE_HOOKING OFF
 
 /***********************************
  * Load NodeManager Library
@@ -317,7 +317,7 @@ NodeManager node;
 //SensorACS712 acs712(node,A0);
 //SensorDigitalInput digitalIn(node,6);
 //SensorDigitalOutput digitalOut(node,6);
-SensorRelay relay(node,6);
+//SensorRelay relay(node,6);
 //SensorLatchingRelay latching(node,6);
 //SensorDHT11 dht11(node,6);
 //SensorDHT22 dht22(node,6);
@@ -360,20 +360,13 @@ SensorRelay relay(node,6);
  * Main Sketch
  */
 
-SensorInterrupt button(node,3);
-void toggleRelay(Sensor* sensor) {
-  relay.toggleStatus();
-}
 // before
 void before() {
   // setup the serial port baud rate
   Serial.begin(MY_BAUD_RATE);
-  button.setInterruptHook(&toggleRelay);
-  button.setInitial(HIGH);
-  button.setMode(FALLING);
-  node.setInterruptDebounce(1000);
-//  node.setSleepMinutes(60);
-    
+  
+
+  
   /*
   * Configure your sensors below
   */

--- a/NodeManager.ino
+++ b/NodeManager.ino
@@ -371,8 +371,8 @@ void before() {
   button.setInterruptHook(&toggleRelay);
   button.setInitial(HIGH);
   button.setMode(FALLING);
-  button.setTriggerTime(5000);
-  
+  node.setInterruptDebounce(1000);
+//  node.setSleepMinutes(60);
     
   /*
   * Configure your sensors below

--- a/NodeManagerLibrary.h
+++ b/NodeManagerLibrary.h
@@ -835,6 +835,8 @@ class SensorDigitalOutput: public Sensor {
     void setPulseWidth(int value);
     // manually switch the output to the provided value
     void setStatus(int value);
+    // toggle the status
+    void toggleStatus();
     // get the current state
     int getStatus();
     void onSetup();

--- a/NodeManagerLibrary.h
+++ b/NodeManagerLibrary.h
@@ -949,8 +949,6 @@ class SensorInterrupt: public Sensor {
     SensorInterrupt(NodeManager& node_manager, int pin, int child_id = -255);
     // [101] set the interrupt mode. Can be CHANGE, RISING, FALLING (default: CHANGE)
     void setMode(int value);
-    // [102] milliseconds to wait before reading the input (default: 0)
-    void setDebounce(int value);
     // [103] time to wait in milliseconds after a change is detected to allow the signal to be restored to its normal value (default: 0)
     void setTriggerTime(int value);
     // [104] Set initial value on the interrupt pin (default: HIGH)
@@ -969,7 +967,6 @@ class SensorInterrupt: public Sensor {
     void onReceive(MyMessage* message);
     void onInterrupt();
   protected:
-    int _debounce = 0;
     int _trigger_time = 0;
     int _mode = CHANGE;
     int _initial = HIGH;
@@ -1785,7 +1782,7 @@ class NodeManager {
     // configure the interrupt pin and mode. Mode can be CHANGE, RISING, FALLING (default: MODE_NOT_DEFINED)
     void setInterrupt(int pin, int mode, int initial = -1);
     // [28] ignore two consecutive interrupts if happening within this timeframe in milliseconds (default: 100)
-    void setInterruptMinDelta(long value);
+    void setInterruptDebounce(long value);
 #endif
     // register a sensor
     void registerSensor(Sensor* sensor);
@@ -1905,7 +1902,7 @@ class NodeManager {
     int _interrupt_2_initial = -1;
     static int _last_interrupt_pin;
     static int _last_interrupt_value;
-    static long _interrupt_min_delta;
+    static long _interrupt_debounce;
     static long _last_interrupt_1;
     static long _last_interrupt_2;
 #endif

--- a/NodeManagerLibrary.ino
+++ b/NodeManagerLibrary.ino
@@ -4593,17 +4593,6 @@ void NodeManager::setup() {
 
 // run the main function for all the register sensors
 void NodeManager::loop() {
-#if FEATURE_INTERRUPTS == ON
-  // there has been an interrupt
-  if (_last_interrupt_pin != -1) {
-    #if FEATURE_DEBUG == ON
-      Serial.print(F("INT P="));
-      Serial.print(_last_interrupt_pin);
-      Serial.print(F(", V="));
-      Serial.println(_last_interrupt_value);
-    #endif
-  }
-#endif
 #if FEATURE_TIME == ON
   // if the time was last updated more than 60 minutes ago, update it
   if (_time_is_valid && (now() - _time_last_sync) > 60*60) syncTime();
@@ -4621,7 +4610,7 @@ void NodeManager::loop() {
       _message.clear();
       sensor->interrupt();
       sensor->loop(nullptr);
-        // reset the last interrupt pin
+      // reset the last interrupt pin
       _last_interrupt_pin = -1;
     }
     else if (_last_interrupt_pin == -1) {
@@ -4895,6 +4884,12 @@ void NodeManager::_onInterrupt_1() {
     _last_interrupt_pin = INTERRUPT_PIN_1;
     _last_interrupt_value = digitalRead(INTERRUPT_PIN_1);
     _last_interrupt_1 = now;
+    #if FEATURE_DEBUG == ON
+      Serial.print(F("INT P="));
+      Serial.print(_last_interrupt_pin);
+      Serial.print(F(", V="));
+      Serial.println(_last_interrupt_value);
+    #endif
   }
 }
 void NodeManager::_onInterrupt_2() {
@@ -4905,6 +4900,12 @@ void NodeManager::_onInterrupt_2() {
     _last_interrupt_pin = INTERRUPT_PIN_2;
     _last_interrupt_value = digitalRead(INTERRUPT_PIN_2);
     _last_interrupt_2 = now;
+    #if FEATURE_DEBUG == ON
+      Serial.print(F("INT P="));
+      Serial.print(_last_interrupt_pin);
+      Serial.print(F(", V="));
+      Serial.println(_last_interrupt_value);
+    #endif
   }
 }
 #endif
@@ -5035,6 +5036,12 @@ void NodeManager::_sleep() {
     if (digitalPinToInterrupt(INTERRUPT_PIN_2) == interrupt) _last_interrupt_pin = INTERRUPT_PIN_2;
     // register the interrupt value
     _last_interrupt_value = digitalRead(_last_interrupt_pin);
+    #if FEATURE_DEBUG == ON
+      Serial.print(F("INT P="));
+      Serial.print(_last_interrupt_pin);
+      Serial.print(F(", V="));
+      Serial.println(_last_interrupt_value);
+    #endif
     // when waking up from an interrupt on the wakup pin, stop sleeping
     if (_sleep_interrupt_pin == _last_interrupt_pin) _status = AWAKE;
   }

--- a/NodeManagerLibrary.ino
+++ b/NodeManagerLibrary.ino
@@ -1278,6 +1278,13 @@ void SensorDigitalOutput::setStatus(int value) {
   // store the new status so it will be sent to the controller
   _status = value;
   ((ChildInt*)children.get(1))->setValueInt(value);
+  Serial.println(value);
+  Serial.println(((ChildInt*)children.get(1))->getValueInt());
+}
+
+// toggle the status
+void SensorDigitalOutput::toggleStatus() {
+  setStatus(!_status);
 }
 
 // setup the provided pin for output

--- a/README.md
+++ b/README.md
@@ -233,7 +233,7 @@ You can interact with each class provided by NodeManager through a set of API fu
     // configure the interrupt pin and mode. Mode can be CHANGE, RISING, FALLING (default: MODE_NOT_DEFINED)
     void setInterrupt(int pin, int mode, int initial = -1);
     // [28] ignore two consecutive interrupts if happening within this timeframe in milliseconds (default: 100)
-    void setInterruptMinDelta(long value);
+    void setInterruptDebounce(long value);
 #endif
     // register a sensor
     void registerSensor(Sensor* sensor);
@@ -511,8 +511,6 @@ Each sensor class exposes additional methods.
 ~~~c
     // [101] set the interrupt mode. Can be CHANGE, RISING, FALLING (default: CHANGE)
     void setMode(int value);
-    // [102] milliseconds to wait before reading the input (default: 0)
-    void setDebounce(int value);
     // [103] time to wait in milliseconds after a change is detected to allow the signal to be restored to its normal value (default: 0)
     void setTriggerTime(int value);
     // [104] Set initial value on the interrupt pin (default: HIGH)

--- a/README.md
+++ b/README.md
@@ -493,6 +493,10 @@ Each sensor class exposes additional methods.
     void setWaitAfterSet(int value);
     // [108] when switching on, turns the output off after the given number of milliseconds. For latching relay controls the pulse width (default: 0)
     void setPulseWidth(int value);
+    // manually switch the output to the provided value
+    void setStatus(int value);
+    // toggle the status
+    void toggleStatus(int value);
 ~~~
 
 * SensorLatchingRelay (in addition to those available for SensorDigitalOutput / SensorRelay)


### PR DESCRIPTION
* Added toggleStatus() to SensorDigitalOutput (fixes #321)
* Added  `_report_timer->unset()` in `onSetup()` for all sensors controlling an output (SensorServo, SensorDimmer, SensorDigitalOutput, SensorRelay, SensorLatchingRelay since they have to report immediately
* Global debounce can be set with `NodeManager::setInterruptMinDelta()` now renamed in `setInterruptDebounce()`
* Removed setDebounce() from SensorInterrupt since no more effective when using getLastInterruptValue() (fixes #320)