### PR TITLE
SensorBosch - fixed forecast propagation and i2c address detection

### DIFF
--- a/NodeManagerLibrary.h
+++ b/NodeManagerLibrary.h
@@ -1098,7 +1098,7 @@ class SensorBosch: public Sensor {
     void setForecastSamplesCount(int value);
     // define what to do at each stage of the sketch
     void onReceive(MyMessage* message);
-    static uint8_t GetI2CAddress(uint8_t chip_id);
+    uint8_t GetI2CAddress(uint8_t chip_id);
   protected:
     char* _weather[6] = { "stable", "sunny", "cloudy", "unstable", "thunderstorm", "unknown" };
     int _forecast_samples_count = 5;

--- a/NodeManagerLibrary.ino
+++ b/NodeManagerLibrary.ino
@@ -1974,7 +1974,7 @@ float SensorBosch::_getLastPressureSamplesAverage() {
 uint8_t SensorBosch::GetI2CAddress(uint8_t chip_id) {
   uint8_t addresses[] = {0x77, 0x76};
   uint8_t register_address = 0xD0;
-  for (int i = 0; i <= sizeof(addresses); i++) { 
+  for (int i = 0; i < sizeof(addresses); i++) { 
     uint8_t i2c_address = addresses[i];
     uint8_t value;
     Wire.beginTransmission((uint8_t)i2c_address);
@@ -2065,7 +2065,7 @@ void SensorBME280::onLoop(Child* child) {
   // Forecast Sensor
   else if (child->type == V_FORECAST) {
     float pressure = _bm->readPressure() / 100.0F;
-    _forecast(pressure);
+    ((ChildString*)child)->setValueString(_forecast(pressure));
   }
 }
 #endif
@@ -2128,7 +2128,7 @@ void SensorBMP085::onLoop(Child* child) {
   // Forecast Sensor
   else if (child->type == V_FORECAST) {
     float pressure = _bm->readPressure() / 100.0F;
-    _forecast(pressure);
+    ((ChildString*)child)->setValueString(_forecast(pressure));
   }
 }
 #endif
@@ -2190,7 +2190,7 @@ void SensorBMP280::onLoop(Child* child) {
   // Forecast Sensor
   else if (child->type == V_FORECAST) {
     float pressure = _bm->readPressure() / 100.0F;
-    _forecast(pressure);
+    ((ChildString*)child)->setValueString(_forecast(pressure));
   }
 }
 #endif


### PR DESCRIPTION
Hi,
this PR fixing 2 issues with **Bosh Sensors**:
### I2C address detection
- there was a problem with iteration through the array which caused freeze
- next issue was also in `static GetI2CAddress` method where the `Wire.read();` returned always 255. I'm not sure what is the exact problem, but after removal of **static** keyword the detection starts working flawlessly.
### Forecast
- forecast value was not sent to controller

Thank you for your GREAT work which saved a LOT of my time!!