### PR TITLE
Naming Convention fixes & SensorDigitalOutput review

### DIFF
--- a/NodeManager.ino
+++ b/NodeManager.ino
@@ -327,8 +327,8 @@ SensorConfiguration configuration(node);
 //SensorACS712 acs712(node,A0);
 //SensorDigitalInput digitalIn(node,6);
 //SensorDigitalOutput digitalOut(node,6);
-//SensorRelay relay(node,6);
-SensorLatchingRelay latching(node,6);
+SensorRelay relay(node,6);
+//SensorLatchingRelay latching(node,6);
 //SensorDHT11 dht11(node,6);
 //SensorDHT22 dht22(node,6);
 //SensorSHT21 sht21(node);
@@ -374,8 +374,7 @@ SensorLatchingRelay latching(node,6);
 void before() {
   // setup the serial port baud rate
   Serial.begin(MY_BAUD_RATE);
-  //latching.setInvertValueToWrite(true);
-
+  relay.setSafeguard(1);
   
   /*
   * Configure your sensors below

--- a/NodeManager.ino
+++ b/NodeManager.ino
@@ -327,13 +327,13 @@ SensorConfiguration configuration(node);
 //SensorACS712 acs712(node,A0);
 //SensorDigitalInput digitalIn(node,6);
 //SensorDigitalOutput digitalOut(node,6);
-SensorRelay relay(node,6);
-//SensorLatchingRelay latching(node,6);
+//SensorRelay relay(node,6);
+SensorLatchingRelay latching(node,6);
 //SensorDHT11 dht11(node,6);
 //SensorDHT22 dht22(node,6);
 //SensorSHT21 sht21(node);
 //SensorHTU21D htu21(node);
-SensorInterrupt interrupt(node,3);
+//SensorInterrupt interrupt(node,3);
 //SensorDoor door(node,3);
 //SensorMotion motion(node,3);
 //SensorDs18b20 ds18b20(node,6);
@@ -351,7 +351,7 @@ SensorInterrupt interrupt(node,3);
 //SensorTSL2561 tsl2561(node);
 //SensorPT100 pt100(node,6);
 //SensorDimmer dimmer(node,3);
-SensorRainGauge rainGauge(node,3);
+//SensorRainGauge rainGauge(node,3);
 //SensorPowerMeter powerMeter(node,3);
 //SensorWaterMeter waterMeter(node,3);
 //SensorPlantowerPMS pms(node,6,7);
@@ -374,7 +374,7 @@ SensorRainGauge rainGauge(node,3);
 void before() {
   // setup the serial port baud rate
   Serial.begin(MY_BAUD_RATE);
-  
+  //latching.setInvertValueToWrite(true);
 
   
   /*

--- a/NodeManager.ino
+++ b/NodeManager.ino
@@ -42,58 +42,59 @@ Once created, the sensor will automatically present one or more child to the gat
 and controller. A list of buil-in sensors, module to enable, required dependencies 
 and the number of child automatically created is presented below:
 
-Sensor Name         |#Child | Module to enable   | Description                                                                                       | Dependencies
---------------------|-------|--------------------|---------------------------------------------------------------------------------------------------|----------------------------------------------------------
-SensorBattery       | 1     | USE_BATTERY        | Built-in sensor for automatic battery reporting                                                   | - 
-SensorSignal        | 1     | USE_SIGNAL         | Built-in sensor for automatic signal level reporting                                              | -
-SensorConfiguration | 1     | USE_CONFIGURATION  | Built-in sensor for OTA remote configuration of any registered sensor                             | -
-SensorAnalogInput   | 1     | USE_ANALOG_INPUT   | Generic analog sensor, return a pin's analog value or its percentage                              | -
-SensorLDR           | 1     | USE_ANALOG_INPUT   | LDR sensor, return the light level of an attached light resistor in percentage                    | -
-SensorRain          | 1     | USE_ANALOG_INPUT   | Rain sensor, return the percentage of rain from an attached analog sensor                         | -
-SensorSoilMoisture  | 1     | USE_ANALOG_INPUT   | Soil moisture sensor, return the percentage of moisture from an attached analog sensor            | -
-SensorThermistor    | 1     | USE_THERMISTOR     | Thermistor sensor, return the temperature based on the attached thermistor                        | -
-SensorML8511        | 1     | USE_ML8511         | ML8511 sensor, return UV intensity                                                                | -
-SensorACS712        | 1     | USE_ACS712         | ACS712 sensor, measure the current going through the attached module                              | -
-SensorDigitalInput  | 1     | USE_DIGITAL_INPUT  | Generic digital sensor, return a pin's digital value                                              | -
-SensorDigitalOutput | 1     | USE_DIGITAL_OUTPUT | Generic digital output sensor, allows setting the digital output of a pin to the requested value  | -
-SensorRelay         | 1     | USE_DIGITAL_OUTPUT | Relay sensor, allows activating the relay                                                         | -
-SensorLatchingRelay | 1     | USE_DIGITAL_OUTPUT | Latching Relay sensor, allows activating the relay with a pulse                                   | -
-SensorDHT11         | 2     | USE_DHT            | DHT11 sensor, return temperature/humidity based on the attached DHT sensor                        | https://github.com/mysensors/MySensorsArduinoExamples/tree/master/libraries/DHT
-SensorDHT22         | 2     | USE_DHT            | DHT22 sensor, return temperature/humidity based on the attached DHT sensor                        | https://github.com/mysensors/MySensorsArduinoExamples/tree/master/libraries/DHT
-SensorSHT21         | 2     | USE_SHT21          | SHT21 sensor, return temperature/humidity based on the attached SHT21 sensor                      | https://github.com/SodaqMoja/Sodaq_SHT2x
-SensorHTU21D        | 2     | USE_SHT21          | HTU21D sensor, return temperature/humidity based on the attached HTU21D sensor                    | https://github.com/SodaqMoja/Sodaq_SHT2x
-SensorInterrupt     | 1     | USE_INTERRUPT      | Generic interrupt-based sensor, wake up the board when a pin changes status                       | -
-SensorDoor          | 1     | USE_INTERRUPT      | Door sensor, wake up the board and report when an attached magnetic sensor has been opened/closed | -
-SensorMotion        | 1     | USE_INTERRUPT      | Motion sensor, wake up the board and report when an attached PIR has triggered                    | -
-SensorDs18b20       | 1+    | USE_DS18B20        | DS18B20 sensor, return the temperature based on the attached sensor                               | https://github.com/milesburton/Arduino-Temperature-Control-Library
-SensorBH1750        | 1     | USE_BH1750         | BH1750 sensor, return light level in lux                                                          | https://github.com/claws/BH1750
-SensorMLX90614      | 2     | USE_MLX90614       | MLX90614 contactless temperature sensor, return ambient and object temperature                    | https://github.com/adafruit/Adafruit-MLX90614-Library
-SensorBME280        | 4     | USE_BME280         | BME280 sensor, return temperature/humidity/pressure based on the attached BME280 sensor           | https://github.com/adafruit/Adafruit_BME280_Library
-SensorBMP085        | 3     | USE_BMP085         | BMP085/BMP180 sensor, return temperature and pressure                                             | https://github.com/adafruit/Adafruit-BMP085-Library
-SensorBMP280        | 3     | USE_BMP280         | BMP280 sensor, return temperature/pressure based on the attached BMP280 sensor                    | https://github.com/adafruit/Adafruit_BMP280_Library
-SensorSonoff        | 1     | USE_SONOFF         | Sonoff wireless smart switch                                                                      | https://github.com/thomasfredericks/Bounce2
-SensorHCSR04        | 1     | USE_HCSR04         | HC-SR04 sensor, return the distance between the sensor and an object                              | https://github.com/mysensors/MySensorsArduinoExamples/tree/master/libraries/NewPing
-SensorMCP9808       | 1     | USE_MCP9808        | MCP9808 sensor, measure the temperature through the attached module                               | https://github.com/adafruit/Adafruit_MCP9808_Library
-SensorMQ            | 1     | USE_MQ             | MQ sensor, return ppm of the target gas                                                           | -
-SensorMHZ19         | 1     | USE_MHZ19          | MH-Z19 CO2 sensor via UART (SoftwareSerial, default on pins 6(Rx) and 7(Tx)                       | -
-SensorAM2320        | 2     | USE_AM2320         | AM2320 sensors, return temperature/humidity based on the attached AM2320 sensor                   | https://github.com/thakshak/AM2320
-SensorTSL2561       | 1     | USE_TSL2561        | TSL2561 sensor, return light in lux                                                               | https://github.com/adafruit/TSL2561-Arduino-Library
-SensorPT100         | 1     | USE_PT100          | DFRobot Driver high temperature sensor, return the temperature from the attached PT100 sensor     | -
-SensorDimmer        | 1     | USE_DIMMER         | Generic dimmer sensor used to drive a pwm output                                                  | -
-SensorRainGauge     | 1     | USE_PULSE_METER    | Rain gauge sensor                                                                                 | -
-SensorPowerMeter    | 1     | USE_PULSE_METER    | Power meter pulse sensor                                                                          | -
-SensorWaterMeter    | 1     | USE_PULSE_METER    | Water meter pulse sensor                                                                          | -
-SensorPlantowerPMS  | 3     | USE_PMS            | Plantower PMS particulate matter sensors (reporting PM<=1.0, PM<=2.5 and PM<=10.0 in µg/m³)       | https://github.com/fu-hsi/pms
-SensorVL53L0X       | 1     | USE_VL53L0X        | VL53L0X laser time-of-flight distance sensor via I²C, sleep pin supported (optional)              | https://github.com/pololu/vl53l0x-arduino
-DisplaySSD1306      | 1     | USE_SSD1306        | SSD1306 128x64 OLED display (I²C); By default displays values of all sensors and children         | https://github.com/greiman/SSD1306Ascii.git
-SensorSHT31         | 2     | USE_SHT31          | SHT31 sensor, return temperature/humidity based on the attached SHT31 sensor                      | https://github.com/adafruit/Adafruit_SHT31
-SensorSI7021        | 2     | USE_SI7021         | SI7021 sensor, return temperature/humidity based on the attached SI7021 sensor                    | https://github.com/sparkfun/SparkFun_Si701_Breakout_Arduino_Library
-SensorChirp         | 3     | USE_CHIRP          | Chirp soil moisture sensor (includes temperature and light sensors)                               | https://github.com/Apollon77/I2CSoilMoistureSensor
-DisplayHD44780      | 1     | USE_HD44780        | Supports most Hitachi HD44780 based LCDs, by default displays values of all sensors and children  | https://github.com/cyberang3l/NewLiquidCrystal
-SensorTTP           | 1     | USE_TTP            | TTP226/TTP229 Touch control sensor                                                                | -
-SensorServo         | 1     | USE_SERVO          | Control a generic Servo motor sensor                                                              | -
-SensorAPDS9960      | 1     | USE_APDS9960       | SparkFun RGB and Gesture Sensor                                                                   | https://github.com/sparkfun/APDS-9960_RGB_and_Gesture_Sensor
-SensorNeopixel      | 1     | USE_NEOPIXEL       | Control a Neopixel LED                                                                            | https://github.com/adafruit/Adafruit_NeoPixel
+Sensor Name              |#Child | Module to enable   | Description                                                                                       | Dependencies
+-------------------------|-------|--------------------|---------------------------------------------------------------------------------------------------|----------------------------------------------------------
+SensorBattery            | 1     | USE_BATTERY        | Built-in sensor for automatic battery reporting                                                   | - 
+SensorSignal             | 1     | USE_SIGNAL         | Built-in sensor for automatic signal level reporting                                              | -
+SensorConfiguration      | 1     | USE_CONFIGURATION  | Built-in sensor for OTA remote configuration of any registered sensor                             | -
+SensorAnalogInput        | 1     | USE_ANALOG_INPUT   | Generic analog sensor, return a pin's analog value or its percentage                              | -
+SensorLDR                | 1     | USE_ANALOG_INPUT   | LDR sensor, return the light level of an attached light resistor in percentage                    | -
+SensorRain               | 1     | USE_ANALOG_INPUT   | Rain sensor, return the percentage of rain from an attached analog sensor                         | -
+SensorSoilMoisture       | 1     | USE_ANALOG_INPUT   | Soil moisture sensor, return the percentage of moisture from an attached analog sensor            | -
+SensorThermistor         | 1     | USE_THERMISTOR     | Thermistor sensor, return the temperature based on the attached thermistor                        | -
+SensorML8511             | 1     | USE_ML8511         | ML8511 sensor, return UV intensity                                                                | -
+SensorACS712             | 1     | USE_ACS712         | ACS712 sensor, measure the current going through the attached module                              | -
+SensorDigitalInput       | 1     | USE_DIGITAL_INPUT  | Generic digital sensor, return a pin's digital value                                              | -
+SensorDigitalOutput      | 1     | USE_DIGITAL_OUTPUT | Generic digital output sensor, allows setting the digital output of a pin to the requested value  | -
+SensorRelay              | 1     | USE_DIGITAL_OUTPUT | Relay sensor, allows activating the relay                                                         | -
+SensorLatchingRelay1Pin  | 1     | USE_DIGITAL_OUTPUT | Latching Relay sensor, allows toggling the relay with a pulse on the configured pin               | -
+SensorLatchingRelay2Pins | 1     | USE_DIGITAL_OUTPUT | Latching Relay sensor, allows turing the relay on and off with a pulse on the configured pins     | -
+SensorDHT11              | 2     | USE_DHT            | DHT11 sensor, return temperature/humidity based on the attached DHT sensor                        | https://github.com/mysensors/MySensorsArduinoExamples/tree/master/libraries/DHT
+SensorDHT22              | 2     | USE_DHT            | DHT22 sensor, return temperature/humidity based on the attached DHT sensor                        | https://github.com/mysensors/MySensorsArduinoExamples/tree/master/libraries/DHT
+SensorSHT21              | 2     | USE_SHT21          | SHT21 sensor, return temperature/humidity based on the attached SHT21 sensor                      | https://github.com/SodaqMoja/Sodaq_SHT2x
+SensorHTU21D             | 2     | USE_SHT21          | HTU21D sensor, return temperature/humidity based on the attached HTU21D sensor                    | https://github.com/SodaqMoja/Sodaq_SHT2x
+SensorInterrupt          | 1     | USE_INTERRUPT      | Generic interrupt-based sensor, wake up the board when a pin changes status                       | -
+SensorDoor               | 1     | USE_INTERRUPT      | Door sensor, wake up the board and report when an attached magnetic sensor has been opened/closed | -
+SensorMotion             | 1     | USE_INTERRUPT      | Motion sensor, wake up the board and report when an attached PIR has triggered                    | -
+SensorDs18b20            | 1+    | USE_DS18B20        | DS18B20 sensor, return the temperature based on the attached sensor                               | https://github.com/milesburton/Arduino-Temperature-Control-Library
+SensorBH1750             | 1     | USE_BH1750         | BH1750 sensor, return light level in lux                                                          | https://github.com/claws/BH1750
+SensorMLX90614           | 2     | USE_MLX90614       | MLX90614 contactless temperature sensor, return ambient and object temperature                    | https://github.com/adafruit/Adafruit-MLX90614-Library
+SensorBME280             | 4     | USE_BME280         | BME280 sensor, return temperature/humidity/pressure based on the attached BME280 sensor           | https://github.com/adafruit/Adafruit_BME280_Library
+SensorBMP085             | 3     | USE_BMP085         | BMP085/BMP180 sensor, return temperature and pressure                                             | https://github.com/adafruit/Adafruit-BMP085-Library
+SensorBMP280             | 3     | USE_BMP280         | BMP280 sensor, return temperature/pressure based on the attached BMP280 sensor                    | https://github.com/adafruit/Adafruit_BMP280_Library
+SensorSonoff             | 1     | USE_SONOFF         | Sonoff wireless smart switch                                                                      | https://github.com/thomasfredericks/Bounce2
+SensorHCSR04             | 1     | USE_HCSR04         | HC-SR04 sensor, return the distance between the sensor and an object                              | https://github.com/mysensors/MySensorsArduinoExamples/tree/master/libraries/NewPing
+SensorMCP9808            | 1     | USE_MCP9808        | MCP9808 sensor, measure the temperature through the attached module                               | https://github.com/adafruit/Adafruit_MCP9808_Library
+SensorMQ                 | 1     | USE_MQ             | MQ sensor, return ppm of the target gas                                                           | -
+SensorMHZ19              | 1     | USE_MHZ19          | MH-Z19 CO2 sensor via UART (SoftwareSerial, default on pins 6(Rx) and 7(Tx)                       | -
+SensorAM2320             | 2     | USE_AM2320         | AM2320 sensors, return temperature/humidity based on the attached AM2320 sensor                   | https://github.com/thakshak/AM2320
+SensorTSL2561            | 1     | USE_TSL2561        | TSL2561 sensor, return light in lux                                                               | https://github.com/adafruit/TSL2561-Arduino-Library
+SensorPT100              | 1     | USE_PT100          | DFRobot Driver high temperature sensor, return the temperature from the attached PT100 sensor     | -
+SensorDimmer             | 1     | USE_DIMMER         | Generic dimmer sensor used to drive a pwm output                                                  | -
+SensorRainGauge          | 1     | USE_PULSE_METER    | Rain gauge sensor                                                                                 | -
+SensorPowerMeter         | 1     | USE_PULSE_METER    | Power meter pulse sensor                                                                          | -
+SensorWaterMeter         | 1     | USE_PULSE_METER    | Water meter pulse sensor                                                                          | -
+SensorPlantowerPMS       | 3     | USE_PMS            | Plantower PMS particulate matter sensors (reporting PM<=1.0, PM<=2.5 and PM<=10.0 in µg/m³)       | https://github.com/fu-hsi/pms
+SensorVL53L0X            | 1     | USE_VL53L0X        | VL53L0X laser time-of-flight distance sensor via I²C, sleep pin supported (optional)              | https://github.com/pololu/vl53l0x-arduino
+DisplaySSD1306           | 1     | USE_SSD1306        | SSD1306 128x64 OLED display (I²C); By default displays values of all sensors and children         | https://github.com/greiman/SSD1306Ascii.git
+SensorSHT31              | 2     | USE_SHT31          | SHT31 sensor, return temperature/humidity based on the attached SHT31 sensor                      | https://github.com/adafruit/Adafruit_SHT31
+SensorSI7021             | 2     | USE_SI7021         | SI7021 sensor, return temperature/humidity based on the attached SI7021 sensor                    | https://github.com/sparkfun/SparkFun_Si701_Breakout_Arduino_Library
+SensorChirp              | 3     | USE_CHIRP          | Chirp soil moisture sensor (includes temperature and light sensors)                               | https://github.com/Apollon77/I2CSoilMoistureSensor
+DisplayHD44780           | 1     | USE_HD44780        | Supports most Hitachi HD44780 based LCDs, by default displays values of all sensors and children  | https://github.com/cyberang3l/NewLiquidCrystal
+SensorTTP                | 1     | USE_TTP            | TTP226/TTP229 Touch control sensor                                                                | -
+SensorServo              | 1     | USE_SERVO          | Control a generic Servo motor sensor                                                              | -
+SensorAPDS9960           | 1     | USE_APDS9960       | SparkFun RGB and Gesture Sensor                                                                   | https://github.com/sparkfun/APDS-9960_RGB_and_Gesture_Sensor
+SensorNeopixel           | 1     | USE_NEOPIXEL       | Control a Neopixel LED                                                                            | https://github.com/adafruit/Adafruit_NeoPixel
 
 NodeManager provides useful built-in features which can be disabled if you need 
 to save some storage for your code. To enable/disable a buil-in feature:
@@ -245,16 +246,16 @@ FEATURE_HOOKING             | OFF     | allow custom code to be hooked in the ou
 
 //#define USE_BATTERY
 //#define USE_SIGNAL
-#define USE_CONFIGURATION
+//#define USE_CONFIGURATION
 //#define USE_ANALOG_INPUT
 //#define USE_THERMISTOR
 //#define USE_ML8511
 //#define USE_ACS712
 //#define USE_DIGITAL_INPUT
-#define USE_DIGITAL_OUTPUT
+//#define USE_DIGITAL_OUTPUT
 //#define USE_DHT
 //#define USE_SHT21
-#define USE_INTERRUPT
+//#define USE_INTERRUPT
 //#define USE_DS18B20
 //#define USE_BH1750
 //#define USE_MLX90614
@@ -270,7 +271,7 @@ FEATURE_HOOKING             | OFF     | allow custom code to be hooked in the ou
 //#define USE_TSL2561
 //#define USE_PT100
 //#define USE_DIMMER
-#define USE_PULSE_METER
+//#define USE_PULSE_METER
 //#define USE_PMS
 //#define USE_VL53L0X
 //#define USE_SSD1306
@@ -313,7 +314,7 @@ NodeManager node;
 
 // built-in sensors
 //SensorBattery battery(node);
-SensorConfiguration configuration(node);
+//SensorConfiguration configuration(node);
 //SensorSignal signal(node);
 //PowerManager power(5,6);
 
@@ -327,8 +328,9 @@ SensorConfiguration configuration(node);
 //SensorACS712 acs712(node,A0);
 //SensorDigitalInput digitalIn(node,6);
 //SensorDigitalOutput digitalOut(node,6);
-SensorRelay relay(node,6);
-//SensorLatchingRelay latching(node,6);
+//SensorRelay relay(node,6);
+//SensorLatchingRelay1Pin latching1pin(node,6);
+//SensorLatchingRelay2Pins latching2pins(node,6,7);
 //SensorDHT11 dht11(node,6);
 //SensorDHT22 dht22(node,6);
 //SensorSHT21 sht21(node);
@@ -374,7 +376,8 @@ SensorRelay relay(node,6);
 void before() {
   // setup the serial port baud rate
   Serial.begin(MY_BAUD_RATE);
-  relay.setSafeguard(1);
+
+
   
   /*
   * Configure your sensors below

--- a/NodeManager.ino
+++ b/NodeManager.ino
@@ -245,7 +245,7 @@ FEATURE_HOOKING             | OFF     | allow custom code to be hooked in the ou
 
 //#define USE_BATTERY
 //#define USE_SIGNAL
-//#define USE_CONFIGURATION
+#define USE_CONFIGURATION
 //#define USE_ANALOG_INPUT
 //#define USE_THERMISTOR
 //#define USE_ML8511
@@ -313,7 +313,7 @@ NodeManager node;
 
 // built-in sensors
 //SensorBattery battery(node);
-//SensorConfiguration configuration(node);
+SensorConfiguration configuration(node);
 //SensorSignal signal(node);
 //PowerManager power(5,6);
 

--- a/NodeManager.ino
+++ b/NodeManager.ino
@@ -251,10 +251,10 @@ FEATURE_HOOKING             | OFF     | allow custom code to be hooked in the ou
 //#define USE_ML8511
 //#define USE_ACS712
 //#define USE_DIGITAL_INPUT
-//#define USE_DIGITAL_OUTPUT
+#define USE_DIGITAL_OUTPUT
 //#define USE_DHT
 //#define USE_SHT21
-//#define USE_INTERRUPT
+#define USE_INTERRUPT
 //#define USE_DS18B20
 //#define USE_BH1750
 //#define USE_MLX90614
@@ -270,7 +270,7 @@ FEATURE_HOOKING             | OFF     | allow custom code to be hooked in the ou
 //#define USE_TSL2561
 //#define USE_PT100
 //#define USE_DIMMER
-//#define USE_PULSE_METER
+#define USE_PULSE_METER
 //#define USE_PMS
 //#define USE_VL53L0X
 //#define USE_SSD1306
@@ -327,13 +327,13 @@ NodeManager node;
 //SensorACS712 acs712(node,A0);
 //SensorDigitalInput digitalIn(node,6);
 //SensorDigitalOutput digitalOut(node,6);
-//SensorRelay relay(node,6);
+SensorRelay relay(node,6);
 //SensorLatchingRelay latching(node,6);
 //SensorDHT11 dht11(node,6);
 //SensorDHT22 dht22(node,6);
 //SensorSHT21 sht21(node);
 //SensorHTU21D htu21(node);
-//SensorInterrupt interrupt(node,3);
+SensorInterrupt interrupt(node,3);
 //SensorDoor door(node,3);
 //SensorMotion motion(node,3);
 //SensorDs18b20 ds18b20(node,6);
@@ -351,7 +351,7 @@ NodeManager node;
 //SensorTSL2561 tsl2561(node);
 //SensorPT100 pt100(node,6);
 //SensorDimmer dimmer(node,3);
-//SensorRainGauge rainGauge(node,3);
+SensorRainGauge rainGauge(node,3);
 //SensorPowerMeter powerMeter(node,3);
 //SensorWaterMeter waterMeter(node,3);
 //SensorPlantowerPMS pms(node,6,7);

--- a/NodeManagerLibrary.h
+++ b/NodeManagerLibrary.h
@@ -863,7 +863,9 @@ class SensorDigitalOutput: public Sensor {
     void setPulseWidth(int value);
     // [109] Invert the value to write. E.g. if ON is received, write LOW (default: false) 
     void setInvertValueToWrite(bool value);
-    // manually switch the output to the provided value
+    // [110] for a 2-pins latching relay, set the pin which turns the relay off (default: -1)
+    void setPinOff(int value);
+    // manually switch the output to the provided status (ON or OFF)
     void setStatus(int value);
     // toggle the status
     void toggleStatus();
@@ -874,6 +876,7 @@ class SensorDigitalOutput: public Sensor {
     void onReceive(MyMessage* message);
   protected:
     int _status = OFF;
+    int _pin_off = -1;
     bool _legacy_mode = false;
     bool _input_is_elapsed = false;
     int _wait_after_set = 0;
@@ -897,16 +900,6 @@ class SensorRelay: public SensorDigitalOutput {
 class SensorLatchingRelay: public SensorRelay {
   public:
     SensorLatchingRelay(NodeManager& node_manager, int pin, int child_id = -255);
-    // [202] set the pin which turns the relay off (default: the pin provided while registering the sensor)
-    void setPinOff(int value);
-    // [203] set the pin which turns the relay on (default: the pin provided while registering the sensor + 1)
-    void setPinOn(int value);
-    // define what to do at each stage of the sketch
-    void onSetup();
-  protected:
-    int _pin_on;
-    int _pin_off;
-    void _switchOutput(int value);
 };
 #endif
 

--- a/NodeManagerLibrary.h
+++ b/NodeManagerLibrary.h
@@ -978,7 +978,7 @@ class SensorInterrupt: public Sensor {
   public:
     SensorInterrupt(NodeManager& node_manager, int pin, int child_id = -255);
     // [101] set the interrupt mode. Can be CHANGE, RISING, FALLING (default: CHANGE)
-    void setMode(int value);
+    void setInterruptMode(int value);
     // [103] time to wait in milliseconds after a change is detected to allow the signal to be restored to its normal value (default: 0)
     void setTriggerTime(int value);
     // [104] Set initial value on the interrupt pin (default: HIGH)
@@ -998,7 +998,7 @@ class SensorInterrupt: public Sensor {
     void onInterrupt();
   protected:
     int _trigger_time = 0;
-    int _mode = CHANGE;
+    int _interrupt_mode = CHANGE;
     int _initial = HIGH;
     int _active_state = HIGH;
     bool _armed = true;
@@ -1441,7 +1441,7 @@ class SensorPulseMeter: public Sensor {
     void setPulseFactor(float value);
     // set initial value - internal pull up (default: HIGH)
     void setInitialValue(int value);
-    // set the interrupt mode to attach to (default: FALLING)
+    // set the interrupt mode. Can be CHANGE, RISING, FALLING (default: FALLING)
     void setInterruptMode(int value);
     // define what to do at each stage of the sketch
     void onSetup();

--- a/NodeManagerLibrary.h
+++ b/NodeManagerLibrary.h
@@ -437,17 +437,27 @@ class Child {
   public:
     Child();
     Child(Sensor* sensor, int child_id, int presentation, int type, const char* description = "");
+    // child id used to communicate with the gateway/controller
     int child_id;
+    // Sensor presentation (default: S_CUSTOM)
     int presentation = S_CUSTOM;
+    // Sensor type (default: V_CUSTOM)
     int type = V_CUSTOM;
+    // how many decimal digits to use (default: 2 for ChildFloat, 4 for ChildDouble)
     int float_precision;
+    // Sensor description
     const char* description = "";
+    // send the current value to the gateway
     virtual void sendValue();
+    // print the current value on a LCD display
     virtual void printOn(Print& p);
 #if FEATURE_CONDITIONAL_REPORT == ON
     Timer* force_update_timer;
+    // return true if the current value is new/different compared to the previous one
     virtual bool isNewValue();
+    // minimum threshold for reporting the value to the controller
     float min_threshold = FLT_MIN;
+    // maximum threshold for reporting the value to the controller
     float max_threshold = FLT_MAX;
 #endif
   protected:
@@ -895,11 +905,19 @@ class SensorRelay: public SensorDigitalOutput {
 };
 
 /*
-   SensorLatchingRelay
+   SensorLatchingRelay1Pin
 */
-class SensorLatchingRelay: public SensorRelay {
+class SensorLatchingRelay1Pin: public SensorRelay {
   public:
-    SensorLatchingRelay(NodeManager& node_manager, int pin, int child_id = -255);
+    SensorLatchingRelay1Pin(NodeManager& node_manager, int pin, int child_id = -255);
+};
+
+/*
+   SensorLatchingRelay2Pins
+*/
+class SensorLatchingRelay2Pins: public SensorRelay {
+  public:
+    SensorLatchingRelay2Pins(NodeManager& node_manager, int pin_off, int pin_on, int child_id = -255);
 };
 #endif
 

--- a/NodeManagerLibrary.h
+++ b/NodeManagerLibrary.h
@@ -979,8 +979,8 @@ class SensorInterrupt: public Sensor {
     SensorInterrupt(NodeManager& node_manager, int pin, int child_id = -255);
     // [101] set the interrupt mode. Can be CHANGE, RISING, FALLING (default: CHANGE)
     void setInterruptMode(int value);
-    // [103] time to wait in milliseconds after a change is detected to allow the signal to be restored to its normal value (default: 0)
-    void setTriggerTime(int value);
+    // [103] milliseconds to wait/sleep after the interrupt before reporting (default: 0)
+    void setWaitAfterTrigger(int value);
     // [104] Set initial value on the interrupt pin. Can be used for internal pull up (default: HIGH)
     void setInitialValue(int value);
     // [105] Set active state (default: HIGH) 
@@ -997,7 +997,7 @@ class SensorInterrupt: public Sensor {
     void onReceive(MyMessage* message);
     void onInterrupt();
   protected:
-    int _trigger_time = 0;
+    int _wait_after_trigger = 0;
     int _interrupt_mode = CHANGE;
     int _initial_value = HIGH;
     int _active_state = HIGH;
@@ -1442,6 +1442,8 @@ class SensorPulseMeter: public Sensor {
     void setInitialValue(int value);
     // set the interrupt mode. Can be CHANGE, RISING, FALLING (default: FALLING)
     void setInterruptMode(int value);
+    // milliseconds to wait/sleep after the interrupt before reporting (default: 0)
+    void setWaitAfterTrigger(int value);
     // define what to do at each stage of the sketch
     void onSetup();
     void onLoop(Child* child);
@@ -1453,6 +1455,7 @@ class SensorPulseMeter: public Sensor {
     float _pulse_factor;
     int _initial_value = HIGH;
     int _interrupt_mode = FALLING;
+    int _wait_after_trigger = 0;
     virtual void _reportTotal(Child* child);
 };
 

--- a/NodeManagerLibrary.h
+++ b/NodeManagerLibrary.h
@@ -981,8 +981,8 @@ class SensorInterrupt: public Sensor {
     void setInterruptMode(int value);
     // [103] time to wait in milliseconds after a change is detected to allow the signal to be restored to its normal value (default: 0)
     void setTriggerTime(int value);
-    // [104] Set initial value on the interrupt pin (default: HIGH)
-    void setInitial(int value);
+    // [104] Set initial value on the interrupt pin. Can be used for internal pull up (default: HIGH)
+    void setInitialValue(int value);
     // [105] Set active state (default: HIGH) 
     void setActiveState(int value);
     // [106] Set armed, if false the sensor will not trigger until armed (default: true) 
@@ -999,7 +999,7 @@ class SensorInterrupt: public Sensor {
   protected:
     int _trigger_time = 0;
     int _interrupt_mode = CHANGE;
-    int _initial = HIGH;
+    int _initial_value = HIGH;
     int _active_state = HIGH;
     bool _armed = true;
 #if FEATURE_TIME == ON
@@ -1023,7 +1023,6 @@ class SensorDoor: public SensorInterrupt {
 class SensorMotion: public SensorInterrupt {
   public:
     SensorMotion(NodeManager& node_manager, int pin, int child_id = -255);
-    void onSetup();
 };
 #endif
 /*
@@ -1439,7 +1438,7 @@ class SensorPulseMeter: public Sensor {
     SensorPulseMeter(NodeManager& node_manager, int pin, int child_id = -255);
     // [102] set how many pulses for each unit (e.g. 1000 pulses for 1 kwh of power, 9 pulses for 1 mm of rain, etc.)
     void setPulseFactor(float value);
-    // set initial value - internal pull up (default: HIGH)
+    // Set initial value on the interrupt pin. Can be used for internal pull up (default: HIGH)
     void setInitialValue(int value);
     // set the interrupt mode. Can be CHANGE, RISING, FALLING (default: FALLING)
     void setInterruptMode(int value);

--- a/NodeManagerLibrary.ino
+++ b/NodeManagerLibrary.ino
@@ -1577,8 +1577,8 @@ void SensorInterrupt::setInterruptMode(int value) {
 void SensorInterrupt::setTriggerTime(int value) {
   _trigger_time = value;
 }
-void SensorInterrupt::setInitial(int value) {
-  _initial = value;
+void SensorInterrupt::setInitialValue(int value) {
+  _initial_value = value;
 }
 void SensorInterrupt::setActiveState(int value) {
   _active_state = value;
@@ -1596,7 +1596,7 @@ void SensorInterrupt::setThreshold(int value) {
 // what to do during setup
 void SensorInterrupt::onSetup() {
   // set the interrupt pin so it will be called only when waking up from that interrupt
-  setInterrupt(_pin,_interrupt_mode,_initial);
+  setInterrupt(_pin,_interrupt_mode,_initial_value);
   // report immediately
   _report_timer->unset();
 }
@@ -1668,14 +1668,10 @@ SensorMotion::SensorMotion(NodeManager& node_manager, int pin, int child_id): Se
   children.get(1)->presentation = S_MOTION;
   children.get(1)->type = V_TRIPPED;
   children.get(1)->description = _name;
+  // set initial value to LOW
+  setInitialValue(LOW);
 }
 
-// what to do during setup
-void SensorMotion::onSetup() {
-  SensorInterrupt::onSetup();
-  // set initial value to LOW
-  setInitial(LOW);
-}
 #endif
 
 /*
@@ -4193,7 +4189,7 @@ void SensorConfiguration::onReceive(MyMessage* message) {
         switch(function) {
           case 101: custom_sensor->setInterruptMode(request.getValueInt()); break;
           case 103: custom_sensor->setTriggerTime(request.getValueInt()); break;
-          case 104: custom_sensor->setInitial(request.getValueInt()); break;
+          case 104: custom_sensor->setInitialValue(request.getValueInt()); break;
           case 105: custom_sensor->setActiveState(request.getValueInt()); break;
           case 106: custom_sensor->setArmed(request.getValueInt()); break;
           default: return;

--- a/NodeManagerLibrary.ino
+++ b/NodeManagerLibrary.ino
@@ -1341,15 +1341,29 @@ SensorRelay::SensorRelay(NodeManager& node_manager, int pin, int child_id): Sens
 }
 
 /*
-   SensorLatchingRelay
+   SensorLatchingRelay1Pin
 */
 
 // contructor
-SensorLatchingRelay::SensorLatchingRelay(NodeManager& node_manager, int pin, int child_id): SensorRelay(node_manager, pin, child_id) {
-  _name = "LATCHING";
+SensorLatchingRelay1Pin::SensorLatchingRelay1Pin(NodeManager& node_manager, int pin, int child_id): SensorRelay(node_manager, pin, child_id) {
+  _name = "LATCHING1PIN";
   children.get(1)->description = _name;
   // set pulse duration
   _pulse_width = 50;
+}
+
+/*
+   SensorLatchingRelay2Pins
+*/
+
+// contructor
+SensorLatchingRelay2Pins::SensorLatchingRelay2Pins(NodeManager& node_manager, int pin_off, int pin_on, int child_id): SensorRelay(node_manager, pin_on, child_id) {
+  _name = "LATCHING2PINS";
+  children.get(1)->description = _name;
+  // set pulse duration
+  _pulse_width = 50;
+  // set off pin
+  setPinOff(pin_off);
 }
 #endif
 
@@ -4124,7 +4138,7 @@ void SensorConfiguration::onReceive(MyMessage* message) {
       }
       #endif
       #ifdef USE_DIGITAL_OUTPUT
-      if (strcmp(sensor->getName(),"DIGITAL_O") == 0 || strcmp(sensor->getName(),"RELAY") == 0 || strcmp(sensor->getName(),"LATCHING") == 0) {
+      if (strcmp(sensor->getName(),"DIGITAL_O") == 0 || strcmp(sensor->getName(),"RELAY") == 0 || strcmp(sensor->getName(),"LATCHING1PIN") == 0 || strcmp(sensor->getName(),"LATCHING2PINS") == 0) {
         SensorDigitalOutput* custom_sensor = (SensorDigitalOutput*)sensor;
         switch(function) {
             case 104: custom_sensor->setLegacyMode(request.getValueInt()); break;

--- a/NodeManagerLibrary.ino
+++ b/NodeManagerLibrary.ino
@@ -1574,8 +1574,8 @@ SensorInterrupt::SensorInterrupt(NodeManager& node_manager, int pin, int child_i
 void SensorInterrupt::setInterruptMode(int value) {
   _interrupt_mode = value;
 }
-void SensorInterrupt::setTriggerTime(int value) {
-  _trigger_time = value;
+void SensorInterrupt::setWaitAfterTrigger(int value) {
+  _wait_after_trigger = value;
 }
 void SensorInterrupt::setInitialValue(int value) {
   _initial_value = value;
@@ -1645,8 +1645,8 @@ void SensorInterrupt::onInterrupt() {
     if (_counter < _threshold) return;
 #endif
     ((ChildInt*)child)->setValueInt(value);
-    // allow the signal to be restored to its normal value
-    if (_trigger_time > 0) _node->sleepOrWait(_trigger_time);
+    // allow the signal to be restored to its normal value before reporting
+    if (_wait_after_trigger > 0) _node->sleepOrWait(_wait_after_trigger);
   }
 }
 
@@ -2977,6 +2977,9 @@ void SensorPulseMeter::setInitialValue(int value) {
 void SensorPulseMeter::setInterruptMode(int value) {
   _interrupt_mode = value;
 }
+void SensorPulseMeter::setWaitAfterTrigger(int value) {
+  _wait_after_trigger = value;
+}
 
 // what to do during setup
 void SensorPulseMeter::onSetup() {
@@ -3024,6 +3027,8 @@ void SensorPulseMeter::_reportTotal(Child* child) {
     Serial.print(F(" V="));
     Serial.println(((ChildFloat*)child)->getValueFloat());
   #endif
+  // allow the signal to be restored to its normal value before reporting
+  if (_wait_after_trigger > 0) _node->sleepOrWait(_wait_after_trigger);
 }
 
 /*
@@ -3059,6 +3064,8 @@ void SensorPowerMeter::_reportTotal(Child* child) {
     Serial.println(((ChildDouble*)child)->getValueDouble());
     Serial.println(_count);
   #endif
+  // allow the signal to be restored to its normal value before reporting
+  if (_wait_after_trigger > 0) _node->sleepOrWait(_wait_after_trigger);
 }
 
 /*
@@ -3082,6 +3089,8 @@ void SensorWaterMeter::_reportTotal(Child* child) {
     Serial.print(F(" V="));
     Serial.println(((ChildDouble*)child)->getValueDouble());
   #endif
+  // allow the signal to be restored to its normal value before reporting
+  if (_wait_after_trigger > 0) _node->sleepOrWait(_wait_after_trigger);
 }
 #endif
 
@@ -4188,7 +4197,7 @@ void SensorConfiguration::onReceive(MyMessage* message) {
         SensorInterrupt* custom_sensor = (SensorInterrupt*)sensor;
         switch(function) {
           case 101: custom_sensor->setInterruptMode(request.getValueInt()); break;
-          case 103: custom_sensor->setTriggerTime(request.getValueInt()); break;
+          case 103: custom_sensor->setWaitAfterTrigger(request.getValueInt()); break;
           case 104: custom_sensor->setInitialValue(request.getValueInt()); break;
           case 105: custom_sensor->setActiveState(request.getValueInt()); break;
           case 106: custom_sensor->setArmed(request.getValueInt()); break;

--- a/NodeManagerLibrary.ino
+++ b/NodeManagerLibrary.ino
@@ -1571,8 +1571,8 @@ SensorInterrupt::SensorInterrupt(NodeManager& node_manager, int pin, int child_i
 }
 
 // setter/getter
-void SensorInterrupt::setMode(int value) {
-  _mode = value;
+void SensorInterrupt::setInterruptMode(int value) {
+  _interrupt_mode = value;
 }
 void SensorInterrupt::setTriggerTime(int value) {
   _trigger_time = value;
@@ -1596,7 +1596,7 @@ void SensorInterrupt::setThreshold(int value) {
 // what to do during setup
 void SensorInterrupt::onSetup() {
   // set the interrupt pin so it will be called only when waking up from that interrupt
-  setInterrupt(_pin,_mode,_initial);
+  setInterrupt(_pin,_interrupt_mode,_initial);
   // report immediately
   _report_timer->unset();
 }
@@ -1627,7 +1627,7 @@ void SensorInterrupt::onInterrupt() {
   // read the value of the pin
   int value = _node->getLastInterruptValue();
   // process the value
-  if ( (_mode == RISING && value == HIGH ) || (_mode == FALLING && value == LOW) || (_mode == CHANGE) )  {
+  if ( (_interrupt_mode == RISING && value == HIGH ) || (_interrupt_mode == FALLING && value == LOW) || (_interrupt_mode == CHANGE) )  {
     // invert the value if Active State is set to LOW
     if (_active_state == LOW) value = !value;
     #if FEATURE_DEBUG == ON
@@ -4187,16 +4187,15 @@ void SensorConfiguration::onReceive(MyMessage* message) {
         }
       }
       #endif
-      #ifdef USE_SWITCH
+      #ifdef USE_INTERRUPT
       if (strcmp(sensor->getName(),"INTERRUPT") == 0 || strcmp(sensor->getName(),"DOOR") == 0 || strcmp(sensor->getName(),"MOTION") == 0) {
         SensorInterrupt* custom_sensor = (SensorInterrupt*)sensor;
         switch(function) {
-          case 101: custom_sensor->setMode(request.getValueInt()); break;
+          case 101: custom_sensor->setInterruptMode(request.getValueInt()); break;
           case 103: custom_sensor->setTriggerTime(request.getValueInt()); break;
           case 104: custom_sensor->setInitial(request.getValueInt()); break;
           case 105: custom_sensor->setActiveState(request.getValueInt()); break;
           case 106: custom_sensor->setArmed(request.getValueInt()); break;
-          case 107: custom_sensor->setThreshold(request.getValueInt()); break;
           default: return;
         }
       }

--- a/README.md
+++ b/README.md
@@ -481,7 +481,7 @@ Each sensor class exposes additional methods.
     void setOffset(int value);
 ~~~
 
-* SensorDigitalOutput / SensorRelay
+* SensorDigitalOutput / SensorRelay / SensorLatchingRelay
 ~~~c
     // [104] when legacy mode is enabled expect a REQ message to trigger, otherwise the default SET (default: false)
     void setLegacyMode(bool value);
@@ -493,18 +493,14 @@ Each sensor class exposes additional methods.
     void setWaitAfterSet(int value);
     // [108] when switching on, turns the output off after the given number of milliseconds. For latching relay controls the pulse width (default: 0)
     void setPulseWidth(int value);
-    // manually switch the output to the provided value
+    // [109] Invert the value to write. E.g. if ON is received, write LOW (default: false) 
+    void setInvertValueToWrite(bool value);
+    // [110] for a 2-pins latching relay, set the pin which turns the relay off (default: -1)
+    void setPinOff(int value);
+    // manually switch the output to the provided status (ON or OFF)
     void setStatus(int value);
     // toggle the status
     void toggleStatus(int value);
-~~~
-
-* SensorLatchingRelay (in addition to those available for SensorDigitalOutput / SensorRelay)
-~~~c
-    // [202] set the pin which turns the relay off (default: the pin provided while registering the sensor)
-    void setPinOff(int value);
-    // [203] set the pin which turns the relay on (default: the pin provided while registering the sensor + 1)
-    void setPinOn(int value);
 ~~~
 
 *  SensorInterrupt / SensorDoor / SensorMotion

--- a/README.md
+++ b/README.md
@@ -31,58 +31,59 @@ To use a buil-in sensor:
 Once created, the sensor will automatically present one or more child to the gateway and controller.
 A list of buil-in sensors, module to enable, required dependencies and the number of child automatically created is presented below:
 
-Sensor Name         |#Child | Module to enable   | Description                                                                                       | Dependencies
---------------------|-------|--------------------|---------------------------------------------------------------------------------------------------|----------------------------------------------------------
-SensorBattery       | 1     | USE_BATTERY        | Built-in sensor for automatic battery reporting                                                   | - 
-SensorSignal        | 1     | USE_SIGNAL         | Built-in sensor for automatic signal level reporting                                              | -
-SensorConfiguration | 1     | USE_CONFIGURATION  | Built-in sensor for OTA remote configuration of any registered sensor                             | -
-SensorAnalogInput   | 1     | USE_ANALOG_INPUT   | Generic analog sensor, return a pin's analog value or its percentage                              | -
-SensorLDR           | 1     | USE_ANALOG_INPUT   | LDR sensor, return the light level of an attached light resistor in percentage                    | -
-SensorRain          | 1     | USE_ANALOG_INPUT   | Rain sensor, return the percentage of rain from an attached analog sensor                         | -
-SensorSoilMoisture  | 1     | USE_ANALOG_INPUT   | Soil moisture sensor, return the percentage of moisture from an attached analog sensor            | -
-SensorThermistor    | 1     | USE_THERMISTOR     | Thermistor sensor, return the temperature based on the attached thermistor                        | -
-SensorML8511        | 1     | USE_ML8511         | ML8511 sensor, return UV intensity                                                                | -
-SensorACS712        | 1     | USE_ACS712         | ACS712 sensor, measure the current going through the attached module                              | -
-SensorDigitalInput  | 1     | USE_DIGITAL_INPUT  | Generic digital sensor, return a pin's digital value                                              | -
-SensorDigitalOutput | 1     | USE_DIGITAL_OUTPUT | Generic digital output sensor, allows setting the digital output of a pin to the requested value  | -
-SensorRelay         | 1     | USE_DIGITAL_OUTPUT | Relay sensor, allows activating the relay                                                         | -
-SensorLatchingRelay | 1     | USE_DIGITAL_OUTPUT | Latching Relay sensor, allows activating the relay with a pulse                                   | -
-SensorDHT11         | 2     | USE_DHT            | DHT11 sensor, return temperature/humidity based on the attached DHT sensor                        | https://github.com/mysensors/MySensorsArduinoExamples/tree/master/libraries/DHT
-SensorDHT22         | 2     | USE_DHT            | DHT22 sensor, return temperature/humidity based on the attached DHT sensor                        | https://github.com/mysensors/MySensorsArduinoExamples/tree/master/libraries/DHT
-SensorSHT21         | 2     | USE_SHT21          | SHT21 sensor, return temperature/humidity based on the attached SHT21 sensor                      | https://github.com/SodaqMoja/Sodaq_SHT2x
-SensorHTU21D        | 2     | USE_SHT21          | HTU21D sensor, return temperature/humidity based on the attached HTU21D sensor                    | https://github.com/SodaqMoja/Sodaq_SHT2x
-SensorInterrupt     | 1     | USE_INTERRUPT      | Generic interrupt-based sensor, wake up the board when a pin changes status                       | -
-SensorDoor          | 1     | USE_INTERRUPT      | Door sensor, wake up the board and report when an attached magnetic sensor has been opened/closed | -
-SensorMotion        | 1     | USE_INTERRUPT      | Motion sensor, wake up the board and report when an attached PIR has triggered                    | -
-SensorDs18b20       | 1+    | USE_DS18B20        | DS18B20 sensor, return the temperature based on the attached sensor                               | https://github.com/milesburton/Arduino-Temperature-Control-Library
-SensorBH1750        | 1     | USE_BH1750         | BH1750 sensor, return light level in lux                                                          | https://github.com/claws/BH1750
-SensorMLX90614      | 2     | USE_MLX90614       | MLX90614 contactless temperature sensor, return ambient and object temperature                    | https://github.com/adafruit/Adafruit-MLX90614-Library
-SensorBME280        | 4     | USE_BME280         | BME280 sensor, return temperature/humidity/pressure based on the attached BME280 sensor           | https://github.com/adafruit/Adafruit_BME280_Library
-SensorBMP085        | 3     | USE_BMP085         | BMP085/BMP180 sensor, return temperature and pressure                                             | https://github.com/adafruit/Adafruit-BMP085-Library
-SensorBMP280        | 3     | USE_BMP280         | BMP280 sensor, return temperature/pressure based on the attached BMP280 sensor                    | https://github.com/adafruit/Adafruit_BMP280_Library
-SensorSonoff        | 1     | USE_SONOFF         | Sonoff wireless smart switch                                                                      | https://github.com/thomasfredericks/Bounce2
-SensorHCSR04        | 1     | USE_HCSR04         | HC-SR04 sensor, return the distance between the sensor and an object                              | https://github.com/mysensors/MySensorsArduinoExamples/tree/master/libraries/NewPing
-SensorMCP9808       | 1     | USE_MCP9808        | MCP9808 sensor, measure the temperature through the attached module                               | https://github.com/adafruit/Adafruit_MCP9808_Library
-SensorMQ            | 1     | USE_MQ             | MQ sensor, return ppm of the target gas                                                           | -
-SensorMHZ19         | 1     | USE_MHZ19          | MH-Z19 CO2 sensor via UART (SoftwareSerial, default on pins 6(Rx) and 7(Tx)                       | -
-SensorAM2320        | 2     | USE_AM2320         | AM2320 sensors, return temperature/humidity based on the attached AM2320 sensor                   | https://github.com/thakshak/AM2320
-SensorTSL2561       | 1     | USE_TSL2561        | TSL2561 sensor, return light in lux                                                               | https://github.com/adafruit/TSL2561-Arduino-Library
-SensorPT100         | 1     | USE_PT100          | DFRobot Driver high temperature sensor, return the temperature from the attached PT100 sensor     | -
-SensorDimmer        | 1     | USE_DIMMER         | Generic dimmer sensor used to drive a pwm output                                                  | -
-SensorRainGauge     | 1     | USE_PULSE_METER    | Rain gauge sensor                                                                                 | -
-SensorPowerMeter    | 1     | USE_PULSE_METER    | Power meter pulse sensor                                                                          | -
-SensorWaterMeter    | 1     | USE_PULSE_METER    | Water meter pulse sensor                                                                          | -
-SensorPlantowerPMS  | 3     | USE_PMS            | Plantower PMS particulate matter sensors (reporting PM<=1.0, PM<=2.5 and PM<=10.0 in µg/m³)       | https://github.com/fu-hsi/pms
-SensorVL53L0X       | 1     | USE_VL53L0X        | VL53L0X laser time-of-flight distance sensor via I²C, sleep pin supported (optional)              | https://github.com/pololu/vl53l0x-arduino
-DisplaySSD1306      | 1     | USE_SSD1306        | SSD1306 128x64 OLED display (I²C); By default displays values of all sensors and children         | https://github.com/greiman/SSD1306Ascii.git
-SensorSHT31         | 2     | USE_SHT31          | SHT31 sensor, return temperature/humidity based on the attached SHT31 sensor                      | https://github.com/adafruit/Adafruit_SHT31
-SensorSI7021        | 2     | USE_SI7021         | SI7021 sensor, return temperature/humidity based on the attached SI7021 sensor                    | https://github.com/sparkfun/SparkFun_Si701_Breakout_Arduino_Library
-SensorChirp         | 3     | USE_CHIRP          | Chirp soil moisture sensor (includes temperature and light sensors)                               |  https://github.com/Apollon77/I2CSoilMoistureSensor
-DisplayHD44780      | 1     | USE_HD44780        | Supports most Hitachi HD44780 based LCDs, by default displays values of all sensors and children  | https://github.com/cyberang3l/NewLiquidCrystal
-SensorTTP           | 1     | USE_TTP            | TTP226/TTP229 Touch control sensor                                                                | -
-SensorServo         | 1     | USE_SERVO          | Control a generic Servo motor sensor                                                              | -
-SensorAPDS9960      | 1     | USE_APDS9960       | SparkFun RGB and Gesture Sensor                                                                   | https://github.com/sparkfun/APDS-9960_RGB_and_Gesture_Sensor
-SensorNeopixel      | 1     | USE_NEOPIXEL       | Control a Neopixel LED                                                                            | https://github.com/adafruit/Adafruit_NeoPixel
+Sensor Name              |#Child | Module to enable   | Description                                                                                       | Dependencies
+-------------------------|-------|--------------------|---------------------------------------------------------------------------------------------------|----------------------------------------------------------
+SensorBattery            | 1     | USE_BATTERY        | Built-in sensor for automatic battery reporting                                                   | - 
+SensorSignal             | 1     | USE_SIGNAL         | Built-in sensor for automatic signal level reporting                                              | -
+SensorConfiguration      | 1     | USE_CONFIGURATION  | Built-in sensor for OTA remote configuration of any registered sensor                             | -
+SensorAnalogInput        | 1     | USE_ANALOG_INPUT   | Generic analog sensor, return a pin's analog value or its percentage                              | -
+SensorLDR                | 1     | USE_ANALOG_INPUT   | LDR sensor, return the light level of an attached light resistor in percentage                    | -
+SensorRain               | 1     | USE_ANALOG_INPUT   | Rain sensor, return the percentage of rain from an attached analog sensor                         | -
+SensorSoilMoisture       | 1     | USE_ANALOG_INPUT   | Soil moisture sensor, return the percentage of moisture from an attached analog sensor            | -
+SensorThermistor         | 1     | USE_THERMISTOR     | Thermistor sensor, return the temperature based on the attached thermistor                        | -
+SensorML8511             | 1     | USE_ML8511         | ML8511 sensor, return UV intensity                                                                | -
+SensorACS712             | 1     | USE_ACS712         | ACS712 sensor, measure the current going through the attached module                              | -
+SensorDigitalInput       | 1     | USE_DIGITAL_INPUT  | Generic digital sensor, return a pin's digital value                                              | -
+SensorDigitalOutput      | 1     | USE_DIGITAL_OUTPUT | Generic digital output sensor, allows setting the digital output of a pin to the requested value  | -
+SensorRelay              | 1     | USE_DIGITAL_OUTPUT | Relay sensor, allows activating the relay                                                         | -
+SensorLatchingRelay1Pin  | 1     | USE_DIGITAL_OUTPUT | Latching Relay sensor, allows toggling the relay with a pulse on the configured pin               | -
+SensorLatchingRelay2Pins | 1     | USE_DIGITAL_OUTPUT | Latching Relay sensor, allows turing the relay on and off with a pulse on the configured pins     | -
+SensorDHT11              | 2     | USE_DHT            | DHT11 sensor, return temperature/humidity based on the attached DHT sensor                        | https://github.com/mysensors/MySensorsArduinoExamples/tree/master/libraries/DHT
+SensorDHT22              | 2     | USE_DHT            | DHT22 sensor, return temperature/humidity based on the attached DHT sensor                        | https://github.com/mysensors/MySensorsArduinoExamples/tree/master/libraries/DHT
+SensorSHT21              | 2     | USE_SHT21          | SHT21 sensor, return temperature/humidity based on the attached SHT21 sensor                      | https://github.com/SodaqMoja/Sodaq_SHT2x
+SensorHTU21D             | 2     | USE_SHT21          | HTU21D sensor, return temperature/humidity based on the attached HTU21D sensor                    | https://github.com/SodaqMoja/Sodaq_SHT2x
+SensorInterrupt          | 1     | USE_INTERRUPT      | Generic interrupt-based sensor, wake up the board when a pin changes status                       | -
+SensorDoor               | 1     | USE_INTERRUPT      | Door sensor, wake up the board and report when an attached magnetic sensor has been opened/closed | -
+SensorMotion             | 1     | USE_INTERRUPT      | Motion sensor, wake up the board and report when an attached PIR has triggered                    | -
+SensorDs18b20            | 1+    | USE_DS18B20        | DS18B20 sensor, return the temperature based on the attached sensor                               | https://github.com/milesburton/Arduino-Temperature-Control-Library
+SensorBH1750             | 1     | USE_BH1750         | BH1750 sensor, return light level in lux                                                          | https://github.com/claws/BH1750
+SensorMLX90614           | 2     | USE_MLX90614       | MLX90614 contactless temperature sensor, return ambient and object temperature                    | https://github.com/adafruit/Adafruit-MLX90614-Library
+SensorBME280             | 4     | USE_BME280         | BME280 sensor, return temperature/humidity/pressure based on the attached BME280 sensor           | https://github.com/adafruit/Adafruit_BME280_Library
+SensorBMP085             | 3     | USE_BMP085         | BMP085/BMP180 sensor, return temperature and pressure                                             | https://github.com/adafruit/Adafruit-BMP085-Library
+SensorBMP280             | 3     | USE_BMP280         | BMP280 sensor, return temperature/pressure based on the attached BMP280 sensor                    | https://github.com/adafruit/Adafruit_BMP280_Library
+SensorSonoff             | 1     | USE_SONOFF         | Sonoff wireless smart switch                                                                      | https://github.com/thomasfredericks/Bounce2
+SensorHCSR04             | 1     | USE_HCSR04         | HC-SR04 sensor, return the distance between the sensor and an object                              | https://github.com/mysensors/MySensorsArduinoExamples/tree/master/libraries/NewPing
+SensorMCP9808            | 1     | USE_MCP9808        | MCP9808 sensor, measure the temperature through the attached module                               | https://github.com/adafruit/Adafruit_MCP9808_Library
+SensorMQ                 | 1     | USE_MQ             | MQ sensor, return ppm of the target gas                                                           | -
+SensorMHZ19              | 1     | USE_MHZ19          | MH-Z19 CO2 sensor via UART (SoftwareSerial, default on pins 6(Rx) and 7(Tx)                       | -
+SensorAM2320             | 2     | USE_AM2320         | AM2320 sensors, return temperature/humidity based on the attached AM2320 sensor                   | https://github.com/thakshak/AM2320
+SensorTSL2561            | 1     | USE_TSL2561        | TSL2561 sensor, return light in lux                                                               | https://github.com/adafruit/TSL2561-Arduino-Library
+SensorPT100              | 1     | USE_PT100          | DFRobot Driver high temperature sensor, return the temperature from the attached PT100 sensor     | -
+SensorDimmer             | 1     | USE_DIMMER         | Generic dimmer sensor used to drive a pwm output                                                  | -
+SensorRainGauge          | 1     | USE_PULSE_METER    | Rain gauge sensor                                                                                 | -
+SensorPowerMeter         | 1     | USE_PULSE_METER    | Power meter pulse sensor                                                                          | -
+SensorWaterMeter         | 1     | USE_PULSE_METER    | Water meter pulse sensor                                                                          | -
+SensorPlantowerPMS       | 3     | USE_PMS            | Plantower PMS particulate matter sensors (reporting PM<=1.0, PM<=2.5 and PM<=10.0 in µg/m³)       | https://github.com/fu-hsi/pms
+SensorVL53L0X            | 1     | USE_VL53L0X        | VL53L0X laser time-of-flight distance sensor via I²C, sleep pin supported (optional)              | https://github.com/pololu/vl53l0x-arduino
+DisplaySSD1306           | 1     | USE_SSD1306        | SSD1306 128x64 OLED display (I²C); By default displays values of all sensors and children         | https://github.com/greiman/SSD1306Ascii.git
+SensorSHT31              | 2     | USE_SHT31          | SHT31 sensor, return temperature/humidity based on the attached SHT31 sensor                      | https://github.com/adafruit/Adafruit_SHT31
+SensorSI7021             | 2     | USE_SI7021         | SI7021 sensor, return temperature/humidity based on the attached SI7021 sensor                    | https://github.com/sparkfun/SparkFun_Si701_Breakout_Arduino_Library
+SensorChirp              | 3     | USE_CHIRP          | Chirp soil moisture sensor (includes temperature and light sensors)                               | https://github.com/Apollon77/I2CSoilMoistureSensor
+DisplayHD44780           | 1     | USE_HD44780        | Supports most Hitachi HD44780 based LCDs, by default displays values of all sensors and children  | https://github.com/cyberang3l/NewLiquidCrystal
+SensorTTP                | 1     | USE_TTP            | TTP226/TTP229 Touch control sensor                                                                | -
+SensorServo              | 1     | USE_SERVO          | Control a generic Servo motor sensor                                                              | -
+SensorAPDS9960           | 1     | USE_APDS9960       | SparkFun RGB and Gesture Sensor                                                                   | https://github.com/sparkfun/APDS-9960_RGB_and_Gesture_Sensor
+SensorNeopixel           | 1     | USE_NEOPIXEL       | Control a Neopixel LED                                                                            | https://github.com/adafruit/Adafruit_NeoPixel
 
 ### Built-in features
 
@@ -345,7 +346,7 @@ The following methods are available for all the sensors:
     void setSamples(int value);
     // [6] If more then one sample has to be taken, set the interval in milliseconds between measurements (default: 0)
     void setSamplesInterval(int value);
-#if FEATURE_TRACK_LAST_VALUE == ON
+#if FEATURE_CONDITIONAL_REPORT == ON
     // [7] if true will report the measure only if different than the previous one (default: false)
     void setTrackLastValue(bool value);
     // [9] if track last value is enabled, force to send an update after the configured number of minutes
@@ -407,16 +408,27 @@ The following methods are available for all the sensors:
 The following methods are available for all the child:
 ~~~c
     Child(Sensor* sensor, int child_id, int presentation, int type, const char* description = "");
+    // child id used to communicate with the gateway/controller
     int child_id;
+    // Sensor presentation (default: S_CUSTOM)
     int presentation = S_CUSTOM;
+    // Sensor type (default: V_CUSTOM)
     int type = V_CUSTOM;
+    // how many decimal digits to use (default: 2 for ChildFloat, 4 for ChildDouble)
+    int float_precision;
+    // Sensor description
     const char* description = "";
+    // send the current value to the gateway
     virtual void sendValue();
+    // print the current value on a LCD display
     virtual void printOn(Print& p);
 #if FEATURE_CONDITIONAL_REPORT == ON
     Timer* force_update_timer;
+    // return true if the current value is new/different compared to the previous one
     virtual bool isNewValue();
+    // minimum threshold for reporting the value to the controller
     float min_threshold = FLT_MIN;
+    // maximum threshold for reporting the value to the controller
     float max_threshold = FLT_MAX;
 #endif
 ~~~
@@ -481,7 +493,7 @@ Each sensor class exposes additional methods.
     void setOffset(int value);
 ~~~
 
-* SensorDigitalOutput / SensorRelay / SensorLatchingRelay
+* SensorDigitalOutput / SensorRelay / SensorLatchingRelay1Pin / SensorLatchingRelay2Pins
 ~~~c
     // [104] when legacy mode is enabled expect a REQ message to trigger, otherwise the default SET (default: false)
     void setLegacyMode(bool value);
@@ -1002,7 +1014,7 @@ void receiveTime(unsigned long ts) {
 
 * Boiler Sensor
 
-The following sketch controls a latching relay connected to a boiler. A latching relay (requiring only a pulse to switch) has been chosen to minimize the power consumption required by a traditional relay to stay on. This relay has normally two pins, one for closing and the other for opening the controlled circuit, connected to pin 6 and 7 of the arduino board. Since using a SensorLatchingRelay type of sensor, NodeManager will automatically consider the provided pin as the ON pin and the one just after as the OFF pin and will take care of just sending out a single pulse only when a SET command of type V_STATUS is sent to the child id. The appropriate pin will be then used.
+The following sketch controls a latching relay connected to a boiler. A latching relay (requiring only a pulse to switch) has been chosen to minimize the power consumption required by a traditional relay to stay on. This relay has normally two pins, one for closing and the other for opening the controlled circuit, connected to pin 6 (off) and 7 (on) of the arduino board. Since using a SensorLatchingRelay2Pins type of sensor, NodeManager will automatically consider the provided pin as the ON pin and the one just after as the OFF pin and will take care of just sending out a single pulse only when a SET command of type V_STATUS is sent to the child id. The appropriate pin will be then used.
 
 In this example, the board also runs at 1Mhz so it can go down to 1.8V: by setting setBatteryMin() and setBatteryMax(), the battery percentage will be calculated and reported (by default, automatically every hour) based on these custom boundaries.
 
@@ -1042,7 +1054,7 @@ NodeManager node;
  */
 
 SensorBattery battery(node);
-SensorLatchingRelay latching(node,6);
+SensorLatchingRelay2Pin latching2pins(node,6,7);
 
 /***********************************
  * Main Sketch
@@ -1262,6 +1274,7 @@ v1.7:
 * SensorPulseMeter now supports running on batteries
 * SensorDs18B20 optimized and now supporting V_ID
 * SensorSwitch (now renamed into SensorInterrupt) now catches interrupt in a more reliable way
+* SensorLatchingRelay now specialized and renamed into SensorLatchingRelay1Pin and SensorLatchingRelay2Pins
 * Added support for HD44780 i2c LCD
 * Added support for MG996R Servo sensor
 * Added support for VL53L0X laser time-of-flight distance sensor

--- a/README.md
+++ b/README.md
@@ -513,10 +513,10 @@ Each sensor class exposes additional methods.
 ~~~c
     // [101] set the interrupt mode. Can be CHANGE, RISING, FALLING (default: CHANGE)
     void setInterruptMode(int value);
-    // [103] time to wait in milliseconds after a change is detected to allow the signal to be restored to its normal value (default: 0)
-    void setTriggerTime(int value);
-    // [104] Set initial value on the interrupt pin (default: HIGH)
-    void setInitial(int value);
+    // [103] milliseconds to wait/sleep after the interrupt before reporting (default: 0)
+    void setWaitAfterTrigger(int value);
+    // [104] Set initial value on the interrupt pin. Can be used for internal pull up (default: HIGH)
+    void setInitialValue(int value);
     // [105] Set active state (default: HIGH) 
     void setActiveState(int value);    
     // [106] Set armed, if false the sensor will not trigger until armed (default: true) 
@@ -631,14 +631,16 @@ Each sensor class exposes additional methods.
     void setPercentage(int value);
 ~~~
 
-* SensorRainGauge / SensorPowerMeter / SensorWaterMeter
+* SensorPulseMeter / SensorRainGauge / SensorPowerMeter / SensorWaterMeter
 ~~~c
     // [102] set how many pulses for each unit (e.g. 1000 pulses for 1 kwh of power, 9 pulses for 1 mm of rain, etc.)
     void setPulseFactor(float value);
-    // set initial value - internal pull up (default: HIGH)
+    // Set initial value on the interrupt pin. Can be used for internal pull up (default: HIGH)
     void setInitialValue(int value);
     // set the interrupt mode. Can be CHANGE, RISING, FALLING (default: FALLING)
     void setInterruptMode(int value);
+    // milliseconds to wait/sleep after the interrupt before reporting (default: 0)
+    void setWaitAfterTrigger(int value);
 ~~~
 
 * DisplaySSD1306

--- a/README.md
+++ b/README.md
@@ -512,7 +512,7 @@ Each sensor class exposes additional methods.
 *  SensorInterrupt / SensorDoor / SensorMotion
 ~~~c
     // [101] set the interrupt mode. Can be CHANGE, RISING, FALLING (default: CHANGE)
-    void setMode(int value);
+    void setInterruptMode(int value);
     // [103] time to wait in milliseconds after a change is detected to allow the signal to be restored to its normal value (default: 0)
     void setTriggerTime(int value);
     // [104] Set initial value on the interrupt pin (default: HIGH)
@@ -637,7 +637,7 @@ Each sensor class exposes additional methods.
     void setPulseFactor(float value);
     // set initial value - internal pull up (default: HIGH)
     void setInitialValue(int value);
-    // set the interrupt mode to attach to (default: FALLING)
+    // set the interrupt mode. Can be CHANGE, RISING, FALLING (default: FALLING)
     void setInterruptMode(int value);
 ~~~
 

--- a/README.md
+++ b/README.md
@@ -483,8 +483,6 @@ Each sensor class exposes additional methods.
 
 * SensorDigitalOutput / SensorRelay
 ~~~c
-    // [103] define which value to set to the output when set to on (default: HIGH)
-    void setOnValue(int value);
     // [104] when legacy mode is enabled expect a REQ message to trigger, otherwise the default SET (default: false)
     void setLegacyMode(bool value);
     // [105] automatically turn the output off after the given number of minutes
@@ -517,8 +515,8 @@ Each sensor class exposes additional methods.
     void setWaitAfterTrigger(int value);
     // [104] Set initial value on the interrupt pin. Can be used for internal pull up (default: HIGH)
     void setInitialValue(int value);
-    // [105] Set active state (default: HIGH) 
-    void setActiveState(int value);    
+    // [105] Invert the value to report. E.g. if FALLING and value is LOW, report HIGH (default: false) 
+    void setInvertValueToReport(bool value);
     // [106] Set armed, if false the sensor will not trigger until armed (default: true) 
     void setArmed(bool value);
 #if FEATURE_TIME == ON


### PR DESCRIPTION
This PR fixes some naming convention issues and specifically:
* Renamed `setMode()` into `setInterruptMode()` in SensorInterrupt (same as SensorPulseMeter)
* Renamed `setInitial()` into `setInitialValue()` in SensorInterrupt (same as SensorPulseMeter)
* Renamed `setTriggerTime()` into `setWaitAfterTrigger()` in SensorInterrupt 
* Added `setWaitAfterTrigger()` to SensorPulseMeter
* Renamed `setActiveState()` into `setInvertValueToReport()` in SensorInterrupt 
* Added `setInvertValueToReport()` to SensorPulseMeter
* Renamed `setOnValue()` into `setInvertValueToWrite()` in SensorDigitalOutput

The PR also reviews SensorDigitalOutput internal logic:
* Moved `setPinOff()` from SensorLatchingRelay to SensorDigitalOutput. 
* Merged `_switchOutput()` from SensorLatchingRelay into SensorDigitalOutput
* Set the output off upon startup/reboot (useful as an emergency safeguard to turn a relay off)
* Replaced SensorLatchingRelay with SensorLatchingRelay1Pin and SensorLatchingRelay2Pins. The latter sets the off pin in additional to the pulse width

**Examples with SensorDigitalOutput only:**
* Standard Relay: no configuration needed
* Standard Relay activated with LOW signal: 
```
digitalOutput.setInvertValueToWrite(true);
```
* Buzzer: like a standard relay. If a single sounds has to be emitted for e.g. 3s: 
```
digitalOutput.setPulseWidth(3000);
```
* Latching relay (1 pin) - equivalent to SensorLatchingRelay1Pin: 
```
digitalOutput.setPulseWidth(50);
```
* Latching relay (1 pin) triggered with LOW signal (fixes #332): 
```
digitalOutput.setPulseWidth(50);
digitalOutput.setInvertValueToWrite(true);
```
* Latching relay (2 pins) - equivalent to SensorLatchingRelay2Pins: 
```
digitalOutput.setPinOff(7);
digitalOutput.setPulseWidth(50);
```
All of those are activated by sending a V_STATUS == 1, ON, regardless of setInvertValueToWrite().
SensorRelay is like SensorDigitalOutput with S_BINARY and V_STATUS set.