### PR TITLE
Child class review

### DIFF
--- a/NodeManager.ino
+++ b/NodeManager.ino
@@ -378,8 +378,9 @@ void before() {
   Serial.begin(MY_BAUD_RATE);
 
 node.setReportIntervalSeconds(5);
-//thermistor.children.get(1)->setValueDelta(5);
+thermistor.children.get(1)->setValueDelta(5);
 thermistor.children.get(1)->setFloatPrecision(1);
+thermistor.children.get(1)->setForceUpdateMinutes(1);
   
   /*
   * Configure your sensors below

--- a/NodeManager.ino
+++ b/NodeManager.ino
@@ -248,7 +248,7 @@ FEATURE_HOOKING             | OFF     | allow custom code to be hooked in the ou
 //#define USE_SIGNAL
 //#define USE_CONFIGURATION
 //#define USE_ANALOG_INPUT
-//#define USE_THERMISTOR
+#define USE_THERMISTOR
 //#define USE_ML8511
 //#define USE_ACS712
 //#define USE_DIGITAL_INPUT
@@ -292,7 +292,7 @@ FEATURE_HOOKING             | OFF     | allow custom code to be hooked in the ou
 #define FEATURE_DEBUG ON
 #define FEATURE_POWER_MANAGER OFF
 #define FEATURE_INTERRUPTS ON
-#define FEATURE_CONDITIONAL_REPORT OFF
+#define FEATURE_CONDITIONAL_REPORT ON
 #define FEATURE_EEPROM OFF
 #define FEATURE_SLEEP ON
 #define FEATURE_RECEIVE ON
@@ -323,7 +323,7 @@ NodeManager node;
 //SensorLDR ldr(node,A0);
 //SensorRain rain(node,A0);
 //SensorSoilMoisture soil(node,A0);
-//SensorThermistor thermistor(node,A0);
+SensorThermistor thermistor(node,A0);
 //SensorML8511 ml8511(node,A0);
 //SensorACS712 acs712(node,A0);
 //SensorDigitalInput digitalIn(node,6);
@@ -377,7 +377,9 @@ void before() {
   // setup the serial port baud rate
   Serial.begin(MY_BAUD_RATE);
 
-
+node.setReportIntervalSeconds(5);
+//thermistor.children.get(1)->setValueDelta(5);
+thermistor.children.get(1)->setFloatPrecision(1);
   
   /*
   * Configure your sensors below

--- a/NodeManager.ino
+++ b/NodeManager.ino
@@ -101,6 +101,8 @@ to save some storage for your code. To enable/disable a buil-in feature:
 * Install the required library if any
 * Enable the corresponding feature by setting it to ON in the main sketch. To 
 disable it, set it to OFF
+* When a feature is enabled additional functions may be made available. Have a look 
+at the API documentation for details
 
 A list of buil-in features and the required dependencies is presented below:
 
@@ -248,7 +250,7 @@ FEATURE_HOOKING             | OFF     | allow custom code to be hooked in the ou
 //#define USE_SIGNAL
 //#define USE_CONFIGURATION
 //#define USE_ANALOG_INPUT
-#define USE_THERMISTOR
+//#define USE_THERMISTOR
 //#define USE_ML8511
 //#define USE_ACS712
 //#define USE_DIGITAL_INPUT
@@ -292,7 +294,7 @@ FEATURE_HOOKING             | OFF     | allow custom code to be hooked in the ou
 #define FEATURE_DEBUG ON
 #define FEATURE_POWER_MANAGER OFF
 #define FEATURE_INTERRUPTS ON
-#define FEATURE_CONDITIONAL_REPORT ON
+#define FEATURE_CONDITIONAL_REPORT OFF
 #define FEATURE_EEPROM OFF
 #define FEATURE_SLEEP ON
 #define FEATURE_RECEIVE ON
@@ -323,7 +325,7 @@ NodeManager node;
 //SensorLDR ldr(node,A0);
 //SensorRain rain(node,A0);
 //SensorSoilMoisture soil(node,A0);
-SensorThermistor thermistor(node,A0);
+//SensorThermistor thermistor(node,A0);
 //SensorML8511 ml8511(node,A0);
 //SensorACS712 acs712(node,A0);
 //SensorDigitalInput digitalIn(node,6);
@@ -376,12 +378,6 @@ SensorThermistor thermistor(node,A0);
 void before() {
   // setup the serial port baud rate
   Serial.begin(MY_BAUD_RATE);
-
-node.setReportIntervalSeconds(5);
-thermistor.children.get(1)->setValueDelta(5);
-thermistor.children.get(1)->setFloatPrecision(1);
-thermistor.children.get(1)->setForceUpdateMinutes(1);
-  
   /*
   * Configure your sensors below
   */
@@ -401,7 +397,6 @@ thermistor.children.get(1)->setForceUpdateMinutes(1);
   //analog.children.get(1)->min_threshold = 40;
   // power all the nodes through dedicated pins
   //node.setPowerManager(power);
-  
   /*
   * Configure your sensors above
   */

--- a/NodeManagerLibrary.h
+++ b/NodeManagerLibrary.h
@@ -50,7 +50,6 @@
 #if defined (MYBOARDNRF5)
   #define CHIP_NRF5
 #endif
-
 #if !defined(CHIP_ESP8266) && !defined(CHIP_STM32) && !defined(CHIP_NRF5)
   #define CHIP_AVR
 #endif

--- a/NodeManagerLibrary.h
+++ b/NodeManagerLibrary.h
@@ -449,34 +449,50 @@ class Child {
   public:
     Child();
     Child(Sensor* sensor, int child_id, int presentation, int type, const char* description = "");
-    // child id used to communicate with the gateway/controller
-    int child_id;
-    // Sensor presentation (default: S_CUSTOM)
-    int presentation = S_CUSTOM;
-    // Sensor type (default: V_CUSTOM)
-    int type = V_CUSTOM;
-    // how many decimal digits to use (default: 2 for ChildFloat, 4 for ChildDouble)
-    int float_precision;
-    // Sensor description
-    const char* description = "";
-    // send the current value to the gateway
-    virtual void sendValue();
-    // print the current value on a LCD display
-    virtual void printOn(Print& p);
+    // set child id used to communicate with the gateway/controller
+    void setChildId(int value);
+    int getChildId();
+    // set sensor presentation (default: S_CUSTOM)
+    void setPresentation(int value);
+    int getPresentation();
+    // set sensor type (default: V_CUSTOM)
+    void setType(int value);
+    int getType();
+    // set how many decimal digits to use (default: 2 for ChildFloat, 4 for ChildDouble)
+    void setFloatPrecision(int value);
+    // set sensor description
+    void setDescription(const char* value);
+    const char* getDescription();
 #if FEATURE_CONDITIONAL_REPORT == ON
-    Timer* force_update_timer;
-    // return true if the current value is new/different compared to the previous one
-    virtual bool isNewValue();
-    // minimum threshold for reporting the value to the controller (default: FLT_MIN)
-    float min_threshold = FLT_MIN;
-    // maximum threshold for reporting the value to the controller (default: FLT_MAX)
-    float max_threshold = FLT_MAX;
-    // a value is considered new when is more or less this delta from the previous one (default: 0)
-    float new_value_delta = 0;
+    // force to send an update after the configured number of minutes
+    void setForceUpdateMinutes(int value);
+    // never report values below this threshold (default: FLT_MIN)
+    void setMinThreshold(float value);
+    // never report values above this threshold (default: FLT_MAX)
+    void setMaxThreshold(float value);
+    // do not report values if too close to the previous one (default: 0)
+    void setValueDelta(float value);
 #endif
+    // send the current value to the gateway
+    virtual void sendValue(bool force);
+    // print the current value on a LCD display
+    virtual void print(Print& device);
+    // reset all the counters
+    virtual void reset();
   protected:
     int _samples = 0;
     Sensor* _sensor;
+    int _child_id;
+    int _presentation = S_CUSTOM;
+    int _type = V_CUSTOM;
+    int _float_precision;
+    const char* _description = "";
+#if FEATURE_CONDITIONAL_REPORT == ON
+    Timer* _force_update_timer;
+    float _min_threshold = FLT_MIN;
+    float _max_threshold = FLT_MAX;
+    float _value_delta = 0;
+#endif
 };
 
 class ChildInt: public Child {
@@ -484,15 +500,13 @@ class ChildInt: public Child {
     ChildInt(Sensor* sensor, int child_id, int presentation, int type, const char* description = "");
     void setValueInt(int value);
     int getValueInt();
-    void sendValue();
-    void printOn(Print& p);
-#if FEATURE_CONDITIONAL_REPORT == ON
-    bool isNewValue();
-#endif
+    void sendValue(bool force);
+    void print(Print& device);
+    void reset();
   private:
     int _value;
 #if FEATURE_CONDITIONAL_REPORT == ON
-    int _last_value;
+    int _last_value = -256;
 #endif
     int _total = 0;
 };
@@ -502,15 +516,13 @@ class ChildFloat: public Child {
     ChildFloat(Sensor* sensor, int child_id, int presentation, int type, const char* description = "");
     void setValueFloat(float value);
     float getValueFloat();
-    void sendValue();
-    void printOn(Print& p);
-#if FEATURE_CONDITIONAL_REPORT == ON
-    bool isNewValue();
-#endif
+    void sendValue(bool force);
+    void print(Print& device);
+    void reset();
   private:
     float _value;
 #if FEATURE_CONDITIONAL_REPORT == ON
-    float _last_value;
+    float _last_value = -256;
 #endif
     float _total = 0;
 };
@@ -520,15 +532,13 @@ class ChildDouble: public Child {
     ChildDouble(Sensor* sensor, int child_id, int presentation, int type, const char* description = "");
     void setValueDouble(double value);
     double getValueDouble();
-    void sendValue();
-    void printOn(Print& p);
-#if FEATURE_CONDITIONAL_REPORT == ON
-    bool isNewValue();
-#endif
+    void sendValue(bool force);
+    void print(Print& device);
+    void reset();
   private:
     double _value;
 #if FEATURE_CONDITIONAL_REPORT == ON
-    double _last_value;
+    double _last_value = -256;
 #endif
     double _total = 0;
 };
@@ -538,11 +548,9 @@ class ChildString: public Child {
     ChildString(Sensor* sensor, int child_id, int presentation, int type, const char* description = "");
     void setValueString(const char* value);
     const char* getValueString();
-    void sendValue();
-    void printOn(Print& p);
-#if FEATURE_CONDITIONAL_REPORT == ON
-    bool isNewValue();
-#endif
+    void sendValue(bool force);
+    void print(Print& device);
+    void reset();
   private:
     const char* _value = "";
 #if FEATURE_CONDITIONAL_REPORT == ON
@@ -567,12 +575,6 @@ class Sensor {
     void setSamples(int value);
     // [6] If more then one sample has to be taken, set the interval in milliseconds between measurements (default: 0)
     void setSamplesInterval(int value);
-#if FEATURE_CONDITIONAL_REPORT == ON
-    // [7] if true will report the measure only if different than the previous one (default: false)
-    void setTrackLastValue(bool value);
-    // [9] if track last value is enabled, force to send an update after the configured number of minutes
-    void setForceUpdateMinutes(int value);
-#endif
 #if FEATURE_POWER_MANAGER == ON
     // to save battery the sensor can be optionally connected to two pins which will act as vcc and ground and activated on demand
     void setPowerPins(int ground_pin, int vcc_pin, int wait_time = 50);
@@ -641,9 +643,6 @@ class Sensor {
     int _pin = -1;
     int _samples = 1;
     int _samples_interval = 0;
-#if FEATURE_CONDITIONAL_REPORT == ON
-    bool _track_last_value = false;
-#endif
 #if FEATURE_INTERRUPTS == ON
     int _interrupt_pin = -1;
 #endif

--- a/NodeManagerLibrary.h
+++ b/NodeManagerLibrary.h
@@ -467,10 +467,12 @@ class Child {
     Timer* force_update_timer;
     // return true if the current value is new/different compared to the previous one
     virtual bool isNewValue();
-    // minimum threshold for reporting the value to the controller
+    // minimum threshold for reporting the value to the controller (default: FLT_MIN)
     float min_threshold = FLT_MIN;
-    // maximum threshold for reporting the value to the controller
+    // maximum threshold for reporting the value to the controller (default: FLT_MAX)
     float max_threshold = FLT_MAX;
+    // a value is considered new when is more or less this delta from the previous one (default: 0)
+    float new_value_delta = 0;
 #endif
   protected:
     int _samples = 0;

--- a/NodeManagerLibrary.ino
+++ b/NodeManagerLibrary.ino
@@ -379,6 +379,8 @@ void ChildFloat::setValueFloat(float value) {
   _samples++;
   // averages the values
   _value = _total / _samples;
+  // round the value if float precision has been customized
+  if (_float_precision != 2) _value = float((int) (_value * (_float_precision*10))) / (_float_precision*10);
 }
 
 // return the value
@@ -400,10 +402,6 @@ void ChildFloat::sendValue(bool force) {
       _force_update_timer->restart();
     } else {
       // if the value does not differ enough from the previous one, do not send the value
-      Serial.println(_value);
-      Serial.println(_last_value);
-      Serial.println((_last_value - _value_delta));
-      Serial.println((_last_value + _value_delta));
       if (_value > (_last_value - _value_delta) && _value < (_last_value + _value_delta)) {
         // keep track of the previous value
         _last_value = _value;
@@ -445,6 +443,8 @@ void ChildDouble::setValueDouble(double value) {
   _samples++;
   // averages the values
   _value = _total / _samples;
+  // round the value if float precision has been customized
+  if (_float_precision != 4) _value = double((int) (_value * (_float_precision*10))) / (_float_precision*10);
 }
 
 // return the value


### PR DESCRIPTION
This PR reviews some aspects of the Child class:
* Added setter/getter for all Child's variables (e.g. `setChildId(), setPresentation(), getChildId()`, etc.)
* Deprecated `Sensor::setTrackLastValue() `and `Sensor::setForceUpdateMinutes()` since the logic has been moved into Child
* Deprecated `Child::isNewValue()`, the comparison taking into account the delta now happens in `Child::sendValue()`
* Added `setValueDelta()` which replaces `setTrackLastValue()` with a configurable delta (fixes #334). For ChildString, if the value delta is set, regardless of the value, only new strings will be sent
* Renamed `printOn()` into `print()`
* Moved `force_update_timer `into Child and added `setForceUpdateMinutes()` to it. Timer is now updated into `Child::sendValue()`. The timer is restarted when over which was not happening in the previous version so fixing a bug
* `sendValue()` now becomes `sendValue(bool force)`. Force will be used when receiving a message (e.g. not when executing loop()) to force the value to be sent back regardless of any conditional reporting setting
* ChildFloat and ChildDouble now takes into account the float precision set to round the value in `setValueFloat()` and `setValueDouble()`

Example:
```c
node.setReportIntervalSeconds(5);
// do not report if the temperature does not differ at least by 0.5 degree
thermistor.children.get(1)->setValueDelta(0.5);
// set float precision to 1 (e.g. 21.6)
thermistor.children.get(1)->setFloatPrecision(1);
// send the temperature back to the controller after 1 minute, regardless
thermistor.children.get(1)->setForceUpdateMinutes(1);
```