### PR TITLE
Adding control for brightness to neopixel sensor

### DIFF
--- a/NodeManagerLibrary.h
+++ b/NodeManagerLibrary.h
@@ -1794,8 +1794,11 @@ class SensorNeopixel: public Sensor {
     SensorNeopixel(NodeManager& node_manager, int pin, int child_id = -255);
     // set how many NeoPixels are attached
     void setNumPixels(int value);
+    void setDefaultBrightness(int value);
     // format expeted is "<pixel_number>,<RGB color in a packed 32 bit format>"
     void setColor(char* string);
+    // set brightness of NeoPixels (0-255)
+    void setBrightness(int value);
     // define what to do at each stage of the sketch
     void onSetup();
     void onLoop(Child* child);
@@ -1807,6 +1810,7 @@ class SensorNeopixel: public Sensor {
   Adafruit_NeoPixel* _pixels;
 #endif
   int _num_pixels = 16;
+  int _default_brightness = 255;
 };
 #endif
 


### PR DESCRIPTION
Hi,
while updating mysensors to an new version i saw the NodeManager component and tried to rewrite some of my sketches. This tool allows me to configure the things much faster. Thank you for this great helper.
For the neopixel sensors i missed a functionality to control the brightness, so i added this on my own. Maybe this could be interesting to you.

 - Adding control for brightness to neopixel sensor
 - You can set a default brightness within the sketch
   with "sensor.setDefaultBrightness(intValue)"