### PR TITLE
MQ Sensor implementation review

### DIFF
--- a/NodeManager.ino
+++ b/NodeManager.ino
@@ -76,7 +76,7 @@ SensorBMP280             | 3     | USE_BMP280         | BMP280 sensor, return te
 SensorSonoff             | 1     | USE_SONOFF         | Sonoff wireless smart switch                                                                      | https://github.com/thomasfredericks/Bounce2
 SensorHCSR04             | 1     | USE_HCSR04         | HC-SR04 sensor, return the distance between the sensor and an object                              | https://github.com/mysensors/MySensorsArduinoExamples/tree/master/libraries/NewPing
 SensorMCP9808            | 1     | USE_MCP9808        | MCP9808 sensor, measure the temperature through the attached module                               | https://github.com/adafruit/Adafruit_MCP9808_Library
-SensorMQ                 | 1     | USE_MQ             | MQ sensor, return ppm of the target gas                                                           | -
+SensorMQ                 | 1     | USE_MQ             | MQ sensor, return ppm of the target gas. Tuned by default for MQ135 and CO2                       | -
 SensorMHZ19              | 1     | USE_MHZ19          | MH-Z19 CO2 sensor via UART (SoftwareSerial, default on pins 6(Rx) and 7(Tx)                       | -
 SensorAM2320             | 2     | USE_AM2320         | AM2320 sensors, return temperature/humidity based on the attached AM2320 sensor                   | https://github.com/thakshak/AM2320
 SensorTSL2561            | 1     | USE_TSL2561        | TSL2561 sensor, return light in lux                                                               | https://github.com/adafruit/TSL2561-Arduino-Library
@@ -252,7 +252,7 @@ FEATURE_HOOKING             | OFF     | allow custom code to be hooked in the ou
 
 //#define USE_BATTERY
 //#define USE_SIGNAL
-//#define USE_CONFIGURATION
+#define USE_CONFIGURATION
 //#define USE_ANALOG_INPUT
 //#define USE_THERMISTOR
 //#define USE_ML8511
@@ -271,7 +271,7 @@ FEATURE_HOOKING             | OFF     | allow custom code to be hooked in the ou
 //#define USE_SONOFF
 //#define USE_HCSR04
 //#define USE_MCP9808
-//#define USE_MQ
+#define USE_MQ
 //#define USE_MHZ19
 //#define USE_AM2320
 //#define USE_TSL2561
@@ -322,7 +322,7 @@ NodeManager node;
 
 // built-in sensors
 //SensorBattery battery(node);
-//SensorConfiguration configuration(node);
+SensorConfiguration configuration(node);
 //SensorSignal signal(node);
 //PowerManager power(5,6);
 
@@ -356,7 +356,7 @@ NodeManager node;
 //SensorSonoff sonoff(node);
 //SensorHCSR04 hcsr04(node,6);
 //SensorMCP9808 mcp9808(node);
-//SensorMQ mq(node,A0);
+SensorMQ mq(node,A0);
 //SensorMHZ19 mhz19(node,6,7);
 //SensorAM2320 am2320(node);
 //SensorTSL2561 tsl2561(node);

--- a/NodeManager.ino
+++ b/NodeManager.ino
@@ -252,7 +252,7 @@ FEATURE_HOOKING             | OFF     | allow custom code to be hooked in the ou
 
 //#define USE_BATTERY
 //#define USE_SIGNAL
-#define USE_CONFIGURATION
+//#define USE_CONFIGURATION
 //#define USE_ANALOG_INPUT
 //#define USE_THERMISTOR
 //#define USE_ML8511
@@ -271,7 +271,7 @@ FEATURE_HOOKING             | OFF     | allow custom code to be hooked in the ou
 //#define USE_SONOFF
 //#define USE_HCSR04
 //#define USE_MCP9808
-#define USE_MQ
+//#define USE_MQ
 //#define USE_MHZ19
 //#define USE_AM2320
 //#define USE_TSL2561
@@ -322,7 +322,7 @@ NodeManager node;
 
 // built-in sensors
 //SensorBattery battery(node);
-SensorConfiguration configuration(node);
+//SensorConfiguration configuration(node);
 //SensorSignal signal(node);
 //PowerManager power(5,6);
 
@@ -356,7 +356,7 @@ SensorConfiguration configuration(node);
 //SensorSonoff sonoff(node);
 //SensorHCSR04 hcsr04(node,6);
 //SensorMCP9808 mcp9808(node);
-SensorMQ mq(node,A0);
+//SensorMQ mq(node,A0);
 //SensorMHZ19 mhz19(node,6,7);
 //SensorAM2320 am2320(node);
 //SensorTSL2561 tsl2561(node);

--- a/NodeManagerLibrary.h
+++ b/NodeManagerLibrary.h
@@ -1304,6 +1304,8 @@ class SensorMQ: public Sensor {
     void setCurveScalingFactor(float value); 
     // [114] with ppm = scaling_factor*x^exponent set the value manually, otherwise will be calculated automatically based on the two points provided
     void setCurveExponent(float value); 
+    // do not report for the given number of minutes, waiting for the sensor to warm up (default: 0);
+    void setWarmupMinutes(int value);
     // define what to do at each stage of the sketch
     void onSetup();
     void onLoop(Child* child);
@@ -1316,6 +1318,7 @@ class SensorMQ: public Sensor {
     int _calibration_sample_interval = 500;
     int _sample_interval = 50;
     int _samples = 5;
+    unsigned long _warmup_minutes = 0;
     float _point1_ppm = 200;
     float _point1_ratio = 5;
     float _point2_ppm = 10000;

--- a/NodeManagerLibrary.h
+++ b/NodeManagerLibrary.h
@@ -1278,55 +1278,51 @@ class SensorMCP9808: public Sensor {
 class SensorMQ: public Sensor {
   public:
     SensorMQ(NodeManager& node_manager, int pin, int child_id = -255);
-    // [101] define the target gas whose ppm has to be returned. 0: LPG, 1: CO, 2: Smoke (default: 1);
-    void setTargetGas(int value);
-    // [102] define the load resistance on the board, in kilo ohms (default: 1);
+    // [102] set the load resistance on the board, in ohms (default: 1000);
     void setRlValue(float value);
-    // [103] define the Ro resistance on the board (default: 10000);
+    // [103] set the Ro resistance in ohms. By default will be calculated at startup during the calibration phase using the known ppm provided
     void setRoValue(float value);
-    // [104] Sensor resistance in clean air (default: 9.83);
-    void setCleanAirFactor(float value);
-    // [105] define how many samples you are going to take in the calibration phase (default: 50);
-    void setCalibrationSampleTimes(int value);
-    // [106] define the time interal(in milisecond) between each samples in the cablibration phase (default: 500);
+    // [104] set the ppm used during the calibration (default: 411);
+    void setKnownPpm(float value);
+    // [105] define how many samples we are going to take in the calibration phase (default: 50);
+    void setCalibrationSamples(int value);
+    // [106] define the time (in milisecond) between each sample in the cablibration phase (default: 500);
     void setCalibrationSampleInterval(int value);
     // [107] define how many samples you are going to take in normal operation (default: 50);
-    void setReadSampleTimes(int value);
-    // [108] define the time interal(in milisecond) between each samples in the normal operations (default: 5);
-    void setReadSampleInterval(int value);
-    // set the LPGCurve array (default: {2.3,0.21,-0.47})
-    void setLPGCurve(float *value);
-    // set the COCurve array (default: {2.3,0.72,-0.34})
-    void setCOCurve(float *value);
-    // set the SmokeCurve array (default: {2.3,0.53,-0.44})
-    void setSmokeCurve(float *value);
+    void setSamples(int value);
+    // [108] define the time (in milisecond) between each sample in the normal operations (default: 5);
+    void setSampleInterval(int value);
+    // [109] set the ppm (x) of a random point on the gas curve (default: 200)
+    void setPoint1Ppm(float value); 
+    // [110] set the Rs/Ro ratio (y) of the same random point on the gas curve (default: 5)
+    void setPoint1Ratio(float value);
+    // [111] set the ppm (x) of another random point on the gas curve (default: 10000)
+    void setPoint2Ppm(float value);
+    // [112] set the Rs/Ro ratio (y) of the same random point on the gas curve (default: 1.2)
+    void setPoint2Ratio(float value);
+    // [113] with ppm = scaling_factor*x^exponent set the value manually, otherwise will be calculated automatically based on the two points provided
+    void setCurveScalingFactor(float value); 
+    // [114] with ppm = scaling_factor*x^exponent set the value manually, otherwise will be calculated automatically based on the two points provided
+    void setCurveExponent(float value); 
     // define what to do at each stage of the sketch
     void onSetup();
     void onLoop(Child* child);
     void onReceive(MyMessage* message);
   protected:
-    float _rl_value = 1.0;
-    float _ro_clean_air_factor = 9.83;
-    int _calibration_sample_times = 50;
+    long _rl = 1000;
+    long _ro = 0;
+    int _known_ppm = 411;
+    int _calibration_samples = 50;
     int _calibration_sample_interval = 500;
-    int _read_sample_interval = 50;
-    int _read_sample_times = 5;
-    float _ro = 10000.0;
-    static float _default_LPGCurve[3];
-    static float _default_COCurve[3];
-    static float _default_SmokeCurve[3];
-    float *_LPGCurve;
-    float *_COCurve;
-    float *_SmokeCurve;
-    float _MQResistanceCalculation(int raw_adc);
-    float _MQCalibration();
-    float _MQRead();
-    int _MQGetGasPercentage(float rs_ro_ratio, int gas_id);
-    int  _MQGetPercentage(float rs_ro_ratio, float *pcurve);
-    const static int _gas_lpg = 0;
-    const static int _gas_co = 1;
-    const static int _gas_smoke = 2;
-    int _target_gas = _gas_co;
+    int _sample_interval = 50;
+    int _samples = 5;
+    float _point1_ppm = 200;
+    float _point1_ratio = 5;
+    float _point2_ppm = 10000;
+    float _point2_ratio = 1.2;
+    float _curve_scaling_factor = 0;
+    float _curve_exponent = 0;
+    float _getRsValue(int samples, int sample_interval);
 };
 #endif
 

--- a/NodeManagerLibrary.ino
+++ b/NodeManagerLibrary.ino
@@ -2441,6 +2441,7 @@ void SensorMCP9808::onReceive(MyMessage* message) {
 /*
  * SensorMQ
  */
+#ifdef USE_MQ
 SensorMQ::SensorMQ(NodeManager& node_manager, int pin, int child_id): Sensor(node_manager, pin) {
   _name = "MQ";
   children.allocateBlocks(1);
@@ -2486,6 +2487,9 @@ void SensorMQ::setCurveScalingFactor(float value) {
 }
 void SensorMQ::setCurveExponent(float value) {
   _curve_exponent = value;
+}
+void SensorMQ::setWarmupMinutes(int value) {
+  _warmup_minutes = value;
 }
 
 // what to do during setup
@@ -2541,6 +2545,10 @@ void SensorMQ::onLoop(Child* child) {
     Serial.print(F(" PPM="));
     Serial.println(ppm);
   #endif
+  // ppm cannot be negative
+  if (ppm < 0) ppm = 0;
+  // if warmup is configured, do not send the value back if within the warmup period
+  if (_warmup_minutes > 0 && millis() < _warmup_minutes*60*1000) return;
   // store the value
   ((ChildInt*)child)->setValueInt(ppm);
 }

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ SensorBMP280             | 3     | USE_BMP280         | BMP280 sensor, return te
 SensorSonoff             | 1     | USE_SONOFF         | Sonoff wireless smart switch                                                                      | https://github.com/thomasfredericks/Bounce2
 SensorHCSR04             | 1     | USE_HCSR04         | HC-SR04 sensor, return the distance between the sensor and an object                              | https://github.com/mysensors/MySensorsArduinoExamples/tree/master/libraries/NewPing
 SensorMCP9808            | 1     | USE_MCP9808        | MCP9808 sensor, measure the temperature through the attached module                               | https://github.com/adafruit/Adafruit_MCP9808_Library
-SensorMQ                 | 1     | USE_MQ             | MQ sensor, return ppm of the target gas                                                           | -
+SensorMQ                 | 1     | USE_MQ             | MQ sensor, return ppm of the target gas. Tuned by default for MQ135 and CO2                       | -
 SensorMHZ19              | 1     | USE_MHZ19          | MH-Z19 CO2 sensor via UART (SoftwareSerial, default on pins 6(Rx) and 7(Tx)                       | -
 SensorAM2320             | 2     | USE_AM2320         | AM2320 sensors, return temperature/humidity based on the attached AM2320 sensor                   | https://github.com/thakshak/AM2320
 SensorTSL2561            | 1     | USE_TSL2561        | TSL2561 sensor, return light in lux                                                               | https://github.com/adafruit/TSL2561-Arduino-Library
@@ -628,6 +628,8 @@ Each sensor class exposes additional methods.
     void setCurveScalingFactor(float value); 
     // [114] with ppm = scaling_factor*x^exponent set the value manually, otherwise will be calculated automatically based on the two points provided
     void setCurveExponent(float value); 
+    // do not report for the given number of minutes, waiting for the sensor to warm up (default: 0);
+    void setWarmupMinutes(int value);
 ~~~
 
 * SensorTSL2561

--- a/README.md
+++ b/README.md
@@ -602,28 +602,32 @@ Each sensor class exposes additional methods.
 
 * SensorMQ
 ~~~c
-    // [101] define the target gas whose ppm has to be returned. 0: LPG, 1: CO, 2: Smoke (default: 1);
-    void setTargetGas(int value);
-    // [102] define the load resistance on the board, in kilo ohms (default: 1);
+    // [102] set the load resistance on the board, in ohms (default: 1000);
     void setRlValue(float value);
-    // [103] define the Ro resistance on the board (default: 10000);
+    // [103] set the Ro resistance in ohms. By default will be calculated at startup during the calibration phase using the known ppm provided
     void setRoValue(float value);
-    // [104] Sensor resistance in clean air (default: 9.83);
-    void setCleanAirFactor(float value);
-    // [105] define how many samples you are going to take in the calibration phase (default: 50);
-    void setCalibrationSampleTimes(int value);
-    // [106] define the time interal(in milisecond) between each samples in the cablibration phase (default: 500);
+    // [104] set the ppm used during the calibration (default: 411);
+    void setKnownPpm(float value);
+    // [105] define how many samples we are going to take in the calibration phase (default: 50);
+    void setCalibrationSamples(int value);
+    // [106] define the time (in milisecond) between each sample in the cablibration phase (default: 500);
     void setCalibrationSampleInterval(int value);
     // [107] define how many samples you are going to take in normal operation (default: 50);
-    void setReadSampleTimes(int value);
-    // [108] define the time interal(in milisecond) between each samples in the normal operations (default: 5);
-    void setReadSampleInterval(int value);
-    // set the LPGCurve array (default: {2.3,0.21,-0.47})
-    void setLPGCurve(float *value);
-    // set the COCurve array (default: {2.3,0.72,-0.34})
-    void setCOCurve(float *value);
-    // set the SmokeCurve array (default: {2.3,0.53,-0.44})
-    void setSmokeCurve(float *value);
+    void setSamples(int value);
+    // [108] define the time (in milisecond) between each sample in the normal operations (default: 5);
+    void setSampleInterval(int value);
+    // [109] set the ppm (x) of a random point on the gas curve (default: 200)
+    void setPoint1Ppm(float value); 
+    // [110] set the Rs/Ro ratio (y) of the same random point on the gas curve (default: 5)
+    void setPoint1Ratio(float value);
+    // [111] set the ppm (x) of another random point on the gas curve (default: 10000)
+    void setPoint2Ppm(float value);
+    // [112] set the Rs/Ro ratio (y) of the same random point on the gas curve (default: 1.2)
+    void setPoint2Ratio(float value);
+    // [113] with ppm = scaling_factor*x^exponent set the value manually, otherwise will be calculated automatically based on the two points provided
+    void setCurveScalingFactor(float value); 
+    // [114] with ppm = scaling_factor*x^exponent set the value manually, otherwise will be calculated automatically based on the two points provided
+    void setCurveExponent(float value); 
 ~~~
 
 * SensorTSL2561


### PR DESCRIPTION
This PR is a full review of the code behind the SensorMQ implementation. The code has been inspired by http://davidegironi.blogspot.com/2014/01/cheap-co2-meter-using-mq135-sensor-with.html#.WyLQo6qFNn5. Default values are for measuring CO2 with a MQ135 sensor.

To customize it for another gas or mq sensor, please set at minimum the following:
* setPoint1Ppm(), setPoint1Ratio() to set ppm and Rs/Ro of a point from the sensitivity chart
* setPoint2Ppm(), setPoint2Ratio() to set ppm and Rs/Ro of another point from the sensitivity chart
* setKnownPpm() to set the known amount of ppm to calibrate the sensor