### PR TITLE
fix interrupt sleep

### DIFF
--- a/NodeManagerLibrary.ino
+++ b/NodeManagerLibrary.ino
@@ -5322,6 +5322,8 @@ void NodeManager::_sleep() {
     interrupt = sleep(interrupt_1_pin,_interrupt_1_mode,sleep_time*1000,_smart_sleep);
   } else if (interrupt_2_pin != INTERRUPT_NOT_DEFINED) {
     interrupt = sleep(interrupt_2_pin,_interrupt_2_mode,sleep_time*1000,_smart_sleep);
+  } else {
+    sleep(INTERRUPT_NOT_DEFINED,MODE_NOT_DEFINED,INTERRUPT_NOT_DEFINED,MODE_NOT_DEFINED,sleep_time*1000,_smart_sleep);
   }
   // woke up by an interrupt
   if (interrupt > -1) {

--- a/NodeManagerLibrary.ino
+++ b/NodeManagerLibrary.ino
@@ -5316,7 +5316,13 @@ void NodeManager::_sleep() {
   int interrupt_1_pin = _interrupt_1_mode == MODE_NOT_DEFINED ? INTERRUPT_NOT_DEFINED  : digitalPinToInterrupt(INTERRUPT_PIN_1);
   int interrupt_2_pin = _interrupt_2_mode == MODE_NOT_DEFINED ? INTERRUPT_NOT_DEFINED  : digitalPinToInterrupt(INTERRUPT_PIN_2);
   // enter smart sleep for the requested sleep interval and with the configured interrupts
-  interrupt = sleep(interrupt_1_pin,_interrupt_1_mode,interrupt_2_pin,_interrupt_2_mode,sleep_time*1000,_smart_sleep);
+  if (interrupt_1_pin != INTERRUPT_NOT_DEFINED && interrupt_2_pin != INTERRUPT_NOT_DEFINED) {
+    interrupt = sleep(interrupt_1_pin,_interrupt_1_mode,interrupt_2_pin,_interrupt_2_mode,sleep_time*1000,_smart_sleep);
+  } else if (interrupt_1_pin != INTERRUPT_NOT_DEFINED) {
+    interrupt = sleep(interrupt_1_pin,_interrupt_1_mode,sleep_time*1000,_smart_sleep);
+  } else if (interrupt_2_pin != INTERRUPT_NOT_DEFINED) {
+    interrupt = sleep(interrupt_2_pin,_interrupt_2_mode,sleep_time*1000,_smart_sleep);
+  }
   // woke up by an interrupt
   if (interrupt > -1) {
     // register the interrupt pin


### PR DESCRIPTION
MySensors requires both interrupts or the first interrupt parameter to be defined.
If first interrupt is INTERRUPT_NOT_DEFINE it will not work.

fixes #363