### PR TITLE
SensorHCSR04 review

### DIFF
--- a/NodeManager.ino
+++ b/NodeManager.ino
@@ -269,7 +269,7 @@ FEATURE_HOOKING             | OFF     | allow custom code to be hooked in the ou
 //#define USE_BMP085_180
 //#define USE_BMP280
 //#define USE_SONOFF
-//#define USE_HCSR04
+#define USE_HCSR04
 //#define USE_MCP9808
 //#define USE_MQ
 //#define USE_MHZ19
@@ -354,7 +354,7 @@ NodeManager node;
 //SensorBMP180 bmp180(node);
 //SensorBMP280 bmp280(node);
 //SensorSonoff sonoff(node);
-//SensorHCSR04 hcsr04(node,6);
+SensorHCSR04 hcsr04(node,6,7);
 //SensorMCP9808 mcp9808(node);
 //SensorMQ mq(node,A0);
 //SensorMHZ19 mhz19(node,6,7);

--- a/NodeManager.ino
+++ b/NodeManager.ino
@@ -269,7 +269,7 @@ FEATURE_HOOKING             | OFF     | allow custom code to be hooked in the ou
 //#define USE_BMP085_180
 //#define USE_BMP280
 //#define USE_SONOFF
-#define USE_HCSR04
+//#define USE_HCSR04
 //#define USE_MCP9808
 //#define USE_MQ
 //#define USE_MHZ19
@@ -354,7 +354,7 @@ NodeManager node;
 //SensorBMP180 bmp180(node);
 //SensorBMP280 bmp280(node);
 //SensorSonoff sonoff(node);
-SensorHCSR04 hcsr04(node,6,7);
+//SensorHCSR04 hcsr04(node,6,7);
 //SensorMCP9808 mcp9808(node);
 //SensorMQ mq(node,A0);
 //SensorMHZ19 mhz19(node,6,7);

--- a/NodeManagerLibrary.h
+++ b/NodeManagerLibrary.h
@@ -1235,13 +1235,11 @@ class SensorSonoff: public Sensor {
 #ifdef USE_HCSR04
 class SensorHCSR04: public Sensor {
   public:
-    SensorHCSR04(NodeManager& node_manager, int pin, int child_id = -255);
-    // [101] Arduino pin tied to trigger pin on the ultrasonic sensor (default: the pin set while registering the sensor)
-    void setTriggerPin(int value);
-    // [102] Arduino pin tied to echo pin on the ultrasonic sensor (default: the pin set while registering the sensor)
-    void setEchoPin(int value);
+    SensorHCSR04(NodeManager& node_manager, int echo_pin, int trigger_pin, int child_id = -255);
     // [103] Maximum distance we want to ping for (in centimeters) (default: 300)
     void setMaxDistance(int value);
+    // [104] Report the measure even if is invalid (e.g. 0) (default: true)
+    void setReportIfInvalid(bool value);
     // define what to do at each stage of the sketch
     void onSetup();
     void onLoop(Child* child);
@@ -1250,6 +1248,7 @@ class SensorHCSR04: public Sensor {
   protected:
     int _trigger_pin;
     int _echo_pin;
+    bool _report_if_invalid = true;
     int _max_distance = 300;
     NewPing* _sonar;
 };

--- a/NodeManagerLibrary.ino
+++ b/NodeManagerLibrary.ino
@@ -2352,23 +2352,20 @@ void SensorSonoff::_blink() {
 */
 #ifdef USE_HCSR04
 // contructor
-SensorHCSR04::SensorHCSR04(NodeManager& node_manager, int pin, int child_id): Sensor(node_manager, pin) {
+SensorHCSR04::SensorHCSR04(NodeManager& node_manager, int echo_pin, int trigger_pin, int child_id): Sensor(node_manager) {
   _name = "HCSR04";
-  _trigger_pin = pin;
-  _echo_pin = pin;
+  _echo_pin = echo_pin;
+  _trigger_pin = trigger_pin;
   children.allocateBlocks(1);
   new ChildInt(this,_node->getAvailableChildId(child_id),S_DISTANCE,V_DISTANCE,_name);
 }
 
 // setter/getter
-void SensorHCSR04::setTriggerPin(int value) {
-  _trigger_pin = value;
-}
-void SensorHCSR04::setEchoPin(int value) {
-  _echo_pin = value;
-}
 void SensorHCSR04::setMaxDistance(int value) {
   _max_distance = value;
+}
+void SensorHCSR04::setReportIfInvalid(bool value) {
+  _report_if_invalid = value;
 }
 
 // what to do during setup
@@ -2387,6 +2384,7 @@ void SensorHCSR04::onLoop(Child* child) {
     Serial.print(F(" D="));
     Serial.println(distance);
   #endif
+  if (! _report_if_invalid && distance == 0) return;
   ((ChildInt*)child)->setValueInt(distance);
 }
 
@@ -4490,9 +4488,8 @@ void SensorConfiguration::onReceive(MyMessage* message) {
       if (strcmp(sensor->getName(),"HCSR04") == 0) {
         SensorHCSR04* custom_sensor = (SensorHCSR04*)sensor;
         switch(function) {
-          case 101: custom_sensor->setTriggerPin(request.getValueInt()); break;
-          case 102: custom_sensor->setEchoPin(request.getValueInt()); break;
           case 103: custom_sensor->setMaxDistance(request.getValueInt()); break;
+          case 104: custom_sensor->setReportIfInvalid(request.getValueInt()); break;
           default: return;
         }
       }

--- a/README.md
+++ b/README.md
@@ -592,12 +592,10 @@ Each sensor class exposes additional methods.
 
 * SensorHCSR04
 ~~~c
-    // [101] Arduino pin tied to trigger pin on the ultrasonic sensor (default: the pin set while registering the sensor)
-    void setTriggerPin(int value);
-    // [102] Arduino pin tied to echo pin on the ultrasonic sensor (default: the pin set while registering the sensor)
-    void setEchoPin(int value);
     // [103] Maximum distance we want to ping for (in centimeters) (default: 300)
     void setMaxDistance(int value);
+    // [104] Report the measure even if is invalid (e.g. 0) (default: true)
+    void setReportIfInvalid(bool value);
 ~~~
 
 * SensorMQ


### PR DESCRIPTION
With this PR SensorHCSR04  constructor takes two arguments, echo_pin and trigger_pin (fixes #382)
* Deprecated setEchoPin() and setTriggerPin()
* Added setReportIfInvalid(), true by default, which will prevent reporting if the distance is invalid (e.g. 0) when set to false