### PR TITLE
Add option to prevent a sensor to report to the gateway

### DIFF
--- a/NodeManagerLibrary.h
+++ b/NodeManagerLibrary.h
@@ -589,6 +589,8 @@ class Sensor {
     // [14] manually turn the power off
     void powerOff();
 #endif
+    // [21] enable/disable reporting to the gateway (default: true)
+    void setReporting(bool value);
     // [17] After how many minutes the sensor will report back its measure (default: 10 minutes)
     void setReportIntervalSeconds(int value);
     // [16] After how many minutes the sensor will report back its measure (default: 10 minutes)
@@ -649,6 +651,7 @@ class Sensor {
     int _pin = -1;
     int _samples = 1;
     int _samples_interval = 0;
+    bool _reporting = true;
 #if FEATURE_INTERRUPTS == ON
     int _interrupt_pin = -1;
 #endif

--- a/NodeManagerLibrary.ino
+++ b/NodeManagerLibrary.ino
@@ -3313,6 +3313,7 @@ Display::Display(NodeManager& node_manager, int child_id): Sensor(node_manager) 
   new ChildString(this, _node->getAvailableChildId(child_id), S_INFO, V_TEXT,_name);
   // prevent reporting to the gateway at each display update
   setReporting(false);
+  _report_timer->unset();
 }
 // setter/getter
 void Display::setCaption(const char* value) {

--- a/NodeManagerLibrary.ino
+++ b/NodeManagerLibrary.ino
@@ -3311,6 +3311,8 @@ Display::Display(NodeManager& node_manager, int child_id): Sensor(node_manager) 
   // We don't need any sensors, but we need a child, otherwise the loop will never be executed
   children.allocateBlocks(1);
   new ChildString(this, _node->getAvailableChildId(child_id), S_INFO, V_TEXT,_name);
+  // prevent reporting to the gateway at each display update
+  setReporting(false);
 }
 // setter/getter
 void Display::setCaption(const char* value) {

--- a/NodeManagerLibrary.ino
+++ b/NodeManagerLibrary.ino
@@ -595,6 +595,11 @@ int Sensor::getInterruptPin() {
 }
 #endif
 
+// enable/disable reporting to the gateway
+void Sensor::setReporting(bool value) {
+  _reporting = value;
+}
+
 // After how many seconds the sensor will report back its measure
 void Sensor::setReportIntervalSeconds(int value) {
   _report_timer->start(value,SECONDS);
@@ -713,7 +718,7 @@ void Sensor::loop(MyMessage* message) {
       if (_samples_interval > 0) _node->sleepOrWait(_samples_interval);
     }
     // send the value back to the controller
-    child->sendValue(message != nullptr);
+    if (_reporting) child->sendValue(message != nullptr);
     // reset the counters
     child->reset();
   }
@@ -4356,6 +4361,7 @@ void SensorConfiguration::onReceive(MyMessage* message) {
         case 17: sensor->setReportIntervalSeconds(request.getValueInt()); break;
         case 19: sensor->setReportIntervalHours(request.getValueInt()); break;
         case 20: sensor->setReportIntervalDays(request.getValueInt()); break;
+        case 21: sensor->setReporting(request.getValueInt()); break;
         default: return;
       }
     } else {

--- a/README.md
+++ b/README.md
@@ -366,6 +366,8 @@ The following methods are available for all the sensors:
     // [14] manually turn the power off
     void powerOff();
 #endif
+    // [21] enable/disable reporting to the gateway (default: true)
+    void setReporting(bool value);
     // [17] After how many minutes the sensor will report back its measure (default: 10 minutes)
     void setReportIntervalSeconds(int value);
     // [16] After how many minutes the sensor will report back its measure (default: 10 minutes)


### PR DESCRIPTION
This PR add an option to prevent a sensor to report to the gateway. E.g. Displays would send a message back at every update
* Added setReporting() to Sensor, default to true
* Added setReporting(false) in Display class constructor