### PR TITLE
Disabled NodeManager's debug output when running a serial gateway

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,10 +36,21 @@ install:
 jobs:
   include:
     - stage: build
-      name: "Base Sketch"
+      name: "Empty Sketch (NRF24 radio)"
       script: 
        - eval $RUN
-    - name: "All features ON"
+    - name: "Empty Sketch (RFM69 radio)"
+      script: 
+       - sed -r -i 's/(#define MY_RADIO_NRF24)/\/\/\1/' $PWD/$SKETCH
+       - sed -r -i 's/\/\/(#define MY_RADIO_RFM69)/\1/' $PWD/$SKETCH
+       - sed -r -i 's/\/\/(#define MY_IS_RFM69HW)/\1/' $PWD/$SKETCH
+       - sed -r -i 's/\/\/(#define MY_RFM69_NEW_DRIVER)/\1/' $PWD/$SKETCH
+       - eval $RUN
+    - name: "Gateway Serial"
+      script: 
+       - sed -r -i 's/\/\/(#define MY_GATEWAY_SERIAL)/\1/' $PWD/$SKETCH
+       - eval $RUN
+    - name: "Features"
       script: 
        - arduino --install-library "DS3232RTC,Time"
        - sed -r -i s/OFF/ON/g $PWD/$SKETCH

--- a/NodeManagerLibrary.h
+++ b/NodeManagerLibrary.h
@@ -263,6 +263,7 @@
 // include third party libraries for enabled features
 #ifdef MY_GATEWAY_SERIAL
   #define FEATURE_SLEEP OFF
+  #define FEATURE_DEBUG OFF
 #endif
 #if FEATURE_TIME == ON
   #include <TimeLib.h>


### PR DESCRIPTION
This PR force FEATURE_DEBUG to OFF if MY_GATEWAY_SERIAL is defined. Fixes #373 
Added gateway tests for CI 