### PR TITLE
Display cpu and memory information

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,8 +239,6 @@ You can interact with each class provided by NodeManager through a set of API fu
 	void hello();
 	// [6] reboot the board
 	void reboot();
-	// return vcc in V
-	float getVcc();
     // [36] set the default interval in minutes all the sensors will report their measures. If the same function is called on a specific sensor, this will not change the previously set value. On sleeping sensors, the elapsed time can be evaluated only upon wake up (default: 10 minutes)
     void setReportIntervalSeconds(unsigned long value);
 	unsigned long getReportIntervalSeconds();

--- a/nodemanager/Node.cpp
+++ b/nodemanager/Node.cpp
@@ -234,6 +234,8 @@ void NodeManager::setup() {
 	// turn the sensor off
 	powerOff();
 #endif
+	// print out information regarding CPU voltage, frequency and free memory
+	debug(PSTR(LOG_SETUP "HW V=%d F=%d M=%d\n"),hwCPUVoltage(),hwCPUFrequency()/10,hwFreeMem());
 }
 
 // run the main function for all the register sensors
@@ -394,31 +396,6 @@ void NodeManager::loop() {
 	}
 
 #endif
-
-	// return vcc in V
-	float NodeManager::getVcc() {
-#ifdef CHIP_AVR
-		// Measure Vcc against 1.1V Vref
-		#if defined(CHIP_MEGA)
-		ADMUX = (_BV(REFS0) | _BV(MUX4) | _BV(MUX3) | _BV(MUX2) | _BV(MUX1));
-		#elif defined (CHIP_TINYX4)
-		ADMUX = (_BV(MUX5) | _BV(MUX0));
-		#elif defined (CHIP_TINYX5)
-		ADMUX = (_BV(MUX3) | _BV(MUX2));
-		#else
-		ADMUX = (_BV(REFS0) | _BV(MUX3) | _BV(MUX2) | _BV(MUX1));
-		#endif
-		// Vref settle
-		wait(70);
-		// Do conversion
-		ADCSRA |= _BV(ADSC);
-		while (bit_is_set(ADCSRA, ADSC)) {};
-		// return Vcc in mV
-		return (float)((1125300UL) / ADC) / 1000;
-#else
-		return (float)0;
-#endif
-	}
 
 #if NODEMANAGER_INTERRUPTS == ON
 	// return the pin from which the last interrupt came

--- a/nodemanager/Node.h
+++ b/nodemanager/Node.h
@@ -47,8 +47,6 @@ public:
 	void hello();
 	// [6] reboot the board
 	void reboot();
-	// return vcc in V
-	float getVcc();
     // [36] set the default interval in minutes all the sensors will report their measures. If the same function is called on a specific sensor, this will not change the previously set value. On sleeping sensors, the elapsed time can be evaluated only upon wake up (default: 10 minutes)
     void setReportIntervalSeconds(unsigned long value);
 	unsigned long getReportIntervalSeconds();

--- a/sensors/SensorBattery.h
+++ b/sensors/SensorBattery.h
@@ -91,7 +91,7 @@ public:
 	void onLoop(Child* child) {
 		// measure the board vcc
 		float volt = 0;
-		if (_battery_internal_vcc || _battery_pin == -1) volt = nodeManager.getVcc();
+		if (_battery_internal_vcc || _battery_pin == -1) volt = (float)hwCPUVoltage()/1000;
 		else volt = analogRead(_battery_pin) * _battery_volts_per_bit;
 		volt = volt * _battery_adj_factor;
 		child->setValue(volt);

--- a/sensors/SensorML8511.h
+++ b/sensors/SensorML8511.h
@@ -41,7 +41,7 @@ public:
 	void onLoop(Child* child) {
 		// read the voltage 
 		int uvLevel = analogRead(_pin);
-		int refLevel = nodeManager.getVcc()*1024/3.3;
+		int refLevel = (float)hwCPUVoltage()/1000*1024/3.3;
 		//Use the 3.3V power pin as a reference to get a very accurate output value from sensor
 		float outputVoltage = 3.3 / refLevel * uvLevel;
 		//Convert the voltage to a UV intensity level


### PR DESCRIPTION
* displays debug information regarding CPU voltage, frequency and free memory available during setup() by leveraging built-in `hwCPUVoltage()`, `hwCPUFrequency()`, `hwFreeMem()`
* Deprecated `NodeManager::getVcc()` now replaced with the built-in `hwCPUVoltage()` (fixes #407)
* Updated log parser