### PR TITLE
Adding control for brightness to neopixel sensor

### DIFF
--- a/README.md
+++ b/README.md
@@ -831,11 +831,15 @@ Each sensor class may expose additional methods.
 ~~~c
     // set how many NeoPixels are attached
     void setNumPixels(int value);
+	// set default brightness
+	void setDefaultBrightness(int value) {
     // format expected is:
     //<pixel_number from>-<pixel_number to>,<RGB color in a packed 24 bit format>
     //<pixel_number>,<RGB color in a packed 24 bit format>
     //<RGB color in a packed 24 bit format>
     void setColor(char* string);
+	// brightness for all LEDs
+	void setBrightness(int value)
 ~~~
 
 * SensorFPM10A


### PR DESCRIPTION
Re-adapted #364 for the new architecture

> Hi,
> while updating mysensors to an new version i saw the NodeManager component and tried to rewrite some of my sketches. This tool allows me to configure the things much faster. Thank you for this great helper.
> For the neopixel sensors i missed a functionality to control the brightness, so i added this on my own. Maybe this could be interesting to you.
> 
> Adding control for brightness to neopixel sensor
> You can set a default brightness within the sketch
> with "sensor.setDefaultBrightness(intValue)"