### PR TITLE
Added setAnalogReference() to NodeManager

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,6 +277,8 @@ You can interact with each class provided by NodeManager through a set of API fu
 	Sensor* getSensorWithChild(uint8_t child_id);
 	// sleep between send()
 	void sleepBetweenSend();
+	// set the analog reference to the given value and optionally perform some fake reading on the given pin
+	void setAnalogReference(uint8_t value, uint8_t pin = -1);
 #if NODEMANAGER_SLEEP == ON
 	// [3] set the duration (in seconds) of a sleep cycle
 	void setSleepSeconds(unsigned long value);

--- a/nodemanager/Node.cpp
+++ b/nodemanager/Node.cpp
@@ -721,3 +721,23 @@ void NodeManager::sleepBetweenSend() {
 	// if we sleep here ack management will not work
 	if (_sleep_between_send > 0) wait(_sleep_between_send);
 }
+
+// set the analog reference 
+void NodeManager::setAnalogReference(uint8_t value, uint8_t pin) {
+#ifdef CHIP_AVR
+	// nothing to do
+	if (value == _analog_reference) return;
+	// change the analog reference
+	analogReference(value);
+	// wait a bit 
+	wait(200);
+	// perform some reading before actually reading the value
+	if (pin > -1) {
+		for (int i = 0; i < 5; i++) {
+			analogRead(pin);
+			wait(50);
+		}
+	}
+#endif
+}
+

--- a/nodemanager/Node.h
+++ b/nodemanager/Node.h
@@ -83,6 +83,8 @@ public:
 	Sensor* getSensorWithChild(uint8_t child_id);
 	// sleep between send()
 	void sleepBetweenSend();
+	// set the analog reference to the given value and optionally perform some fake reading on the given pin
+	void setAnalogReference(uint8_t value, uint8_t pin = -1);
 #if NODEMANAGER_SLEEP == ON
 	// [3] set the duration (in seconds) of a sleep cycle
 	void setSleepSeconds(unsigned long value);
@@ -179,6 +181,7 @@ private:
 	uint8_t _reboot_pin = -1;
 	void _present(uint8_t child_id, uint8_t type);
 	List<Timer*> _timers;
+	uint8_t _analog_reference = DEFAULT;
 #if NODEMANAGER_INTERRUPTS == ON
 	uint8_t _interrupt_1_mode = MODE_NOT_DEFINED;
 	uint8_t _interrupt_2_mode = MODE_NOT_DEFINED;

--- a/sensors/SensorAnalogInput.h
+++ b/sensors/SensorAnalogInput.h
@@ -111,10 +111,7 @@ protected:
 	int _getAnalogRead() {
 #ifdef CHIP_AVR
 		// set the reference
-		if (_reference != -1) {
-			analogReference(_reference);
-			wait(100);
-		}
+		if (_reference != -1) nodeManager.setAnalogReference(_reference);
 #endif
 		// read and return the value
 		int value = analogRead(_pin);

--- a/sensors/SensorBattery.h
+++ b/sensors/SensorBattery.h
@@ -74,25 +74,21 @@ public:
 		_battery_adj_factor = value;
 	};
 	
-	// define what to do during setup
-	void onSetup() {
-#ifdef CHIP_AVR
-		// when measuring the battery from a pin, analog reference must be internal
-		if (! _battery_internal_vcc && _battery_pin > -1)
-#ifdef CHIP_MEGA
-		analogReference(INTERNAL1V1);
-#else
-		analogReference(INTERNAL);
-#endif
-#endif
-	};
-	
 	// define what to do during loop
 	void onLoop(Child* child) {
-		// measure the board vcc
+		// measure the battery
 		float volt = 0;
 		if (_battery_internal_vcc || _battery_pin == -1) volt = (float)hwCPUVoltage()/1000;
-		else volt = analogRead(_battery_pin) * _battery_volts_per_bit;
+		else {
+			// when measuring the battery from a pin, analog reference must be internal
+#ifdef CHIP_AVR
+			nodeManager.setAnalogReference(INTERNAL);
+#endif
+#ifdef CHIP_MEGA
+			nodeManager.setAnalogReference(INTERNAL1V1);
+#endif
+			volt = analogRead(_battery_pin) * _battery_volts_per_bit;
+		}
 		volt = volt * _battery_adj_factor;
 		child->setValue(volt);
 		// calculate the percentage

--- a/sensors/SensorRain.h
+++ b/sensors/SensorRain.h
@@ -32,7 +32,6 @@ public:
 		children.get()->setPresentation(S_RAIN);
 		children.get()->setType(V_RAINRATE);
 		children.get()->setDescription(_name);
-		setReference(DEFAULT);
 		setOutputPercentage(true);
 		setReverse(true);
 		setRangeMin(100);

--- a/sensors/SensorSoilMoisture.h
+++ b/sensors/SensorSoilMoisture.h
@@ -35,7 +35,6 @@ public:
 		setReverse(true);
 		setRangeMin(100);
 		setOutputPercentage(true);
-		setReference(DEFAULT);
 	};
 
 };


### PR DESCRIPTION
With this PR NodeManager keeps track of the current analog reference set. When a sensor needs to change it, has to invoke setAnalogReference() which does nothing if already set to the given value, otherwise change the analog reference, wait a bit and optionally does some random reads to a pin so to stabilize the value.

Adapted SensorAnalogInput and SensorBattery to use setAnalogReference() during loop() and no more in setup() (fixes #358)