### PR TITLE
Fix conditional report issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -502,7 +502,7 @@ The following methods are available for all the child:
 #if NODEMANAGER_CONDITIONAL_REPORT == ON
 	// force to send an update after the configured number of minutes
 	void setForceUpdateTimerValue(unsigned long value);
-	// never report values below this threshold (default: FLT_MIN)
+	// never report values below this threshold (default: -FLT_MAX)
 	void setMinThreshold(float value);
 	// never report values above this threshold (default: FLT_MAX)
 	void setMaxThreshold(float value);

--- a/nodemanager/Child.cpp
+++ b/nodemanager/Child.cpp
@@ -150,10 +150,6 @@ void Child::sendValue(bool force) {
 			// if the force update timer is over, send the value regardless and restart it
 			if (_force_update_timer->isOver()) _force_update_timer->start();
 			else {
-				Serial.println(_value);
-				Serial.println(_last_value);
-				Serial.println(_value_delta);
-				Serial.println((_last_value - _value_delta));
 				// if the value does not differ enough from the previous one, do not send the value
 				if (_value > (_last_value - _value_delta) && _value < (_last_value + _value_delta)) {
 					return;
@@ -168,7 +164,6 @@ void Child::sendValue(bool force) {
 			}
 		}
 	}
-	Serial.println("->");
 	// keep track of the previous value
 	if (_format != STRING) _last_value = _value;
 	else _last_value_string = _value_string;

--- a/nodemanager/Child.cpp
+++ b/nodemanager/Child.cpp
@@ -149,6 +149,10 @@ void Child::sendValue(bool force) {
 			// if the force update timer is over, send the value regardless and restart it
 			if (_force_update_timer->isOver()) _force_update_timer->start();
 			else {
+				Serial.println(_value);
+				Serial.println(_last_value);
+				Serial.println(_value_delta);
+				Serial.println((_last_value - _value_delta));
 				// if the value does not differ enough from the previous one, do not send the value
 				if (_value > (_last_value - _value_delta) && _value < (_last_value + _value_delta)) {
 					return;

--- a/nodemanager/Child.cpp
+++ b/nodemanager/Child.cpp
@@ -141,7 +141,8 @@ void Child::sendValue(bool force) {
 	// do not send if no samples have been collected, unless instructed otherwise
 	if (! _send_without_value && _samples == 0) return;
 #if NODEMANAGER_CONDITIONAL_REPORT == ON
-	if (! force) {
+	// ignore conditional reporting settings if forced to report or if it is the first run
+	if (! force || ! _sensor->getFirstRun()) {
 		// if the value is a number
 		if (_format != STRING) {
 			// if below or above the thresholds, do not send the value
@@ -167,6 +168,7 @@ void Child::sendValue(bool force) {
 			}
 		}
 	}
+	Serial.println("->");
 	// keep track of the previous value
 	if (_format != STRING) _last_value = _value;
 	else _last_value_string = _value_string;

--- a/nodemanager/Child.h
+++ b/nodemanager/Child.h
@@ -82,7 +82,7 @@ public:
 #if NODEMANAGER_CONDITIONAL_REPORT == ON
 	// force to send an update after the configured number of minutes
 	void setForceUpdateTimerValue(unsigned long value);
-	// never report values below this threshold (default: FLT_MIN)
+	// never report values below this threshold (default: -FLT_MAX)
 	void setMinThreshold(float value);
 	// never report values above this threshold (default: FLT_MAX)
 	void setMaxThreshold(float value);

--- a/nodemanager/Child.h
+++ b/nodemanager/Child.h
@@ -122,7 +122,7 @@ protected:
 	double _last_value = 0;
 	const char* _last_value_string = "";
 	Timer* _force_update_timer = new Timer();
-	float _min_threshold = FLT_MIN;
+	float _min_threshold = -FLT_MAX;
 	float _max_threshold = FLT_MAX;
 	float _value_delta = 0;
 #endif

--- a/nodemanager/Node.cpp
+++ b/nodemanager/Node.cpp
@@ -557,7 +557,9 @@ void NodeManager::loop() {
 		_message.setType(type);
 		// send the message, multiple times if requested
 		for (int i = 0; i < _retries; i++) {
+			Serial.println(mGetPayloadType(_message));
 			if (mGetPayloadType(_message) == P_INT16) debug_verbose(PSTR(LOG_MSG "SEND(%d) t=%d p=%d\n"),_message.sensor,_message.type,_message.getInt());
+			if (mGetPayloadType(_message) == P_LONG32) debug_verbose(PSTR(LOG_MSG "SEND(%d) t=%d p=%ld\n"),_message.sensor,_message.type,_message.getLong());
 			if (mGetPayloadType(_message) == P_FLOAT32) debug_verbose(PSTR(LOG_MSG "SEND(%d) t=%d p=%d.%02d\n"),_message.sensor,_message.type,(unsigned int)_message.getFloat(), (unsigned int)(_message.getFloat()*100)%100);
 			if (mGetPayloadType(_message) == P_STRING) debug_verbose(PSTR(LOG_MSG "SEND(%d) t=%d p=%s\n"),_message.sensor,_message.type,_message.getString());
 			send(_message, _ack);

--- a/nodemanager/Node.cpp
+++ b/nodemanager/Node.cpp
@@ -557,7 +557,6 @@ void NodeManager::loop() {
 		_message.setType(type);
 		// send the message, multiple times if requested
 		for (int i = 0; i < _retries; i++) {
-			Serial.println(mGetPayloadType(_message));
 			if (mGetPayloadType(_message) == P_INT16) debug_verbose(PSTR(LOG_MSG "SEND(%d) t=%d p=%d\n"),_message.sensor,_message.type,_message.getInt());
 			if (mGetPayloadType(_message) == P_LONG32) debug_verbose(PSTR(LOG_MSG "SEND(%d) t=%d p=%ld\n"),_message.sensor,_message.type,_message.getLong());
 			if (mGetPayloadType(_message) == P_FLOAT32) debug_verbose(PSTR(LOG_MSG "SEND(%d) t=%d p=%d.%02d\n"),_message.sensor,_message.type,(unsigned int)_message.getFloat(), (unsigned int)(_message.getFloat()*100)%100);

--- a/nodemanager/Sensor.cpp
+++ b/nodemanager/Sensor.cpp
@@ -108,6 +108,11 @@ void Sensor::setReportIntervalDays(uint8_t value) {
 	setReportIntervalSeconds(value*86400UL);
 }
 
+// return true if it is the first execution of loop on this sensor
+bool Sensor::getFirstRun() {
+	return _first_run;
+}
+
 // register a child
 void Sensor::registerChild(Child* child) {
 	children.push(child);

--- a/nodemanager/Sensor.h
+++ b/nodemanager/Sensor.h
@@ -58,6 +58,8 @@ public:
 	void setMeasureTimerMode(timer_mode value);
 	// [27] Set the value for the reporting timer's mode which has been set with setReportTimerMode() If not set explicitely, will be set with the same value as the reporting timer
 	void setMeasureTimerValue(unsigned long value);
+	// return true if it is the first execution of loop on this sensor
+	bool getFirstRun();
 	// list of configured child
 	List<Child*> children;
 	// return the child object based on the provided child_id


### PR DESCRIPTION
This PR fixes the following:

* `_min_threshold` default is now `-FT_MAX` (and no more `FT_MIN ` which is zero) (fixes #420)
* Always send out the value if it is the first run (otherwise comparison is done with 0 which is not always correct)
* Fixed `NodeManager::_sendMessage()` to print debug message when handling long int