### PR TITLE
Improve support for NRF5 boards...

### DIFF
--- a/nodemanager/Constants.h
+++ b/nodemanager/Constants.h
@@ -89,7 +89,7 @@ Chip type
 #if defined(ESP32) || defined(MY_GATEWAY_ESP32)
 #define CHIP_ESP32
 #endif
-#if defined (MYBOARDNRF5)
+#if defined (MYBOARDNRF5) || defined(NRF51) || defined(NRF52)
 #define CHIP_NRF5
 #endif
 #if !defined(CHIP_ESP8266) && !defined(CHIP_ESP32) && !defined(CHIP_STM32) && !defined(CHIP_NRF5)

--- a/sensors/DisplaySSD1306.h
+++ b/sensors/DisplaySSD1306.h
@@ -24,13 +24,21 @@
 */
 
 #include <SSD1306Ascii.h>
-#include <SSD1306AsciiAvrI2c.h>
+#ifdef CHIP_AVR
+  #include <SSD1306AsciiAvrI2c.h>
+#else
+  #include <SSD1306AsciiWire.h>
+#endif
 
 #include "Display.h"
 
 class DisplaySSD1306: public Display {
 protected:
+#ifdef CHIP_AVR
 	SSD1306AsciiAvrI2c* _oled;
+#else
+	SSD1306AsciiWire* _oled;
+#endif
 	const DevType* _dev = &Adafruit128x64;
 	uint8_t _i2caddress = 0x3c;
 	int _fontsize = 1;
@@ -125,7 +133,11 @@ public:
 	
 	// define what to do during setup
 	void onSetup() {
+#ifdef CHIP_AVR
 		_oled = new SSD1306AsciiAvrI2c();
+#else
+		_oled = new SSD1306AsciiWire();
+#endif
 		_oled->begin(_dev, _i2caddress);
 		_oled->setFont(_font);
 		if (_contrast > -1) _oled->setContrast(_contrast);

--- a/sensors/SensorConfiguration.h
+++ b/sensors/SensorConfiguration.h
@@ -19,6 +19,7 @@
 #ifndef SensorConfiguration_h
 #define SensorConfiguration_h
 
+#if NODEMANAGER_OTA_CONFIGURATION == ON
 /*
 SensorConfiguration: allow remote configuration of the board and any configured sensor
 */
@@ -126,4 +127,9 @@ public:
 		nodeManager.sendMessage(children.get(1)->getChildId(),V_CUSTOM,function);
 	};
 };
+
+#else
+#warning "SensorConfiguration.h included, but NODEMANAGER_OTA_CONFIGURATION configured to off..."
+#endif
+
 #endif


### PR DESCRIPTION
-) Allow other boards than the MyBoardNRF5*
-) use the generic SS1306 wire library rather than the AVR-specific version
-) the nrf5* has disconnected high output mode, so use this together with the sensor's pullup to prevent frying the VL53L0X laser distance sensor
-) prevent crash if _lox==NULL in VL53L0X

-) Including SensorConfiguration.h only makes sense with NODEMANAGER_OTA_CONFIGURATION, so print a compiler warning in other cases