### PR TITLE
Report PR #438, correct timer rollover, %battery

### DIFF
--- a/README.md
+++ b/README.md
@@ -493,6 +493,8 @@ The following methods are available for all the child:
 	float getValueFloat();
 	double getValueDouble();
 	const char* getValueString();
+	// check if the value must be sended back to the controller
+	bool valueReadyToSend();
 	// send the current value to the gateway
 	void sendValue(bool force = 0);
 	// print the current value on a LCD display
@@ -508,6 +510,8 @@ The following methods are available for all the child:
 	void setMaxThreshold(float value);
 	// do not report values if too close to the previous one (default: 0)
 	void setValueDelta(float value);
+	// set when the last value is updated. Possible values are UPDATE_ALWAYS (at every cycle), UPDATE_ON_SEND (only after sending) (default: UPDATE_ON_SEND)
+	void setUpdateLastValue(last_value_mode value);
 	// get the last value of the child
 	int getLastValueInt();
 	float getLastValueFloat();

--- a/nodemanager/Child.h
+++ b/nodemanager/Child.h
@@ -73,6 +73,8 @@ public:
 	float getValueFloat();
 	double getValueDouble();
 	const char* getValueString();
+	// check if the value must be sended back to the controller
+	bool valueReadyToSend();
 	// send the current value to the gateway
 	void sendValue(bool force = 0);
 	// print the current value on a LCD display
@@ -88,6 +90,8 @@ public:
 	void setMaxThreshold(float value);
 	// do not report values if too close to the previous one (default: 0)
 	void setValueDelta(float value);
+	// set when the last value is updated. Possible values are UPDATE_ALWAYS (at every cycle), UPDATE_ON_SEND (only after sending) (default: UPDATE_ON_SEND)
+	void setUpdateLastValue(last_value_mode value);
 	// get the last value of the child
 	int getLastValueInt();
 	float getLastValueFloat();
@@ -125,6 +129,7 @@ protected:
 	float _min_threshold = -FLT_MAX;
 	float _max_threshold = FLT_MAX;
 	float _value_delta = 0;
+	last_value_mode _last_value_mode = UPDATE_ON_SEND;
 #endif
 #if NODEMANAGER_EEPROM == ON
 	bool _persist_value = false;

--- a/nodemanager/Constants.h
+++ b/nodemanager/Constants.h
@@ -67,6 +67,14 @@ enum value_format {
 	STRING
 };
 
+#if NODEMANAGER_CONDITIONAL_REPORT == ON
+// define update last value modes
+enum last_value_mode {
+	UPDATE_ALWAYS,
+	UPDATE_ON_SEND
+};
+#endif
+
 /***********************************
 Chip type
 */

--- a/nodemanager/Node.cpp
+++ b/nodemanager/Node.cpp
@@ -30,7 +30,9 @@ NodeManager::NodeManager(uint8_t sensor_count) {
 	// allocate block for all the sensors if sensor_count is provided
 	if (sensor_count > 0) sensors.allocateBlocks(sensor_count);
 	// setup serial port baud rate
+#ifndef CHIP_NRF5
 	MY_SERIALDEVICE.begin(MY_BAUD_RATE);
+#endif
 	// print out the version
 	debug(PSTR(LOG_INIT "VER=" VERSION "\n"));
 	// print out sketch name

--- a/nodemanager/Timer.cpp
+++ b/nodemanager/Timer.cpp
@@ -27,17 +27,22 @@ Timer::Timer() {
 	nodeManager.registerTimer(this);
 }
 
+// set the timer mode
 void Timer::setMode(timer_mode mode) {
 	_mode = mode;
 }
+
+// get the timer mode
 timer_mode Timer::getMode() {
 	return _mode;
 }
 
+// set the timer value in seconds
 void Timer::setValue(unsigned long value) {
 	_value = value;
 }
 
+// get the timer value in seconds
 unsigned long Timer::getValue() {
 	return _value;
 }
@@ -104,8 +109,8 @@ bool Timer::isOver() {
 	}
 #else
 	if (_mode == TIME_INTERVAL) {
-		// check if the current millis() is greater than the target
-		if (millis() > _target) return true;
+		// check for a millis() rollover. The difference between millis() and the target (in seconds) cannot be less than value
+		if ( (_target - millis()) >= (_value * 1000UL) ) return true;
 		return false;
 	}
 #endif

--- a/nodemanager/Timer.h
+++ b/nodemanager/Timer.h
@@ -42,8 +42,8 @@ public:
 	bool isOver();
 private:
 	timer_mode _mode = NOT_CONFIGURED;
-	unsigned long _value = 0;
-	unsigned long _target = 0;
+	unsigned long _value = 0;  // s
+	unsigned long _target = 0;  // ms
 	bool _is_running = false;
 #if NODEMANAGER_TIME == ON
 	bool _already_reported = false;

--- a/sensors/Display.h
+++ b/sensors/Display.h
@@ -35,6 +35,9 @@ public:
 		new Child(this,STRING,nodeManager.getAvailableChildId(child_id), S_INFO, V_TEXT,_name);
 		// prevent reporting to the gateway at each display update
 		setReportTimerMode(DO_NOT_REPORT);
+		// refresh the display every minute by default
+		setMeasureTimerValue(TIME_INTERVAL);
+		setMeasureTimerValue(60UL);
 	};
 
 	// set a static caption text on header of the display

--- a/sensors/SensorBattery.h
+++ b/sensors/SensorBattery.h
@@ -97,7 +97,7 @@ public:
 		}
 		volt = volt * _battery_adj_factor;
 		child->setValue(volt);
-		if (_send_battery_level) {
+		if (_send_battery_level && child->valueReadyToSend()) {
 			// calculate the percentage
 			int percentage = ((volt - _battery_min) / (_battery_max - _battery_min)) * 100;
 			if (percentage > 100) percentage = 100;


### PR DESCRIPTION
Report all changes from PR #438
Correct timer rollover
Send battery % only when battery level is reported

@user2684, This PR can replace PR #438. All changes done in #438 are included here.
In addion I change the Timer rolover test and add a test in order to send battery % only when battery level is send in order to reduce battery usage. Conditional report is modified, I test it but please take a look.

If you agree with my modifications, you can merge this PR or add the modifications to PR #438. At the end only one PR, #438 or #440 (this one) must be merged. The orher one must be closed. 