### PR TITLE
Fix bug where loop() is run for ALL sensors after an interrupt

### DIFF
--- a/nodemanager/Node.cpp
+++ b/nodemanager/Node.cpp
@@ -265,8 +265,6 @@ void NodeManager::loop() {
 		if (_last_interrupt_pin != -1 && sensor->getInterruptPin() == _last_interrupt_pin) {
 			// call the sensor interrupt() and then loop(), provided the interrupt has been "accepted" by interrupt()
 			if (sensor->interrupt()) sensor->loop(nullptr);
-			// reset the last interrupt pin
-			_last_interrupt_pin = -1;
 		}
 		else if (_last_interrupt_pin == -1) {
 #endif
@@ -276,6 +274,8 @@ void NodeManager::loop() {
 		}
 #endif
 	}
+	// reset the last interrupt pin
+	_last_interrupt_pin = -1;
 #if NODEMANAGER_POWER_MANAGER == ON
 	// turn off the pin powering all the sensors
 	powerOff();


### PR DESCRIPTION
Fix to ensure intended behaviour for SensorDoor (and other interrupt sensors) - when the SensorDoor changes state, the node should wake up, report the value of SensorDoor only, then go straight back to sleep.

What it actually did (before this fix) is wake up, skip over all sensors with a child_id lower than the SensorDoor, report on SensorDoor, then report on all the sensors with a child_id higher than the SensorDoor, before going back to sleep.