### PR TITLE
Fixes Display showing always all zeros

### DIFF
--- a/nodemanager/Child.cpp
+++ b/nodemanager/Child.cpp
@@ -105,6 +105,11 @@ void Child::setValue(const char* value) {
 // store a new value and update the total
 void Child::_setValueNumber(double value) {
 	if (isnan(value)) return;
+	// this is the first measure after a send(), reset _value and _total
+	if (_samples == 0) {
+		_value = 0; 
+		_total = 0;
+	}
 	if (_value_processing != NONE) _total = _total + value;
 	// keep track of the samples
 	_samples++;
@@ -211,15 +216,12 @@ void Child::print(Print& device) {
 void Child::reset() { 
 	if (_format != STRING) {
 		if (_value_processing != NONE) {
-			// reset the counters
-			_total = 0;
-			_value = 0;
 #if NODEMANAGER_EEPROM == ON
 			// if the value is supposed to be persisted in EEPROM, save it
 			if (_persist_value) saveValue();
 #endif
 		}
-	} else _value_string = "";
+	}
 	_samples = 0;
 }
 

--- a/sensors/Display.h
+++ b/sensors/Display.h
@@ -36,7 +36,7 @@ public:
 		// prevent reporting to the gateway at each display update
 		setReportTimerMode(DO_NOT_REPORT);
 		// refresh the display every minute by default
-		setMeasureTimerValue(TIME_INTERVAL);
+		setMeasureTimerMode(TIME_INTERVAL);
 		setMeasureTimerValue(60UL);
 	};
 


### PR DESCRIPTION
* Using `setMeasureTimerMode()` - before `setMeasureTimerValue()` was wrongly called twice
* Changed the logic of child reset (#433). If resetting `_value` after send() both display and hook functions do not have the latest value available. `reset()` no more set `_value` and `_total` to 0 but this is done in `_setValueNumber()` when _samples is 0.