### PR TITLE
Bosch sensors improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,10 +109,10 @@ SensorMotion             | 1     | Motion sensor, wake up the board and report w
 SensorDs18b20            | 1+    | DS18B20 sensor, return the temperature based on the attached sensor                               | https://github.com/milesburton/Arduino-Temperature-Control-Library
 SensorBH1750             | 1     | BH1750 sensor, return light level in lux                                                          | https://github.com/claws/BH1750
 SensorMLX90614           | 2     | MLX90614 contactless temperature sensor, return ambient and object temperature                    | https://github.com/adafruit/Adafruit-MLX90614-Library
-SensorBME280             | 4     | BME280 sensor, return temperature/humidity/pressure based on the attached BME280 sensor           | https://github.com/adafruit/Adafruit_BME280_Library
-SensorBMP085             | 3     | BMP085 sensor, return temperature and pressure                                                    | https://github.com/adafruit/Adafruit-BMP085-Library
-SensorBMP180             | 3     | BMP180 sensor, return temperature and pressure                                                    | https://github.com/adafruit/Adafruit-BMP085-Library
-SensorBMP280             | 3     | BMP280 sensor, return temperature/pressure based on the attached BMP280 sensor                    | https://github.com/adafruit/Adafruit_BMP280_Library
+SensorBME280             | 4     | BME280 sensor, return temperature/humidity/pressure based on the attached BME280 sensor           | https://github.com/adafruit/Adafruit_BME280_Library / https://github.com/adafruit/Adafruit_Sensor
+SensorBMP085             | 3     | BMP085 sensor, return temperature and pressure                                                    | https://github.com/adafruit/Adafruit-BMP085-Library / https://github.com/adafruit/Adafruit_Sensor
+SensorBMP180             | 3     | BMP180 sensor, return temperature and pressure                                                    | https://github.com/adafruit/Adafruit-BMP085-Library / https://github.com/adafruit/Adafruit_Sensor
+SensorBMP280             | 3     | BMP280 sensor, return temperature/pressure based on the attached BMP280 sensor                    | https://github.com/adafruit/Adafruit_BMP280_Library / https://github.com/adafruit/Adafruit_Sensor
 SensorSonoff             | 1     | Sonoff wireless smart switch                                                                      | https://github.com/thomasfredericks/Bounce2
 SensorHCSR04             | 1     | HC-SR04 sensor, return the distance between the sensor and an object                              | https://github.com/mysensors/MySensorsArduinoExamples/tree/master/libraries/NewPing
 SensorMCP9808            | 1     | MCP9808 sensor, measure the temperature through the attached module                               | https://github.com/adafruit/Adafruit_MCP9808_Library

--- a/examples/Template/Template.ino
+++ b/examples/Template/Template.ino
@@ -259,6 +259,7 @@ NodeManager. Just uncomment the settings you need and the sensors you want to ad
 //#include <sensors/SensorMLX90614.h>
 //SensorMLX90614 mlx90614;
 
+//#define NODEMANAGER_SENSOR_BOSCH_LITE
 //#include <sensors/SensorBME280.h>
 //SensorBME280 bme280;
 

--- a/sensors/SensorBME280.h
+++ b/sensors/SensorBME280.h
@@ -37,11 +37,17 @@ protected:
 public:
 	SensorBME280(uint8_t child_id = 0): SensorBosch(child_id) {
 		_name = "BME280";
+#if !defined(NODEMANAGER_SENSOR_BOSCH_LITE)
 		children.allocateBlocks(4);
+#else
+		children.allocateBlocks(3);
+#endif
 		new Child(this,FLOAT,nodeManager.getAvailableChildId(child_id),S_TEMP,V_TEMP,_name);
 		new Child(this,FLOAT,child_id > 0 ? nodeManager.getAvailableChildId(child_id+1) : nodeManager.getAvailableChildId(child_id),S_HUM,V_HUM,_name);
 		new Child(this,FLOAT,child_id > 0 ? nodeManager.getAvailableChildId(child_id+2) : nodeManager.getAvailableChildId(child_id),S_BARO,V_PRESSURE,_name);
+#if !defined(NODEMANAGER_SENSOR_BOSCH_LITE)
 		new Child(this,STRING,child_id > 0 ? nodeManager.getAvailableChildId(child_id+3) : nodeManager.getAvailableChildId(child_id),S_BARO,V_FORECAST,_name);
+#endif
 	};
 	
 	// set custom sampling to the sensor
@@ -80,11 +86,13 @@ public:
 			// store the value
 			child->setValue(pressure);
 		}
+#if !defined(NODEMANAGER_SENSOR_BOSCH_LITE)
 		// Forecast Sensor
 		else if (child->getType() == V_FORECAST) {
 			float pressure = _bm->readPressure() / 100.0F;
 			child->setValue(_forecast(pressure));
 		}
+#endif
 	};
 };
 #endif

--- a/sensors/SensorBMP085.h
+++ b/sensors/SensorBMP085.h
@@ -35,10 +35,16 @@ protected:
 public:
 	SensorBMP085(uint8_t child_id = 0): SensorBosch(child_id) {
 		_name = "BMP085";
+#if !defined(NODEMANAGER_SENSOR_BOSCH_LITE)
 		children.allocateBlocks(3);
+#else
+		children.allocateBlocks(2);
+#endif
 		new Child(this,FLOAT,nodeManager.getAvailableChildId(child_id),S_TEMP,V_TEMP,_name);
 		new Child(this,FLOAT,child_id > 0 ? nodeManager.getAvailableChildId(child_id+1) : nodeManager.getAvailableChildId(child_id),S_BARO,V_PRESSURE,_name);
+#if !defined(NODEMANAGER_SENSOR_BOSCH_LITE)
 		new Child(this,STRING,child_id > 0 ? nodeManager.getAvailableChildId(child_id+2) : nodeManager.getAvailableChildId(child_id),S_BARO,V_FORECAST,_name);
+#endif
 	};
 
 	// define what to do during setup
@@ -65,11 +71,13 @@ public:
 			// store the value
 			child->setValue(pressure);
 		}
+#if !defined(NODEMANAGER_SENSOR_BOSCH_LITE)
 		// Forecast Sensor
 		else if (child->getType() == V_FORECAST) {
 			float pressure = _bm->readPressure() / 100.0F;
 			child->setValue(_forecast(pressure));
 		}
+#endif
 	};
 };
 #endif

--- a/sensors/SensorBMP180.h
+++ b/sensors/SensorBMP180.h
@@ -31,7 +31,9 @@ public:
 		_name = "BMP180";
 		children.get(1)->setDescription(_name);
 		children.get(2)->setDescription(_name);
+#if !defined(NODEMANAGER_SENSOR_BOSCH_LITE)
 		children.get(3)->setDescription(_name);
+#endif
 	};
 };
 #endif

--- a/sensors/SensorBMP280.h
+++ b/sensors/SensorBMP280.h
@@ -36,10 +36,16 @@ protected:
 public:
 	SensorBMP280(uint8_t child_id = 0): SensorBosch(child_id) {
 		_name = "BMP280";
+#if !defined(NODEMANAGER_SENSOR_BOSCH_LITE)
 		children.allocateBlocks(3);
+#else
+		children.allocateBlocks(2);
+#endif
 		new Child(this,FLOAT,nodeManager.getAvailableChildId(child_id),S_TEMP,V_TEMP,_name);
 		new Child(this,FLOAT,child_id > 0 ? nodeManager.getAvailableChildId(child_id+1) : nodeManager.getAvailableChildId(child_id),S_BARO,V_PRESSURE,_name);
+#if !defined(NODEMANAGER_SENSOR_BOSCH_LITE)
 		new Child(this,STRING,child_id > 0 ? nodeManager.getAvailableChildId(child_id+2) : nodeManager.getAvailableChildId(child_id),S_BARO,V_FORECAST,_name);
+#endif
 
 	};
 
@@ -67,11 +73,13 @@ public:
 			// store the value
 			child->setValue(pressure);
 		}
+#if !defined(NODEMANAGER_SENSOR_BOSCH_LITE)
 		// Forecast Sensor
 		else if (child->getType() == V_FORECAST) {
 			float pressure = _bm->readPressure() / 100.0F;
 			child->setValue(_forecast(pressure));
 		}
+#endif
 	};
 };
 #endif

--- a/sensors/SensorBosch.h
+++ b/sensors/SensorBosch.h
@@ -25,6 +25,7 @@
 
 class SensorBosch: public Sensor {
 protected:
+#if !defined(NODEMANAGER_SENSOR_BOSCH_LITE)
 	const char* _weather[6] = { "stable", "sunny", "cloudy", "unstable", "thunderstorm", "unknown" };
 	int _forecast_samples_count = 5;
 	float* _forecast_samples;
@@ -33,18 +34,23 @@ protected:
 	float _pressure_avg2;
 	float _dP_dt;
 	bool _first_round = true;
-	
+#endif
+
 public:
 	SensorBosch(uint8_t child_id = 0): Sensor(-1) {
 		_name = "BOSCH";
+#if !defined(NODEMANAGER_SENSOR_BOSCH_LITE)
 		// initialize the forecast samples array
 		_forecast_samples = new float[_forecast_samples_count];
+#endif
 	};
 	
+#if !defined(NODEMANAGER_SENSOR_BOSCH_LITE)
 	// [101] define how many pressure samples to keep track of for calculating the forecast (default: 5)
 	void setForecastSamplesCount(int value) {
 		_forecast_samples_count = value;
 	};
+#endif
 	
 	// search for a given chip on i2c bus (emulating Adafruit's init() function)
 	uint8_t detectI2CAddress(uint8_t chip_id) {
@@ -84,6 +90,7 @@ public:
 #endif
 	
 protected:
+#if !defined(NODEMANAGER_SENSOR_BOSCH_LITE)
 	// returns the average of the latest pressure samples
 	float _getLastPressureSamplesAverage() {
 		float avg = 0;
@@ -158,5 +165,6 @@ protected:
 		else forecast = 5;
 		return _weather[forecast];
 	};
+#endif
 };
 #endif


### PR DESCRIPTION
- Added `NODEMANAGER_SENSOR_BOSCH_LITE `define which will exclude the forecast child so saving storage (see below) (fix #455 #393)

Without `NODEMANAGER_SENSOR_BOSCH_LITE`:
```
Sketch uses 25336 bytes (82%) of program storage space. Maximum is 30720 bytes.
Global variables use 800 bytes (39%) of dynamic memory, leaving 1248 bytes for local variables. Maximum is 2048 bytes.
```

With `NODEMANAGER_SENSOR_BOSCH_LITE`:
```
Sketch uses 24176 bytes (78%) of program storage space. Maximum is 30720 bytes.
Global variables use 715 bytes (34%) of dynamic memory, leaving 1333 bytes for local variables. Maximum is 2048 bytes.
```