### PR TITLE
Core Multiple Fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,6 +289,10 @@ You can interact with each class provided by NodeManager through a set of API fu
 	void sleepBetweenSend();
 	// set the analog reference to the given value and optionally perform some fake reading on the given pin
 	void setAnalogReference(uint8_t value, uint8_t pin = -1);
+	// send the configured unit prefix just before sending the first measure (default: false)
+	void setSendUnitPrefix(bool value);
+	// return the default unit prefix for the given sensor presentation and type
+	const char* getDefaultUnitPrefix(uint8_t presentation, uint8_t type);
 #if NODEMANAGER_SLEEP == ON
 	// [3] set the duration (in seconds) of a sleep cycle
 	void setSleepSeconds(unsigned long value);
@@ -465,7 +469,7 @@ The following methods are available for all the sensors:
 
 The following methods are available for all the child:
 ~~~c
-	Child(Sensor* sensor, value_format format, uint8_t child_id, uint8_t presentation, uint8_t type, const char* description = "");
+	Child(Sensor* sensor, value_format format, uint8_t child_id, uint8_t presentation, uint8_t type, const char* description = "", const char* unit_prefix = "");
 	// set child id used to communicate with the gateway/controller
 	void setChildId(uint8_t value);
 	uint8_t getChildId();

--- a/README.md
+++ b/README.md
@@ -301,6 +301,8 @@ You can interact with each class provided by NodeManager through a set of API fu
 	void setSleepDays(uint8_t value);
 	// [20] optionally sleep interval in milliseconds before sending each message to the radio network (default: 0)
 	void setSleepBetweenSend(unsigned int value);
+	// [43] when sleep between send is set, by default the node will only wait, set it to true to make it sleeping for long intervals (default: false)
+	void setSleepBetweenSendSleepOrWait(bool value);
 	// [9] wake up the board
 	void wakeup();
 	// use smart sleep for sleeping boards (default: true)

--- a/README.md
+++ b/README.md
@@ -469,7 +469,7 @@ The following methods are available for all the sensors:
 
 The following methods are available for all the child:
 ~~~c
-	Child(Sensor* sensor, value_format format, uint8_t child_id, uint8_t presentation, uint8_t type, const char* description = "", const char* unit_prefix = "");
+	Child(Sensor* sensor, value_format format, uint8_t child_id, uint8_t presentation, uint8_t type, const char* description = "", const char* unit_prefix = "", , bool request_initial_value = false);
 	// set child id used to communicate with the gateway/controller
 	void setChildId(uint8_t value);
 	uint8_t getChildId();
@@ -509,6 +509,9 @@ The following methods are available for all the child:
 	void print(Print& device);
 	// reset all the counters
 	void reset();
+	// if set request the controller the initial value of this child (default: false)
+	void setRequestInitialValue(bool value);
+	bool getRequestInitialValue();
 #if NODEMANAGER_CONDITIONAL_REPORT == ON
 	// force to send an update after the configured number of minutes
 	void setForceUpdateTimerValue(unsigned long value);

--- a/README.md
+++ b/README.md
@@ -323,6 +323,8 @@ You can interact with each class provided by NodeManager through a set of API fu
 	int8_t getLastInterruptPin();
 	// return the value of the pin from which the last interrupt came
 	int8_t getLastInterruptValue();
+	// setup the interrupt pins
+	void setupInterrupts(bool from_setup);
 #endif
 #if NODEMANAGER_POWER_MANAGER == ON
 	// configure a PowerManager common to all the sensors
@@ -343,6 +345,9 @@ You can interact with each class provided by NodeManager through a set of API fu
 	void saveToMemory(int index, int value);
 	// [40] if set save the sleep settings in memory, also when changed remotely (default: false)
 	void setSaveSleepSettings(bool value);
+	// keep track in the eeprom of enabled/disabled status for each sensor (default: false)
+	void setPersistEnabledSensors(bool value);
+	bool getPersistEnabledSensors();
 #endif
 #if NODEMANAGER_TIME == ON
 	// [41] synchronize the local time with the controller
@@ -411,6 +416,9 @@ The following methods are available for all the sensors:
 	Child* getChild(uint8_t child_id);
 	// register a child
 	void registerChild(Child* child);
+	// [28] enabler/disable the sensor (default: true)
+	void setEnabled(bool value, bool just_set = false);
+	bool getEnabled();
 #if NODEMANAGER_INTERRUPTS == ON
 	// return the pin the interrupt is attached to
 	int8_t getInterruptPin();

--- a/keywords.txt
+++ b/keywords.txt
@@ -119,6 +119,7 @@ setSamplesInterval	KEYWORD2
 setSaveSleepSettings	KEYWORD2
 setSetupHook	KEYWORD2
 setSleepBetweenSend	KEYWORD2
+setSleepBetweenSendSleepOrWait KEYWORD2
 setSleepDays	KEYWORD2
 setSleepHours	KEYWORD2
 setSleepInterruptPin	KEYWORD2

--- a/nodemanager/Child.cpp
+++ b/nodemanager/Child.cpp
@@ -27,7 +27,7 @@ Child::Child() {
 }
 
 // constructor
-Child::Child(Sensor* sensor, value_format format, uint8_t child_id, uint8_t presentation, uint8_t type, const char* description, const char* unit_prefix) {
+Child::Child(Sensor* sensor, value_format format, uint8_t child_id, uint8_t presentation, uint8_t type, const char* description, const char* unit_prefix, bool request_initial_value) {
 	_sensor = sensor;
 	setFormat(format);
 	_child_id = child_id;
@@ -35,6 +35,7 @@ Child::Child(Sensor* sensor, value_format format, uint8_t child_id, uint8_t pres
 	_type = type;
 	_description = description;
 	_unit_prefix = unit_prefix;
+	_request_initial_value = request_initial_value;
 	// register the child with the sensor
 	_sensor->registerChild(this);
 #if NODEMANAGER_EEPROM == ON
@@ -108,6 +109,12 @@ void Child::setUnitPrefix(const char* value) {
 const char* Child::getUnitPrefix() {
 	if (_unit_prefix == NULL) return nodeManager.getDefaultUnitPrefix(_presentation,_type);
 	return _unit_prefix;
+}
+void Child::setRequestInitialValue(bool value) {
+	_request_initial_value = value;
+}
+bool Child::getRequestInitialValue() {
+	return _request_initial_value;
 }
 
 // store a new value and update the total

--- a/nodemanager/Child.cpp
+++ b/nodemanager/Child.cpp
@@ -27,13 +27,14 @@ Child::Child() {
 }
 
 // constructor
-Child::Child(Sensor* sensor, value_format format, uint8_t child_id, uint8_t presentation, uint8_t type, const char* description) {
+Child::Child(Sensor* sensor, value_format format, uint8_t child_id, uint8_t presentation, uint8_t type, const char* description, const char* unit_prefix) {
 	_sensor = sensor;
 	setFormat(format);
 	_child_id = child_id;
 	_presentation = presentation;
 	_type = type;
 	_description = description;
+	_unit_prefix = unit_prefix;
 	// register the child with the sensor
 	_sensor->registerChild(this);
 #if NODEMANAGER_EEPROM == ON
@@ -100,6 +101,13 @@ void Child::setValue(const char* value) {
 	_value_string = value;
 	_samples = 1;
 	debug(PSTR(LOG_LOOP "%s(%d):SET t=%d v=%s\n"),_description,_child_id,_type,_value_string);
+}
+void Child::setUnitPrefix(const char* value) {
+	_unit_prefix = value;
+}
+const char* Child::getUnitPrefix() {
+	if (_unit_prefix == NULL) return nodeManager.getDefaultUnitPrefix(_presentation,_type);
+	return _unit_prefix;
 }
 
 // store a new value and update the total
@@ -181,20 +189,21 @@ void Child::sendValue(bool force) {
 	// update last value if mode = UPDATE_ALWAYS
 	if (_last_value_mode == UPDATE_ALWAYS) _last_value = _value;
 #endif
-
 	// ignore conditional reporting settings if forced to report
 	if (!force && !valueReadyToSend()) return;
-
 	// we report value
 #if NODEMANAGER_CONDITIONAL_REPORT == ON
 	// if the force update timer is over restart it
 	if (_force_update_timer->isOver()) _force_update_timer->start();
-
 	// keep track of the previous value
 	if (_format != STRING) _last_value = _value;
 	else _last_value_string = _value_string;
 #endif
-
+	// send unit prefix if configured to do so
+	if (nodeManager.getSendUnitPrefix() && ! _unit_prefix_sent) {
+		nodeManager.sendMessage(_child_id,V_UNIT_PREFIX,getUnitPrefix());
+		_unit_prefix_sent = true;
+	}
 	// send the value to the gateway
 	if (_format == INT) nodeManager.sendMessage(_child_id,_type,(int)_value);
 	if (_format == FLOAT) nodeManager.sendMessage(_child_id,_type,(float)_value,_float_precision);

--- a/nodemanager/Child.h
+++ b/nodemanager/Child.h
@@ -41,7 +41,7 @@ class Sensor;
 class Child {
 public:
 	Child();
-	Child(Sensor* sensor, value_format format, uint8_t child_id, uint8_t presentation, uint8_t type, const char* description = "");
+	Child(Sensor* sensor, value_format format, uint8_t child_id, uint8_t presentation, uint8_t type, const char* description = "", const char* unit_prefix = NULL);
 	// set child id used to communicate with the gateway/controller
 	void setChildId(uint8_t value);
 	uint8_t getChildId();
@@ -59,6 +59,9 @@ public:
 	// set sensor description
 	void setDescription(const char* value);
 	const char* getDescription();
+	// set sensor unit
+	void setUnitPrefix(const char* value);
+	const char* getUnitPrefix();
 	// configure the behavior of the child when setValue() is called multiple times. It can be NONE (ignore the previous values but the last one),  AVG (averages the values), SUM (sum up the values) (default: AVG)
 	void setValueProcessing(child_processing value);
 	// send the value to the gateway even if there have been no samples collected (default: false)
@@ -122,6 +125,8 @@ protected:
 	double _total = 0;
 	bool _send_without_value = false;
 	void _setValueNumber(double value);
+	const char* _unit_prefix = NULL;
+	bool _unit_prefix_sent = false;
 #if NODEMANAGER_CONDITIONAL_REPORT == ON
 	double _last_value = 0;
 	const char* _last_value_string = "";

--- a/nodemanager/Child.h
+++ b/nodemanager/Child.h
@@ -41,7 +41,7 @@ class Sensor;
 class Child {
 public:
 	Child();
-	Child(Sensor* sensor, value_format format, uint8_t child_id, uint8_t presentation, uint8_t type, const char* description = "", const char* unit_prefix = NULL);
+	Child(Sensor* sensor, value_format format, uint8_t child_id, uint8_t presentation, uint8_t type, const char* description = "", const char* unit_prefix = NULL, bool request_initial_value = false);
 	// set child id used to communicate with the gateway/controller
 	void setChildId(uint8_t value);
 	uint8_t getChildId();
@@ -84,6 +84,9 @@ public:
 	void print(Print& device);
 	// reset all the counters
 	void reset();
+	// if set request the controller the initial value of this child (default: false)
+	void setRequestInitialValue(bool value);
+	bool getRequestInitialValue();
 #if NODEMANAGER_CONDITIONAL_REPORT == ON
 	// force to send an update after the configured number of minutes
 	void setForceUpdateTimerValue(unsigned long value);
@@ -127,6 +130,7 @@ protected:
 	void _setValueNumber(double value);
 	const char* _unit_prefix = NULL;
 	bool _unit_prefix_sent = false;
+	bool _request_initial_value = false;
 #if NODEMANAGER_CONDITIONAL_REPORT == ON
 	double _last_value = 0;
 	const char* _last_value_string = "";

--- a/nodemanager/Node.cpp
+++ b/nodemanager/Node.cpp
@@ -524,6 +524,7 @@ void NodeManager::loop() {
 		if (_interrupt_debounce > 0 &&  (millis() - _last_interrupt_millis < _interrupt_debounce) && pin == _last_interrupt_pin && millis() > _last_interrupt_millis) return;
 		// save pin and value
 		_last_interrupt_pin = pin;
+		_last_interrupt_millis = millis();
 		_last_interrupt_value = digitalRead(pin);
 		debug(PSTR(LOG_LOOP "INT p=%d v=%d\n"),_last_interrupt_pin,_last_interrupt_value);
 	}

--- a/nodemanager/Node.cpp
+++ b/nodemanager/Node.cpp
@@ -324,6 +324,10 @@ void NodeManager::loop() {
 	// dispacth inbound messages
 	void NodeManager::receive(const MyMessage &message) {
 		debug_verbose(PSTR(LOG_MSG "RECV(%d) c=%d t=%d p=%s\n"),message.sensor,message.getCommand(),message.type,message.getString());
+		// ignore the message if we are not the final destination
+		if (getNodeId() != message.getDestination()) return;
+		// ignore the message if we are running a gatway and the message is coming from a different node (to avoid triggering our sensors when others are reporting)
+		if (getNodeId() == 0 && message.getSender() != 0) return;
 		// dispatch the message to the registered sensor
 		Sensor* sensor = getSensorWithChild(message.sensor);
 		if (sensor != nullptr) {

--- a/nodemanager/Node.cpp
+++ b/nodemanager/Node.cpp
@@ -752,3 +752,29 @@ void NodeManager::setAnalogReference(uint8_t value, uint8_t pin) {
 #endif
 }
 
+// send the configured unit prefix just before sending the first measure (default: false)
+void NodeManager::setSendUnitPrefix(bool value) {
+	_send_unit_prefix = value;
+}
+bool NodeManager::getSendUnitPrefix() {
+	return _send_unit_prefix;
+}
+
+// return the default unit prefix for the given sensor presentation and type
+const char* NodeManager::getDefaultUnitPrefix(uint8_t presentation, uint8_t type) {
+	const char* percentage = "%";
+	if (type == V_TEMP) {
+		if (getIsMetric()) return "C";
+		else return "F";
+	}
+	else if (type == V_HUM || type == V_PERCENTAGE) return percentage;
+	else if (type == V_PRESSURE) return "Pa";
+	else if (type == V_WIND || type == V_GUST) return "Km/h";
+	else if (type == V_VOLTAGE) return "V";
+	else if (type == V_CURRENT) return "A";
+	else if (type == V_LEVEL && presentation == S_SOUND) return "dB";
+	else if (type == V_LIGHT_LEVEL && presentation == S_LIGHT_LEVEL) return percentage;
+	else if (type == V_RAINRATE) return percentage;
+	else if (type == V_LEVEL && presentation == S_MOISTURE) return percentage;
+	else return "";
+}

--- a/nodemanager/Node.cpp
+++ b/nodemanager/Node.cpp
@@ -69,6 +69,9 @@ unsigned long NodeManager::getSleepSeconds() {
 void NodeManager::setSleepBetweenSend(unsigned int value) {
 	_sleep_between_send = value;
 }
+void NodeManager::setSleepBetweenSendSleepOrWait(bool value) {
+	_sleep_between_send_sleep_or_wait = value;
+}
 #endif
 #if NODEMANAGER_INTERRUPTS == ON
 void NodeManager::setSleepInterruptPin(int8_t value) {
@@ -722,8 +725,9 @@ void NodeManager::loop() {
 
 // sleep between send()
 void NodeManager::sleepBetweenSend() {
-	// if we sleep here ack management will not work
-	if (_sleep_between_send > 0) wait(_sleep_between_send);
+	if (_sleep_between_send == 0) return;
+	if (_sleep_between_send_sleep_or_wait) sleepOrWait(_sleep_between_send);
+	else wait(_sleep_between_send);
 }
 
 // set the analog reference 

--- a/nodemanager/Node.h
+++ b/nodemanager/Node.h
@@ -85,6 +85,11 @@ public:
 	void sleepBetweenSend();
 	// set the analog reference to the given value and optionally perform some fake reading on the given pin
 	void setAnalogReference(uint8_t value, uint8_t pin = 0);
+	// send the configured unit prefix just before sending the first measure (default: false)
+	void setSendUnitPrefix(bool value);
+	bool getSendUnitPrefix();
+	// return the default unit prefix for the given sensor presentation and type
+	const char* getDefaultUnitPrefix(uint8_t presentation, uint8_t type);
 #if NODEMANAGER_SLEEP == ON
 	// [3] set the duration (in seconds) of a sleep cycle
 	void setSleepSeconds(unsigned long value);
@@ -184,6 +189,7 @@ private:
 	uint8_t _reboot_pin = 0;
 	void _present(uint8_t child_id, uint8_t type);
 	List<InternalTimer*> _timers;
+	bool _send_unit_prefix = false;
 #if defined(ARDUINO_ARCH_STM32F1)
 	uint8_t _analog_reference = -1;
 #else

--- a/nodemanager/Node.h
+++ b/nodemanager/Node.h
@@ -97,6 +97,8 @@ public:
 	void setSleepDays(uint8_t value);
 	// [20] optionally sleep interval in milliseconds before sending each message to the radio network (default: 0)
 	void setSleepBetweenSend(unsigned int value);
+	// [43] when sleep between send is set, by default the node will only wait, set it to true to make it sleeping for long intervals (default: false)
+	void setSleepBetweenSendSleepOrWait(bool value);
 	// [9] wake up the board
 	void wakeup();
 	// use smart sleep for sleeping boards (default: true)
@@ -177,6 +179,7 @@ private:
 	bool _sleep_or_wait = true;
 	uint8_t _sleep_interrupt_pin = 0;
 	unsigned int _sleep_between_send = 0;
+	bool _sleep_between_send_sleep_or_wait = false;
 	unsigned long _report_interval_seconds = 10*60;
 	uint8_t _reboot_pin = 0;
 	void _present(uint8_t child_id, uint8_t type);

--- a/nodemanager/Node.h
+++ b/nodemanager/Node.h
@@ -120,6 +120,8 @@ public:
 	int8_t getLastInterruptPin();
 	// return the value of the pin from which the last interrupt came
 	int8_t getLastInterruptValue();
+	// setup the interrupt pins
+	void setupInterrupts(bool from_setup);
 #endif
 #if NODEMANAGER_POWER_MANAGER == ON
 	// configure a PowerManager common to all the sensors
@@ -140,6 +142,9 @@ public:
 	void saveToMemory(int index, int value);
 	// [40] if set save the sleep settings in memory, also when changed remotely (default: false)
 	void setSaveSleepSettings(bool value);
+	// keep track in the eeprom of enabled/disabled status for each sensor (default: false)
+	void setPersistEnabledSensors(bool value);
+	bool getPersistEnabledSensors();
 #endif
 #if NODEMANAGER_TIME == ON
 	// [41] synchronize the local time with the controller
@@ -204,11 +209,11 @@ private:
 	static int8_t _last_interrupt_value;
 	static long unsigned _interrupt_debounce;
 	static long unsigned _last_interrupt_millis;
-	void _setupInterrupts();
 	static void _onInterrupt_1();
 	static void _onInterrupt_2();
+	bool _run_interrupt_setup = false;
 	static void _saveInterrupt(int8_t pin);
-#endif
+	#endif
 #if NODEMANAGER_SLEEP == ON
 	void _sleep();
 	bool _smart_sleep = true;
@@ -218,6 +223,7 @@ private:
 #endif
 #if NODEMANAGER_EEPROM == ON
 	bool _save_sleep_settings = false;
+	bool _persist_enabled_sensors = false;
 	void _loadSleepSettings();
 	void _saveSleepSettings();
 #endif

--- a/nodemanager/Sensor.cpp
+++ b/nodemanager/Sensor.cpp
@@ -300,6 +300,41 @@ void Sensor::setReceiveHook(void (*function)(Sensor* sensor, MyMessage* message)
 }
 #endif
 
+// enabler/disable the sensor
+void Sensor::setEnabled(bool value, bool just_set) {
+	if (!just_set) {
+		// sensors was enabled and now has to be disable
+		if (_enabled && ! value) {
+			setup();
+#if NODEMANAGER_INTERRUPTS == ON
+			nodeManager.setupInterrupts();
+#endif
+		}
+		// sensors was disabled and now has to be enable
+		if (!_enabled && value) {
+#if NODEMANAGER_INTERRUPTS == ON
+			nodeManager.setupInterrupts();
+#endif		
+		}
+#if NODEMANAGER_EEPROM == ON
+		// if the status of a sensor has to be persisted in EEPROM
+		if (_enabled != value && nodeManager.getPersistEnabledSensors()) {
+			// iterates over all the children
+			for (List<Child*>::iterator itr = children.begin(); itr != children.end(); ++itr) {
+				Child* child = *itr;
+				// save to the index equals to child id the enabled flag
+				nodeManager.saveToMemory(child->getChildId(), value);
+			}
+		}
+#endif
+	}
+	_enabled = value;
+}
+
+bool Sensor::getEnabled() {
+	return _enabled;
+}
+
 // virtual functions
 void Sensor::onSetup(){
 }

--- a/nodemanager/Sensor.cpp
+++ b/nodemanager/Sensor.cpp
@@ -157,6 +157,17 @@ void Sensor::setup() {
 	// start the timers
 	_report_timer->start();
 	_measure_timer->start();
+	// for each child, request the initial value to the controller if configured
+	bool requested_initial_value = false;
+	for (List<Child*>::iterator itr = children.begin(); itr != children.end(); ++itr) {
+		Child* child = *itr;
+		if (child->getRequestInitialValue()) {
+			request(child->getChildId(),child->getType());
+			requested_initial_value = true;
+		}
+	}
+	// wait a bit before controller returns the requested value
+	if (requested_initial_value) wait(2000);
 #if NODEMANAGER_INTERRUPTS == ON
 	// for interrupt based sensors, register a callback for the interrupt
 	if (_interrupt_mode != MODE_NOT_DEFINED) {

--- a/nodemanager/Sensor.h
+++ b/nodemanager/Sensor.h
@@ -66,6 +66,9 @@ public:
 	Child* getChild(uint8_t child_id);
 	// register a child
 	void registerChild(Child* child);
+	// [28] enabler/disable the sensor (default: true)
+	void setEnabled(bool value, bool just_set = false);
+	bool getEnabled();
 #if NODEMANAGER_INTERRUPTS == ON
 	// return the pin the interrupt is attached to
 	int8_t getInterruptPin();
@@ -127,6 +130,7 @@ protected:
 	InternalTimer* _report_timer;
 	InternalTimer* _measure_timer;
 	bool _evaluateTimer(InternalTimer* timer);
+	bool _enabled = true;
 #if NODEMANAGER_INTERRUPTS == ON
 	int8_t _interrupt_pin = -1;
 	uint8_t _interrupt_mode = MODE_NOT_DEFINED;

--- a/sensors/Display.h
+++ b/sensors/Display.h
@@ -79,20 +79,8 @@ public:
 				}
 				// print value
 				printChild(ch);
-				// print type
-				if (ch->getType() == V_TEMP) {
-					if (nodeManager.getIsMetric()) print("C");
-					else print("F");
-				}
-				else if (ch->getType() == V_HUM || ch->getType() == V_PERCENTAGE) print("%");
-				else if (ch->getType() == V_PRESSURE) print("Pa");
-				else if (ch->getType() == V_WIND || ch->getType() == V_GUST) print("Km/h");
-				else if (ch->getType() == V_VOLTAGE) print("V");
-				else if (ch->getType() == V_CURRENT) print("A");
-				else if (ch->getType() == V_LEVEL && ch->getPresentation() == S_SOUND) print("dB");
-				else if (ch->getType() == V_LIGHT_LEVEL && ch->getPresentation() == S_LIGHT_LEVEL) print("%");
-				else if (ch->getType() == V_RAINRATE) print("%");
-				else if (ch->getType() == V_LEVEL && ch->getPresentation() == S_MOISTURE) print("%");
+				// print unit prefix
+				print(ch->getUnitPrefix());
 				println(nullptr);
 			}
 		}

--- a/sensors/SensorConfiguration.h
+++ b/sensors/SensorConfiguration.h
@@ -54,6 +54,7 @@ public:
 			case 5: nodeManager.setSleepHours(request.getValueInt()); break;
 			case 29: nodeManager.setSleepDays(request.getValueInt()); break;
 			case 20: nodeManager.setSleepBetweenSend(request.getValueInt()); break;
+			case 43: nodeManager.setSleepBetweenSendSleepOrWait(request.getValueInt()); break;
 			case 9: nodeManager.wakeup(); break;
 #endif
 #ifdef CHIP_AVR

--- a/sensors/SensorConfiguration.h
+++ b/sensors/SensorConfiguration.h
@@ -113,6 +113,7 @@ public:
 				case 17: sensor->setReportIntervalSeconds(request.getValueInt()); break;
 				case 19: sensor->setReportIntervalHours(request.getValueInt()); break;
 				case 20: sensor->setReportIntervalDays(request.getValueInt()); break;
+				case 28: sensor->setEnabled(request.getValueInt()); break;
 #if NODEMANAGER_INTERRUPTS == ON			
 				case 22: sensor->setInterruptMode(request.getValueInt()); break;
 				case 23: sensor->setWaitAfterInterrupt(request.getValueInt()); break;

--- a/sensors/SensorPca9685Rgb.h
+++ b/sensors/SensorPca9685Rgb.h
@@ -45,7 +45,7 @@ public:
 	  _name = "Pca9685Rgb";
 	  //present as RGB
 	  children.allocateBlocks(2);
-	  new Child(this,STRING,nodeManager.getAvailableChildId(child_id),S_RGB_LIGHT,V_RGB,_name); 
+	  new Child(this,STRING,nodeManager.getAvailableChildId(child_id),S_RGB_LIGHT,V_RGB,_name, NULL, true);
 	  new Child(this,STRING,child_id > 0 ? nodeManager.getAvailableChildId(child_id+1) : nodeManager.getAvailableChildId(child_id),S_RGB_LIGHT,V_WATT,_name);
 	  //store values for PWMServoDriver
 	  _ch_r = ch_r;
@@ -91,8 +91,6 @@ public:
 	    _pca9685r->onSetup();
 	    _pca9685g->onSetup();
 		_pca9685b->onSetup();
-		//get current value from host
-		request( children.get(1)->getChildId(), V_RGB  );
 		// report immediately
 		setReportTimerMode(IMMEDIATELY);
 		// do not average the value

--- a/sensors/SensorPca9685Rgbw.h
+++ b/sensors/SensorPca9685Rgbw.h
@@ -47,7 +47,7 @@ public:
 	  _name = "Pca9685Rgbw";
 	  //present as RGB
 	  children.allocateBlocks(2);
-	  new Child(this,STRING,nodeManager.getAvailableChildId(child_id),S_RGB_LIGHT,V_RGB,_name); 
+	  new Child(this,STRING,nodeManager.getAvailableChildId(child_id),S_RGB_LIGHT,V_RGB,_name, NULL, true); 
 	  new Child(this,STRING,child_id > 0 ? child_id > 0 ? nodeManager.getAvailableChildId(child_id+1) : nodeManager.getAvailableChildId(child_id) : nodeManager.getAvailableChildId(child_id),S_RGB_LIGHT,V_WATT,_name);
 	  //store values for PWMServoDriver
 	  _ch_r = ch_r;
@@ -99,8 +99,6 @@ public:
 	    _pca9685g->onSetup();
 		_pca9685b->onSetup();
 		_pca9685w->onSetup();
-		//get current value from host
-		request( children.get(1)->getChildId(), V_RGB  );
 		// report immediately
 		setReportTimerMode(IMMEDIATELY);
 		// do not average the value

--- a/sensors/SensorPca9685W.h
+++ b/sensors/SensorPca9685W.h
@@ -41,8 +41,8 @@ public:
 	  _name = "Pca9685W";
 	  //present as Dimmer
 	  children.allocateBlocks(2);
-	  new Child(this,INT,nodeManager.getAvailableChildId(child_id),S_DIMMER,V_PERCENTAGE,_name);  //intern child 1
-	  new Child(this,INT,child_id > 0 ? nodeManager.getAvailableChildId(child_id+1) : nodeManager.getAvailableChildId(child_id),S_DIMMER,V_STATUS,_name);      //intern child 2
+	  new Child(this,INT,nodeManager.getAvailableChildId(child_id),S_DIMMER,V_PERCENTAGE,_name, NULL, true);
+	  new Child(this,INT,child_id > 0 ? nodeManager.getAvailableChildId(child_id+1) : nodeManager.getAvailableChildId(child_id),S_DIMMER,V_STATUS,_name, NULL, true);
 	  //store values for PWMServoDriver
 	  _channel = channel;
 	  _i2c_addr = i2c_addr;
@@ -75,9 +75,6 @@ public:
 		//init pca9685
 		_pca9685w = new SensorPca9685Led (_channel, _i2c_addr, _pca9685); 
 		_pca9685w->onSetup();
-		//get current value from host
-		request( children.get(1)->getChildId(), V_PERCENTAGE );
-		request( children.get(2)->getChildId(), V_STATUS );
 		// report immediately
 		setReportTimerMode(IMMEDIATELY);
 		// do not average the value

--- a/sensors/SensorSignal.h
+++ b/sensors/SensorSignal.h
@@ -22,8 +22,9 @@
 /*
 SensorSignal: report RSSI signal strength from the radio
 */
-
-#define MY_SIGNAL_REPORT_ENABLED
+#ifndef MY_SIGNAL_REPORT_ENABLED
+#error "SensorSignal: MY_SIGNAL_REPORT_ENABLED must be defined in the sketch in order to SensorSignal to work"
+#endif
 #define SIGNAL_CHILD_ID 202
 
 class SensorSignal: public Sensor {


### PR DESCRIPTION
- Added `setSleepBetweenSendSleepOrWait()` to control when `setSleepBetweenSend()` is configured if the node should only wait (default) or sleep or wait depending on the duration set (fixes #456)
- Fixed Interrupt Debounce not working since `_last_interrupt_millis` was never updated (fixes #465)
- Added support for unit prefix consistently across all the sensors (fixes #492 #436):
  - Child constructor can now accept a `unit_prefix `parameter. Setter and getter are also provided (`setUnitPrefix()` / `getUnitPrefix()`). Users can set custom unit prefix by calling `setUnitPrefix()` of the Child class (e.g. `analog.children.get()->setUnitPrefix("%")`). Sensors developers can set the unit prefix directly within their code
  - Added `setSendUnitPrefix()` to NodeManager class. If set (default to false), a prefix is sent once for each child just before sending the first value
  - If the prefix is not explicitly set to the child, `getDefaultUnitPrefix()` of the NodeManager class returns a reasonable default based on the sensor presentation and type
- Added support for requesting initial value to the controller (fixes #436):
  - Child constructor can now accept a `request_initial_value`parameter (default to false). Setter and getter are also provided (`setRequestInitialValue()` / `getRequestInitialValue()`). Users can ask NodeManager to request the inital value by calling `setRequestInitialValue(true)` of the Child class (e.g. `relay.children.get()->setRequestInitialValue(true)`). Sensors developers can set custom default directly within their code
  - During `setup()` in the Sensor class for every child with `request_initial_value` set a `request()` is sent to the controller. Response will be handled as any standard inbound message by `onReceive()` without any change to the code
  - If a request is sent for at least one child, setup() will wait for 2 seconds before proceeding
- Added option to enable/disable sensors remotely (fixes #500):
  - All sensors have to be declared in the sketch regardless if enabled or not (constructors just set variables, don't do any action). This has a cost in terms of memory utilization but this capability is for boards with large memory and runtime lifecycle cannot be managed differently
  - Presentation is done for all the sensors since we need a child_id allocated to receive enable/disable requests for the sensors
  - Setup and Loop are not called unless a sensor is enabled (the default)
  - Added `_enabled `variable to Sensor class (default to true) and `setEnabled()` / `getEnabled()` functions
  - When `setEnabled()` is called, if the sensor has to be enabled, setup() is called first, then interrupts are riconfigured. If the sensors has to be disabled, just interrupts are riconfigured
  - `setEnabled()` can be also called remotely by setting `NODEMANAGER_OTA_CONFIGURATION` to `ON` and sending a V_CUSTOM message to the configuration child 200 with value `28,0` or `28,1` (e.g. through SensorConfiguration)
  -  Added `setPersistEnabledSensors()` to Node class allowing to save enable/disable status flag in EEPROM (requires `NODEMANAGER_EEPROM `set to `ON`)
- Throw compilation error if SensorSignal is included but `MY_SIGNAL_REPORT_ENABLED`  is not defined (fixes #504)
- Fixed gateway wrongly reporting its own sensors if the child_id overlaps with the reporting child of a remote board (fixes #457)