### PR TITLE
HomeAssistant Compatibility: Core Changes

### DIFF
--- a/nodemanager/Node.cpp
+++ b/nodemanager/Node.cpp
@@ -193,6 +193,7 @@ void NodeManager::presentation() {
 		sensor->presentation();
 		sleepBetweenSend();
 	}
+
 	// wait a bit before leaving this function
 	sleepBetweenSend();
 	sleepBetweenSend();
@@ -280,6 +281,14 @@ void NodeManager::loop() {
 		Sensor* sensor = *itr;
 		// skip the sensor if not enabled
 		if (! sensor->getEnabled()) continue;
+		/* Entities won't show up for some controllers (e.g. HomeAssistant) unless we send initial states */
+		if (sensor->getFirstRun()) {
+			for (List<Child*>::iterator citr = sensor->children.begin(); citr != sensor->children.end(); ++citr) {
+				Child* child = *citr;
+				child->sendValue(true);
+				sleepBetweenSend();
+			}
+		}
 		// clear the MyMessage so will be ready to be used for the sensor
 		_message.clear();
 #if NODEMANAGER_INTERRUPTS == ON

--- a/nodemanager/Sensor.cpp
+++ b/nodemanager/Sensor.cpp
@@ -127,6 +127,15 @@ Child* Sensor::getChild(uint8_t child_id) {
 	return nullptr;
 }
 
+Child* Sensor::getChild(uint8_t child_id, uint8_t ctype) {
+	for (List<Child*>::iterator itr = children.begin(); itr != children.end(); ++itr) {
+		Child* child = *itr;
+		if ((child->getChildId() == child_id) && (child->getType() == ctype))
+			return child;
+	}
+	return nullptr;
+}
+
 // present the sensor to the gateway and controller
 void Sensor::presentation() {
 	for (List<Child*>::iterator itr = children.begin(); itr != children.end(); ++itr) {
@@ -342,7 +351,7 @@ void Sensor::onLoop(Child* /*child*/){}
 
 // by default when a child receive a REQ message and the type matches the type of the request, executes its onLoop function
 void Sensor::onReceive(MyMessage* message){
-	Child* child = getChild(message->sensor);
+	Child* child = getChild(message->sensor, message->type);
 	if (child == nullptr) return;
 	if (message->getCommand() == C_REQ && message->type == child->getType()) onLoop(child);
 }

--- a/nodemanager/Sensor.cpp
+++ b/nodemanager/Sensor.cpp
@@ -217,7 +217,11 @@ void Sensor::loop(MyMessage* message) {
 		for (List<Child*>::iterator itr = children.begin(); itr != children.end(); ++itr) {
 			Child* child = *itr;
 			// if a specific child is requested from receive(), skip all the others
-			if (message != nullptr && message->sensor != child->getChildId()) continue;
+			if (message != nullptr &&
+				((message->sensor != child->getChildId()) ||
+				(message->type != child->getType()))) {
+					continue;
+				}
 			// collect multiple samples if needed
 			for (unsigned int i = 0; i < _samples; i++) {
 				// we've been called from receive(), pass the message along

--- a/nodemanager/Sensor.h
+++ b/nodemanager/Sensor.h
@@ -64,6 +64,7 @@ public:
 	List<Child*> children;
 	// return the child object based on the provided child_id
 	Child* getChild(uint8_t child_id);
+	Child* getChild(uint8_t child_id, uint8_t ctype);
 	// register a child
 	void registerChild(Child* child);
 	// [28] enabler/disable the sensor (default: true)


### PR DESCRIPTION
The pull request implements the basic changes to NodeManager's code required for HomeAssistant compatibilty as discussed in #532 

- A Sensor can now have several Child elements with the same ID, each accepting different value types
- Inbound messages will be now dispatched according to their message type 
- NodeManager now reports all initial values to the controller on startup to make HomeAssistant happy

@user2684 You may want to have a detailed look at my changes. They seem trivial, but since I'm not very familiar with the codebase I might've left a few goblins lurking here and there. 