### PR TITLE
New packaging of child values in EEPROM

### DIFF
--- a/nodemanager/Child.cpp
+++ b/nodemanager/Child.cpp
@@ -288,8 +288,8 @@ bool Child::getPersistValue() {
 // save value to EEPROM - subclass needs to implement
 void Child::saveValue() {
 	if (_format == STRING) return;
-	// number is too large to be saved or we run out of EEPROM slots
-	if ((_eeprom_address+EEPROM_CHILD_SIZE) > 255) return;
+	// check if slots of EEPROM run out
+	if ((_eeprom_address + EEPROM_CHILD_SIZE) > (EEPROM_USER_END - EEPROM_USER_START)) return;
 	debug(PSTR(LOG_EEPROM "%s(%d):SAVE\n"),_description,_child_id);
 	// save the type
 	nodeManager.saveToMemory(_eeprom_address+EEPROM_CHILD_TYPE,_type);
@@ -322,7 +322,7 @@ void Child::saveValue() {
 void Child::loadValue() { 
 	if (_format == STRING) return;
 	// ensure we are not going to read beyond the available EEPROM slots
-	if ((_eeprom_address+EEPROM_CHILD_SIZE) > 255 ) return;
+	if ((_eeprom_address + EEPROM_CHILD_SIZE) > (EEPROM_USER_END - EEPROM_USER_START)) return;
 	debug(PSTR(LOG_EEPROM "%s(%d):LOAD\n"),_description,_child_id);
 	// ensure the type is valid
 	if (nodeManager.loadFromMemory(_eeprom_address+EEPROM_CHILD_TYPE) != _type) return;

--- a/nodemanager/Child.cpp
+++ b/nodemanager/Child.cpp
@@ -289,39 +289,69 @@ bool Child::getPersistValue() {
 void Child::saveValue() {
 	if (_format == STRING) return;
 	// number is too large to be saved or we run out of EEPROM slots
-	if (_value >= 10000 || ((_eeprom_address+EEPROM_CHILD_SIZE) > 255) ) return;
+	if ((_eeprom_address+EEPROM_CHILD_SIZE) > 255) return;
 	debug(PSTR(LOG_EEPROM "%s(%d):SAVE\n"),_description,_child_id);
 	// save the type
 	nodeManager.saveToMemory(_eeprom_address+EEPROM_CHILD_TYPE,_type);
-	// encode the sign (e.g. 0 if > 0, 1 otherwise)
-	nodeManager.saveToMemory(_eeprom_address+EEPROM_CHILD_SIGN, _value >= 0 ? 0 : 1);
-	// encode and save the integer value (e.g. 7240 -> int_1 = 72, int_2 = 40)
-	nodeManager.saveToMemory(_eeprom_address+EEPROM_CHILD_INT_1,(int)(_value/100)%100);
-	nodeManager.saveToMemory(_eeprom_address+EEPROM_CHILD_INT_2,(int)_value%100);
-	// encode and save the first part of the decimal value (e.g. 7240.12 -> dec_1 = 12)
-	if (_format == FLOAT || _format == DOUBLE) nodeManager.saveToMemory(_eeprom_address+EEPROM_CHILD_DEC_1,(int)(_value*100)%100);
-	// encode and save the second part of the decimal value (e.g. 7240.1244 -> dec_2 = 44)
-	if (_format == DOUBLE) nodeManager.saveToMemory(_eeprom_address+EEPROM_CHILD_DEC_1,(int)(_value*10000)%100);
+	// encode the bytes
+	uint8_t bytes[EEPROM_CHILD_SIZE - EEPROM_CHILD_VALUE];
+	if (_format == INT) {
+		// encode integer value
+		const int word = (int)_value;
+		// shift out the bytes of the int number into the buffer
+		for (uint8_t i = 0; i < sizeof(int); i++) {
+			bytes[i] = (uint8_t)((word >> ((sizeof(int) - 1 - i) * 8)) & 0xFF);
+		}
+	}
+	if ((_format == FLOAT || _format == DOUBLE)) {
+		// encode the decimal value
+		const float word = (float)_value;
+		const uint8_t* src = (uint8_t*)&word;
+		// copy bytes from float number as is into the buffer
+		for (uint8_t i = 0; i < sizeof(bytes); i++) {
+			bytes[i] = src[sizeof(bytes) - 1 - i];
+		}
+	}
+	// save the bytes of the loaded value
+	for (uint8_t i = 0; i < (_format == INT ? sizeof(int) : sizeof(bytes)); i++) {
+		nodeManager.saveToMemory(_eeprom_address + EEPROM_CHILD_VALUE + i, bytes[i]);
+	}
 }
 
 // load value from EEPROM 
 void Child::loadValue() { 
 	if (_format == STRING) return;
 	// ensure we are not going to read beyond the available EEPROM slots
-	if (((_eeprom_address+EEPROM_CHILD_SIZE) > 255) ) return;
+	if ((_eeprom_address+EEPROM_CHILD_SIZE) > 255 ) return;
+	debug(PSTR(LOG_EEPROM "%s(%d):LOAD\n"),_description,_child_id);
 	// ensure the type is valid
 	if (nodeManager.loadFromMemory(_eeprom_address+EEPROM_CHILD_TYPE) != _type) return;
-	debug(PSTR(LOG_EEPROM "%s(%d):LOAD\n"),_description,_child_id);
-	// decode the integer part
+	// decode the bytes
 	double value = 0;
-	value = nodeManager.loadFromMemory(_eeprom_address+EEPROM_CHILD_INT_1)*100 + nodeManager.loadFromMemory(_eeprom_address+EEPROM_CHILD_INT_2);
-	if (value == 255) return;
-	// decode the sign
-	if (nodeManager.loadFromMemory(_eeprom_address+EEPROM_CHILD_SIGN) == 1) value = value * -1;
-	// decode the first part of the decimal value
-	if (_format == FLOAT || _format == DOUBLE) value += nodeManager.loadFromMemory(_eeprom_address+EEPROM_CHILD_DEC_1)/100.0;
-	// decode the second part of the decimal value
-	if (_format == DOUBLE) value += nodeManager.loadFromMemory(_eeprom_address+EEPROM_CHILD_DEC_2)/10000.0;
+	uint8_t bytes[EEPROM_CHILD_SIZE - EEPROM_CHILD_VALUE];
+	// load the bytes of the saved value
+	for (uint8_t i = 0; i < (_format == INT ? sizeof(int) : sizeof(bytes)); i++) {
+		bytes[i] = (uint8_t)nodeManager.loadFromMemory(_eeprom_address + EEPROM_CHILD_VALUE + i);
+	}
+	if (_format == INT) {
+		// decode the integer value
+		int word = 0;
+		// shift back bytes into position of the int number
+		for (uint8_t i = 0; i < sizeof(int); i++) {
+			word |= ((int)bytes[i]) << ((sizeof(int) - 1 - i) * 8);
+		}
+		value = word;
+	}
+	if (_format == FLOAT || _format == DOUBLE) {
+		// decode the decimal value
+		float word;
+		uint8_t* dst = (uint8_t*)&word;
+		// copy bytes as is into float number
+		for (uint8_t i = 0; i < sizeof(bytes); i++) {
+			dst[i] = bytes[sizeof(bytes) - 1 - i];
+		}
+		value = word;
+	}
 	setValue(value);
 }
 #endif

--- a/nodemanager/Child.h
+++ b/nodemanager/Child.h
@@ -28,15 +28,11 @@ class Sensor;
 
 // how many slots to leave for the user before starting using them for Child
 #define EEPROM_CHILD_OFFSET	10
-// define the number of slots of the EEPROM needed to store a Child's value
-#define EEPROM_CHILD_SIZE 6
 // define the relative positions of each information
-#define EEPROM_CHILD_TYPE 0
-#define EEPROM_CHILD_SIGN 1
-#define EEPROM_CHILD_INT_1 2
-#define EEPROM_CHILD_INT_2 3
-#define EEPROM_CHILD_DEC_1 4
-#define EEPROM_CHILD_DEC_2 5
+#define EEPROM_CHILD_TYPE  0
+#define EEPROM_CHILD_VALUE (EEPROM_CHILD_TYPE + 1)
+// define the number of slots of the EEPROM needed to store a Child's value
+#define EEPROM_CHILD_SIZE  (EEPROM_CHILD_VALUE + 4)
 
 class Child {
 public:

--- a/nodemanager/Constants.h
+++ b/nodemanager/Constants.h
@@ -121,6 +121,7 @@ Chip type
 #define EEPROM_SLEEP_2 6
 #define EEPROM_SLEEP_3 7
 #define EEPROM_USER_START 20
+#define EEPROM_USER_END 255
 
 /***********************************
 Default configuration settings

--- a/nodemanager/Node.cpp
+++ b/nodemanager/Node.cpp
@@ -402,7 +402,7 @@ void NodeManager::loop() {
 	// return the value stored at the requested index from the EEPROM
 	int NodeManager::loadFromMemory(int index) {
 		int position = index+EEPROM_USER_START;
-		if (position >= 255) {
+		if (position >= EEPROM_USER_END) {
 			debug(PSTR(LOG_EEPROM "!LOAD i=%d\n"),index);
 			return 0;
 		}
@@ -414,7 +414,7 @@ void NodeManager::loop() {
 	// save the given index of the EEPROM the provided value
 	void NodeManager::saveToMemory(int index, int value) {
 		int position = index+EEPROM_USER_START;
-		if (position >= 255) {
+		if (position >= EEPROM_USER_END) {
 			debug(PSTR(LOG_EEPROM "!SAVE i=%d\n"),index);
 			return;
 		}


### PR DESCRIPTION
With this change the value of a child gets stored in a more compact way
without the need of a sign byte and with an extended range or precision.
An int number will be composed by bitshifts and a float number will be memory
copied for each byte. See also issue #544.