### PR TITLE
SensorInterrupt onLoop routine sends value

### DIFF
--- a/sensors/SensorInterrupt.h
+++ b/sensors/SensorInterrupt.h
@@ -41,14 +41,14 @@ public:
 		setInterruptMode(CHANGE);
 	};
 
-	// [105] Invert the value to report. E.g. if FALLING and value is LOW, report HIGH (default: false) 
+	// [105] Invert the value to report. E.g. if FALLING and value is LOW, report HIGH (default: false)
 	void setInvertValueToReport(bool value) {
 		_invert_value_to_report = value;
 	};
 #if NODEMANAGER_TIME == ON
 	// [107] when keeping track of the time, trigger only after X consecutive interrupts within the same minute (default: 1)
 	void setThreshold(int value) {
-		_threshold = value;      
+		_threshold = value;
 	};
 #endif
 
@@ -89,6 +89,16 @@ public:
 #endif
 		child->setValue(value);
 	};
+
+	void onLoop(Child* child) {
+		// read the value
+		int value = digitalRead(_pin);
+		// invert the value if needed
+		if (_invert_value_to_report) value = !value;
+		// store the value
+		child->setValue(value);
+	};
+
 
 #if NODEMANAGER_OTA_CONFIGURATION == ON
 	// define what to do when receiving an OTA configuration request


### PR DESCRIPTION
Hello
I've made change that is maybe worth of discussion. The actual SensorInterrupt does send it's value only when the interrupt happens. But when the transmission fails for some reason then the value is not propagated to server not even on report interval.

So I've added the onLoop() method to SensorInterrupt.h.